### PR TITLE
add tests of multimodal model with two encoders

### DIFF
--- a/cornstarch/models/multimodal_language_model/processing_multimodal_language_model.py
+++ b/cornstarch/models/multimodal_language_model/processing_multimodal_language_model.py
@@ -1,7 +1,9 @@
+import inspect
 import math
 from typing import Optional, Union
 
 import numpy as np
+from transformers.feature_extraction_sequence_utils import SequenceFeatureExtractor
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.image_processing_utils import BaseImageProcessor, get_size_dict
 from transformers.image_transforms import (
@@ -443,17 +445,19 @@ class ImageProcessorWrapper(BaseImageProcessor):
         # Pad features
         max_patch = max(len(x) for x in new_images)
         pixel_values = [
-            np.concatenate(
-                [
-                    x,
-                    np.zeros(
-                        [max_patch - x.shape[0]] + list(x.shape[1:]), dtype=x.dtype
-                    ),
-                ],
-                axis=0,
+            (
+                np.concatenate(
+                    [
+                        x,
+                        np.zeros(
+                            [max_patch - x.shape[0]] + list(x.shape[1:]), dtype=x.dtype
+                        ),
+                    ],
+                    axis=0,
+                )
+                if x.shape[0] < max_patch
+                else x
             )
-            if x.shape[0] < max_patch
-            else x
             for x in new_images
         ]
 
@@ -479,16 +483,19 @@ class MultimodalModelProcessor(ProcessorMixin):
     """
 
     attributes = ["image_processor", "tokenizer"]
+    feature_extractor_class = "AutoFeatureExtractor"
     image_processor_class = "AutoImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
     def __init__(
         self,
+        feature_extractor: SequenceFeatureExtractor = None,
         image_processor: BaseImageProcessor = None,
         tokenizer: PreTrainedTokenizerBase = None,
         **kwargs,
     ):
-        super().__init__(image_processor, tokenizer)
+        super().__init__(feature_extractor, image_processor, tokenizer)
+        self.feature_extractor = feature_extractor
         self.image_processor = image_processor
         self.tokenizer = tokenizer
 
@@ -503,28 +510,56 @@ class MultimodalModelProcessor(ProcessorMixin):
                 f"Setting `pad_token_id` to `eos_token_id`: {self.tokenizer.eos_token_id}."
             )
 
+        self.tokenizer_args = (
+            list(inspect.signature(self.tokenizer.__call__).parameters.keys())
+            if self.tokenizer is not None
+            else []
+        )
+        self.image_processor_args = (
+            list(inspect.signature(self.image_processor.__call__).parameters.keys())
+            if self.image_processor is not None
+            else []
+        )
+        self.feature_extractor_args = (
+            list(inspect.signature(self.feature_extractor.__call__).parameters.keys())
+            if self.feature_extractor is not None
+            else []
+        )
+
     def __call__(
         self,
         text: Union[
             TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]
         ],
         images: ImageInput = None,
+        raw_speech: Union[
+            np.ndarray, list[float], list[np.ndarray], list[list[float]]
+        ] = None,
         return_tensors: str | TensorType = TensorType.PYTORCH,
         **kwargs,
     ) -> BatchFeature:
-        if text is None and images is None:
-            raise ValueError("You have to specify either text or images.")
+        assert text is not None
 
-        padding = kwargs.pop("padding", True)
-        inputs = self.tokenizer(
-            text, return_tensors=return_tensors, padding=padding, **kwargs
-        )
+        tokenizer_kwargs = {k: v for k, v in kwargs.items() if k in self.tokenizer_args}
+        inputs = self.tokenizer(text, return_tensors=return_tensors, **tokenizer_kwargs)
 
         if images is not None:
+            image_processor_kwargs = {
+                k: v for k, v in kwargs.items() if k in self.image_processor_args
+            }
             image_inputs = self.image_processor(
-                images, return_tensors=return_tensors, **kwargs
+                images, return_tensors=return_tensors, **image_processor_kwargs
             )
             inputs.update(image_inputs.data)
+
+        if raw_speech is not None:
+            feature_extractor_kwargs = {
+                k: v for k, v in kwargs.items() if k in self.feature_extractor_args
+            }
+            feature = self.feature_extractor(
+                raw_speech, return_tensors=return_tensors, **feature_extractor_kwargs
+            )
+            inputs.update(feature)
 
         return BatchFeature(data=inputs, tensor_type=return_tensors)
 
@@ -536,6 +571,23 @@ class MultimodalModelProcessor(ProcessorMixin):
 
     @property
     def model_input_names(self):
-        tokenizer_input_names = self.tokenizer.model_input_names
-        image_processor_input_names = self.image_processor.model_input_names
-        return list(dict.fromkeys(tokenizer_input_names + image_processor_input_names))
+        tokenizer_input_names = (
+            self.tokenizer.model_input_names if self.tokenizer is not None else []
+        )
+        image_processor_input_names = (
+            self.image_processor.model_input_names
+            if self.image_processor is not None
+            else []
+        )
+        feature_extractor_input_names = (
+            self.feature_extractor.model_input_names
+            if self.feature_extractor is not None
+            else []
+        )
+        return list(
+            dict.fromkeys(
+                tokenizer_input_names
+                + image_processor_input_names
+                + feature_extractor_input_names
+            )
+        )

--- a/tests/test_models/test_multimodal_language_model.py
+++ b/tests/test_models/test_multimodal_language_model.py
@@ -12,6 +12,7 @@ from transformers import (
 )
 from transformers.models.clip import CLIPVisionConfig, CLIPVisionModel
 from transformers.models.dinov2 import Dinov2Config, Dinov2Model
+from transformers.models.whisper.modeling_whisper import WhisperConfig, WhisperEncoder
 
 from cornstarch.models.multimodal_language_model import ModalModule, MultimodalModel
 
@@ -20,6 +21,10 @@ vision_model = [
     ("laion/CLIP-ViT-B-32-laion2B-s34B-b79k", CLIPVisionConfig, CLIPVisionModel),
     ("BAAI/EVA-CLIP-18B", CLIPVisionConfig, CLIPVisionModel),
     ("facebook/dinov2-giant", Dinov2Config, Dinov2Model),
+]
+
+audio_model = [
+    ("openai/whisper-small", WhisperConfig, WhisperEncoder),
 ]
 
 language_model = [
@@ -31,9 +36,32 @@ language_model = [
 ]
 
 
+@pytest.mark.parametrize("audio_model", audio_model, ids=lambda x: x[0])
+@pytest.mark.parametrize("language_model", language_model)
+def test_build_alm(
+    audio_model: tuple[str, Type[PretrainedConfig], Type[PreTrainedModel]],
+    language_model: str,
+):
+    with init_empty_weights():
+        audio_config = audio_model[1].from_pretrained(audio_model[0])
+        audio_model = audio_model[2](audio_config)
+
+        language_config = AutoConfig.from_pretrained(
+            language_model, trust_remote_code=False
+        )
+        language_model = AutoModelForCausalLM.from_config(
+            language_config, trust_remote_code=False
+        )
+
+        MultimodalModel(
+            encoders={"audio": ModalModule(audio_model)},
+            language_model=language_model,
+        )
+
+
 @pytest.mark.parametrize("vision_model", vision_model, ids=lambda x: x[0])
 @pytest.mark.parametrize("language_model", language_model)
-def test_build_empty_model(
+def test_build_vlm(
     vision_model: tuple[str, Type[PretrainedConfig], Type[PreTrainedModel]],
     language_model: str,
 ):
@@ -47,10 +75,10 @@ def test_build_empty_model(
         vision_model = vision_model[2](vision_config)
 
         language_config = AutoConfig.from_pretrained(
-            language_model, trust_remote_code=True
+            language_model, trust_remote_code=False
         )
         language_model = AutoModelForCausalLM.from_config(
-            language_config, trust_remote_code=True
+            language_config, trust_remote_code=False
         )
 
         MultimodalModel(

--- a/tests/test_plugins/multimodal_parallel_plugin/test_multimodal_parallel_plugin.py
+++ b/tests/test_plugins/multimodal_parallel_plugin/test_multimodal_parallel_plugin.py
@@ -12,6 +12,7 @@ from transformers.models.clip import CLIPVisionConfig, CLIPVisionModel
 from transformers.models.llama import LlamaConfig, LlamaForCausalLM
 from transformers.models.mistral import MistralConfig, MistralForCausalLM
 from transformers.models.opt import OPTConfig, OPTForCausalLM
+from transformers.models.whisper.modeling_whisper import WhisperConfig, WhisperEncoder
 
 from cornstarch.models.multimodal_language_model import (
     ModalModule,
@@ -24,6 +25,23 @@ from cornstarch.plugin.multimodal_parallel_plugin.multimodal_parallel_plugin imp
     MultimodalParallelModule,
     MultimodalParallelPlugin,
 )
+
+whisper_config: WhisperConfig = WhisperConfig.from_pretrained("openai/whisper-small")
+whisper_config.encoder_layers = 2
+whisper_config._attn_implementation = "eager"
+audio_configs = [("openai/whisper-small", whisper_config, WhisperEncoder)]
+
+expected_audio_module_layers = {
+    "openai/whisper-small": [
+        "module.conv1",
+        "module.conv2",
+        "module.embed_positions",
+        "module.layers.0",
+        "module.layers.1",
+        "module.layer_norm",
+        "projector.projection",
+    ]
+}
 
 clip_config = CLIPVisionConfig.from_pretrained("openai/clip-vit-base-patch32")
 vision_configs = [("openai/clip-vit-base-patch32", clip_config, CLIPVisionModel)]
@@ -83,6 +101,22 @@ expected_language_module_layers = {
     ],
 }
 
+expected_audio_module_layers_per_stage = {
+    "openai/whisper-small": [
+        [
+            "module.conv1",
+            "module.conv2",
+            "module.embed_positions",
+            "module.layers.0",
+        ],
+        [
+            "module.layers.1",
+            "module.layer_norm",
+            "projector.projection",
+        ],
+    ]
+}
+
 expected_vision_module_layers_per_stage = {
     "openai/clip-vit-base-patch32": [
         [
@@ -121,7 +155,7 @@ expected_language_module_layers_per_stage = {
 }
 
 
-class TestPluginInitializationWithFakeBackend:
+class TestPluginInitializationWithFakeBackendBase:
     @pytest.fixture(autouse=True)
     def fake_backend(self, mocker: MockerFixture):
         mocker.patch.object(
@@ -132,126 +166,6 @@ class TestPluginInitializationWithFakeBackend:
         yield
 
         if dist.is_initialized():
-            dist.destroy_process_group()
-
-    def generate_multimodal_model(
-        self,
-        vision_config: PretrainedConfig,
-        vision_model_cls: Type[PreTrainedModel],
-        language_model_config: PretrainedConfig,
-        language_model_cls: Type[PreTrainedModel],
-    ) -> tuple[ModalModule, PreTrainedModel, MultimodalModel]:
-        vision_encoder = vision_model_cls(vision_config)
-        vision_module = ModalModule(vision_encoder)
-        language_module = language_model_cls(language_model_config)
-
-        model = MultimodalModel(
-            encoders={"vision": vision_module},
-            language_model=language_module,
-        ).to(dtype=torch.float16)
-
-        return vision_module, language_module, model
-
-    def generate_multimodal_plugin(
-        self,
-        vision_model_name: str,
-        language_model_name: str,
-        vision_tp_size: int,
-        language_tp_size: int,
-    ) -> MultimodalParallelPlugin:
-        vision_plugin = ModalParallelPlugin(
-            tp_size=vision_tp_size,
-            pipeline_template=PipelineTemplate(
-                vision_model_name,
-                expected_vision_module_layers_per_stage[vision_model_name],
-            ),
-        )
-        language_plugin = ModalParallelPlugin(
-            tp_size=language_tp_size,
-            pipeline_template=PipelineTemplate(
-                language_model_name,
-                expected_language_module_layers_per_stage[language_model_name],
-            ),
-        )
-
-        return MultimodalParallelPlugin(
-            encoder_plugins={"vision": vision_plugin},
-            language_model_plugin=language_plugin,
-            num_microbatches=12,
-            microbatch_size=1,
-        )
-
-    @pytest.mark.parametrize("vision_config", vision_configs, ids=["clip"])
-    @pytest.mark.parametrize(
-        "language_model_config", language_configs, ids=["mistral", "llama", "opt"]
-    )
-    @pytest.mark.parametrize(
-        "world_size, vision_tp_size, language_tp_size, expected_mesh",
-        [
-            (
-                32,
-                2,
-                4,
-                [
-                    [[0, 0, 1, 1], [2, 2, 3, 3]],
-                    [[4, 4, 5, 5], [6, 6, 7, 7]],
-                    [[8, 9, 10, 11], [12, 13, 14, 15]],
-                    [[16, 17, 18, 19], [20, 21, 22, 23]],
-                    [[24, 25, 26, 27], [28, 29, 30, 31]],
-                ],
-            )
-        ],
-        ids=["tp=(2, 4)"],
-    )
-    def test_initialize_plugin(
-        self,
-        vision_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
-        language_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
-        world_size: int,
-        vision_tp_size: int,
-        language_tp_size: int,
-        expected_mesh: list[list[list[int]]],
-    ):
-        vision_model_name = vision_config[0]
-        language_model_name = language_model_config[0]
-        vision_module, language_module, model = self.generate_multimodal_model(
-            vision_config[1],
-            vision_config[2],
-            language_model_config[1],
-            language_model_config[2],
-        )
-
-        # This check should be done AFTER creating `MultimodalModel`, as it adds a projector inside
-        assert (
-            PipelineTemplate.get_modules(vision_module)
-            == expected_vision_module_layers[vision_model_name]
-        )
-        assert (
-            PipelineTemplate.get_modules(language_module)
-            == expected_language_module_layers[language_model_name]
-        )
-
-        for rank in range(world_size):
-            plugin = self.generate_multimodal_plugin(
-                vision_model_name, language_model_name, vision_tp_size, language_tp_size
-            )
-            per_rank_model = copy.deepcopy(model)
-            dist.init_process_group(
-                backend="fake", store=FakeStore(), rank=rank, world_size=world_size
-            )
-            module = plugin.configure(per_rank_model)[0]
-
-            assert (plugin.stage_manager.pg_mesh.mesh == expected_mesh).all()
-
-            assert isinstance(module, MultimodalParallelModule)
-            assert module.module.vision_encoder is not None
-            assert module.module.language_model is not None
-            assert isinstance(module.module.vision_encoder.module, vision_config[2])
-            assert isinstance(
-                module.module.vision_encoder.projector, MultimodalProjector
-            )
-            assert isinstance(module.module.language_model, language_model_config[2])
-
             dist.destroy_process_group()
 
     def check_layers_cover_all_params(
@@ -270,12 +184,153 @@ class TestPluginInitializationWithFakeBackend:
 
         return sorted(used_prefixes) == sorted(set(layer_names))
 
-    @pytest.mark.parametrize("vision_config", vision_configs, ids=["clip"])
+
+class TestSingleEncoderModelInitializationClass(
+    TestPluginInitializationWithFakeBackendBase
+):
+    def generate_multimodal_model(
+        self,
+        encoder_config: PretrainedConfig,
+        encoder_model_cls: Type[PreTrainedModel],
+        language_model_config: PretrainedConfig,
+        language_model_cls: Type[PreTrainedModel],
+    ) -> tuple[ModalModule, PreTrainedModel, MultimodalModel]:
+        encoder_module = encoder_model_cls(encoder_config)
+        encoder_module = ModalModule(encoder_module)
+        language_module = language_model_cls(language_model_config)
+
+        model = MultimodalModel(
+            encoders={"encoder": encoder_module},
+            language_model=language_module,
+        ).to(dtype=torch.float16)
+
+        return encoder_module, language_module, model
+
+    def generate_multimodal_plugin(
+        self,
+        encoder_model_name: str,
+        language_model_name: str,
+        encoder_tp_size: int,
+        language_tp_size: int,
+    ) -> MultimodalParallelPlugin:
+        encoder_layers_per_stage = (
+            expected_audio_module_layers_per_stage[encoder_model_name]
+            if encoder_model_name in expected_audio_module_layers_per_stage
+            else expected_vision_module_layers_per_stage[encoder_model_name]
+        )
+        encoder_plugin = ModalParallelPlugin(
+            tp_size=encoder_tp_size,
+            pipeline_template=PipelineTemplate(
+                encoder_model_name, encoder_layers_per_stage
+            ),
+        )
+        language_plugin = ModalParallelPlugin(
+            tp_size=language_tp_size,
+            pipeline_template=PipelineTemplate(
+                language_model_name,
+                expected_language_module_layers_per_stage[language_model_name],
+            ),
+        )
+
+        return MultimodalParallelPlugin(
+            encoder_plugins={"encoder": encoder_plugin},
+            language_model_plugin=language_plugin,
+            num_microbatches=12,
+            microbatch_size=1,
+        )
+
+    @pytest.mark.parametrize(
+        "encoder_config", audio_configs + vision_configs, ids=["whisper", "clip"]
+    )
     @pytest.mark.parametrize(
         "language_model_config", language_configs, ids=["mistral", "llama", "opt"]
     )
     @pytest.mark.parametrize(
-        "world_size, vision_tp_size, language_tp_size, stage_indices",
+        "world_size, encoder_tp_size, language_tp_size, expected_mesh",
+        [
+            (
+                32,
+                2,
+                4,
+                [
+                    [[0, 0, 1, 1], [2, 2, 3, 3]],
+                    [[4, 4, 5, 5], [6, 6, 7, 7]],
+                    [[8, 9, 10, 11], [12, 13, 14, 15]],
+                    [[16, 17, 18, 19], [20, 21, 22, 23]],
+                    [[24, 25, 26, 27], [28, 29, 30, 31]],
+                ],
+            )
+        ],
+        ids=["tp=(2, 4)"],
+    )
+    def test_initialize_plugin(
+        self,
+        encoder_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        language_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        world_size: int,
+        encoder_tp_size: int,
+        language_tp_size: int,
+        expected_mesh: list[list[list[int]]],
+    ):
+        encoder_model_name = encoder_config[0]
+        language_model_name = language_model_config[0]
+        encoder_module, language_module, model = self.generate_multimodal_model(
+            encoder_config[1],
+            encoder_config[2],
+            language_model_config[1],
+            language_model_config[2],
+        )
+
+        # This check should be done AFTER creating `MultimodalModel`, as it adds a projector inside
+        if encoder_model_name in expected_audio_module_layers_per_stage:
+            assert (
+                PipelineTemplate.get_modules(encoder_module)
+                == expected_audio_module_layers[encoder_model_name]
+            )
+        else:
+            assert (
+                PipelineTemplate.get_modules(encoder_module)
+                == expected_vision_module_layers[encoder_model_name]
+            )
+        assert (
+            PipelineTemplate.get_modules(language_module)
+            == expected_language_module_layers[language_model_name]
+        )
+
+        for rank in range(world_size):
+            plugin = self.generate_multimodal_plugin(
+                encoder_model_name,
+                language_model_name,
+                encoder_tp_size,
+                language_tp_size,
+            )
+            per_rank_model = copy.deepcopy(model)
+            dist.init_process_group(
+                backend="fake", store=FakeStore(), rank=rank, world_size=world_size
+            )
+            module = plugin.configure(per_rank_model)[0]
+
+            assert (plugin.stage_manager.pg_mesh.mesh == expected_mesh).all()
+
+            assert isinstance(module, MultimodalParallelModule)
+            assert module.module.encoder_encoder is not None
+            assert module.module.language_model is not None
+            assert isinstance(module.module.encoder_encoder.module, encoder_config[2])
+            assert isinstance(
+                module.module.encoder_encoder.projector, MultimodalProjector
+            )
+            assert isinstance(module.module.language_model, language_model_config[2])
+
+            dist.destroy_process_group()
+
+    @pytest.mark.parametrize(
+        "encoder_config", audio_configs + vision_configs, ids=["whisper", "clip"]
+    )
+    @pytest.mark.parametrize(
+        "language_model_config", language_configs, ids=["mistral", "llama", "opt"]
+    )
+    @pytest.mark.parametrize(
+        "world_size, encoder_tp_size, language_tp_size, stage_indices",
         [
             (
                 32,
@@ -318,27 +373,27 @@ class TestPluginInitializationWithFakeBackend:
     )
     def test_model_parallelization(
         self,
-        vision_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        encoder_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
         language_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
         world_size: int,
-        vision_tp_size: int,
+        encoder_tp_size: int,
         language_tp_size: int,
         stage_indices: dict[tuple[int], int],
     ):
-        vision_model_name = vision_config[0]
+        encoder_model_name = encoder_config[0]
         language_model_name = language_model_config[0]
         *_, model = self.generate_multimodal_model(
-            vision_config[1],
-            vision_config[2],
+            encoder_config[1],
+            encoder_config[2],
             language_model_config[1],
             language_model_config[2],
         )
 
         for rank in range(world_size):
             plugin = self.generate_multimodal_plugin(
-                vision_model_name,
+                encoder_model_name,
                 language_model_name,
-                vision_tp_size=vision_tp_size,
+                encoder_tp_size=encoder_tp_size,
                 language_tp_size=language_tp_size,
             )
 
@@ -355,7 +410,320 @@ class TestPluginInitializationWithFakeBackend:
             )
 
             if stage_index < 2:
-                # must only have vision
+                # must only have encoder
+                assert len(list(module.module.language_model.named_parameters())) == 0
+                parameters_in_encoder = list(
+                    name for name, _ in module.module.encoder_encoder.named_parameters()
+                )
+                if encoder_model_name in expected_audio_module_layers_per_stage:
+                    assert self.check_layers_cover_all_params(
+                        expected_audio_module_layers_per_stage[encoder_model_name][
+                            stage_index
+                        ],
+                        parameters_in_encoder,
+                    )
+                else:
+                    assert self.check_layers_cover_all_params(
+                        expected_vision_module_layers_per_stage[encoder_model_name][
+                            stage_index
+                        ],
+                        parameters_in_encoder,
+                    )
+            else:
+                # must only have language model
+                assert len(list(module.module.encoder_encoder.named_parameters())) == 0
+                assert self.check_layers_cover_all_params(
+                    expected_language_module_layers_per_stage[language_model_name][
+                        stage_index - 2
+                    ],
+                    list(
+                        name
+                        for name, _ in module.module.language_model.named_parameters()
+                    ),
+                )
+
+            dist.destroy_process_group()
+
+
+class TestMultiEncodersModelInitializationClass(
+    TestPluginInitializationWithFakeBackendBase
+):
+    def generate_multimodal_model(
+        self,
+        encoder_configs: list[PretrainedConfig],
+        encoder_model_clss: list[Type[PreTrainedModel]],
+        language_model_config: PretrainedConfig,
+        language_model_cls: Type[PreTrainedModel],
+    ) -> tuple[dict[str, ModalModule], PreTrainedModel, MultimodalModel]:
+        assert len(encoder_configs) == len(encoder_model_clss)
+        encoder_modules = {}
+        for index, (encoder_config, encoder_model_cls) in enumerate(
+            zip(encoder_configs, encoder_model_clss)
+        ):
+            encoder_module = encoder_model_cls(encoder_config)
+            encoder_module = ModalModule(encoder_module)
+            encoder_modules[f"encoder{index}"] = encoder_module
+
+        language_module = language_model_cls(language_model_config)
+
+        model = MultimodalModel(
+            encoders=encoder_modules,
+            language_model=language_module,
+        ).to(dtype=torch.float16)
+
+        return encoder_modules, language_module, model
+
+    def generate_multimodal_plugin(
+        self,
+        encoder_model_names: list[str],
+        language_model_name: str,
+        encoder_tp_sizes: list[int],
+        language_tp_size: int,
+    ) -> MultimodalParallelPlugin:
+        assert len(encoder_model_names) == len(encoder_tp_sizes)
+        encoder_plugins = {}
+        for index, (encoder_model_name, encoder_tp_size) in enumerate(
+            zip(encoder_model_names, encoder_tp_sizes)
+        ):
+            encoder_layers_per_stage = (
+                expected_audio_module_layers_per_stage[encoder_model_name]
+                if encoder_model_name in expected_audio_module_layers_per_stage
+                else expected_vision_module_layers_per_stage[encoder_model_name]
+            )
+            encoder_plugin = ModalParallelPlugin(
+                tp_size=encoder_tp_size,
+                pipeline_template=PipelineTemplate(
+                    encoder_model_name, encoder_layers_per_stage
+                ),
+            )
+            encoder_plugins[f"encoder{index}"] = encoder_plugin
+
+        language_plugin = ModalParallelPlugin(
+            tp_size=language_tp_size,
+            pipeline_template=PipelineTemplate(
+                language_model_name,
+                expected_language_module_layers_per_stage[language_model_name],
+            ),
+        )
+
+        return MultimodalParallelPlugin(
+            encoder_plugins=encoder_plugins,
+            language_model_plugin=language_plugin,
+            num_microbatches=12,
+            microbatch_size=1,
+        )
+
+    @pytest.mark.parametrize("vision_model_config", vision_configs, ids=["clip"])
+    @pytest.mark.parametrize("audio_model_config", audio_configs, ids=["whisper"])
+    @pytest.mark.parametrize(
+        "language_model_config", language_configs, ids=["mistral", "llama", "opt"]
+    )
+    @pytest.mark.parametrize(
+        "world_size, tp_size, expected_mesh",
+        [
+            (
+                28,
+                (2, 2, 2),
+                [
+                    [[0, 1], [2, 3]],
+                    [[4, 5], [6, 7]],
+                    [[8, 9], [10, 11]],
+                    [[12, 13], [14, 15]],
+                    [[16, 17], [18, 19]],
+                    [[20, 21], [22, 23]],
+                    [[24, 25], [26, 27]],
+                ],
+            ),
+            (
+                20,
+                (2, 2, 4),
+                [
+                    [[0, 0, 1, 1]],
+                    [[2, 2, 3, 3]],
+                    [[4, 4, 5, 5]],
+                    [[6, 6, 7, 7]],
+                    [[8, 9, 10, 11]],
+                    [[12, 13, 14, 15]],
+                    [[16, 17, 18, 19]],
+                ],
+            ),
+            (
+                18,
+                (2, 4, 2),
+                [
+                    [[0, 0, 1, 1]],
+                    [[2, 2, 3, 3]],
+                    [[4, 5, 6, 7]],
+                    [[8, 9, 10, 11]],
+                    [[12, 12, 13, 13]],
+                    [[14, 14, 15, 15]],
+                    [[16, 16, 17, 17]],
+                ],
+            ),
+        ],
+        ids=["tp=(2, 2, 2)", "tp=(2, 2, 4)", "tp=(2, 4, 2)"],
+    )
+    def test_initialize_plugin(
+        self,
+        vision_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        audio_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        language_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        world_size: int,
+        tp_size: tuple[int, int, int],
+        expected_mesh: list[list[list[int]]],
+    ):
+        vision_model_name = vision_model_config[0]
+        audio_model_name = audio_model_config[0]
+        language_model_name = language_model_config[0]
+        encoder_modules, language_module, model = self.generate_multimodal_model(
+            [vision_model_config[1], audio_model_config[1]],
+            [vision_model_config[2], audio_model_config[2]],
+            language_model_config[1],
+            language_model_config[2],
+        )
+
+        assert (
+            PipelineTemplate.get_modules(encoder_modules["encoder0"])
+            == expected_vision_module_layers[vision_model_name]
+        )
+        assert (
+            PipelineTemplate.get_modules(encoder_modules["encoder1"])
+            == expected_audio_module_layers[audio_model_name]
+        )
+        assert (
+            PipelineTemplate.get_modules(language_module)
+            == expected_language_module_layers[language_model_name]
+        )
+
+        vision_tp_size, audio_tp_size, language_tp_size = tp_size
+        for rank in range(world_size):
+            plugin = self.generate_multimodal_plugin(
+                [vision_model_name, audio_model_name],
+                language_model_name,
+                [vision_tp_size, audio_tp_size],
+                language_tp_size,
+            )
+            per_rank_model = copy.deepcopy(model)
+            dist.init_process_group(
+                backend="fake", store=FakeStore(), rank=rank, world_size=world_size
+            )
+            module = plugin.configure(per_rank_model)[0]
+
+            assert (plugin.stage_manager.pg_mesh.mesh == expected_mesh).all()
+
+            assert isinstance(module, MultimodalParallelModule)
+            assert module.module.encoder0_encoder is not None
+            assert module.module.encoder1_encoder is not None
+            assert module.module.language_model is not None
+
+            assert isinstance(
+                module.module.encoder0_encoder.module, vision_model_config[2]
+            )
+            assert isinstance(
+                module.module.encoder1_encoder.module, audio_model_config[2]
+            )
+            assert isinstance(
+                module.module.encoder0_encoder.projector, MultimodalProjector
+            )
+            assert isinstance(
+                module.module.encoder1_encoder.projector, MultimodalProjector
+            )
+            assert isinstance(module.module.language_model, language_model_config[2])
+
+            dist.destroy_process_group()
+
+    @pytest.mark.parametrize("vision_model_config", vision_configs, ids=["clip"])
+    @pytest.mark.parametrize("audio_model_config", audio_configs, ids=["whisper"])
+    @pytest.mark.parametrize(
+        "language_model_config", language_configs, ids=["mistral", "llama", "opt"]
+    )
+    @pytest.mark.parametrize(
+        "world_size, tp_size, stage_indices",
+        [
+            (
+                28,
+                (2, 2, 2),
+                {
+                    (0, 1, 2, 3): 0,
+                    (4, 5, 6, 7): 1,
+                    (8, 9, 10, 11): 2,
+                    (12, 13, 14, 15): 3,
+                    (16, 17, 18, 19): 4,
+                    (20, 21, 22, 23): 5,
+                    (24, 25, 26, 27): 6,
+                },
+            ),
+            (
+                20,
+                (2, 2, 4),
+                {
+                    (0, 1): 0,
+                    (2, 3): 1,
+                    (4, 5): 2,
+                    (6, 7): 3,
+                    (8, 9, 10, 11): 4,
+                    (12, 13, 14, 15): 5,
+                    (16, 17, 18, 19): 6,
+                },
+            ),
+            (
+                18,
+                (2, 4, 2),
+                {
+                    (0, 1): 0,
+                    (2, 3): 1,
+                    (4, 5, 6, 7): 2,
+                    (8, 9, 10, 11): 3,
+                    (12, 13): 4,
+                    (14, 15): 5,
+                    (16, 17): 6,
+                },
+            ),
+        ],
+        ids=["tp=(2, 2, 2)", "tp=(2, 2, 4)", "tp=(2, 4, 2)"],
+    )
+    def test_modal_parallelization(
+        self,
+        vision_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        audio_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        language_model_config: tuple[str, PretrainedConfig, Type[PreTrainedModel]],
+        world_size: int,
+        tp_size: tuple[int, int, int],
+        stage_indices: dict[tuple[int], int],
+    ):
+        vision_model_name = vision_model_config[0]
+        audio_model_name = audio_model_config[0]
+        language_model_name = language_model_config[0]
+        encoder_modules, language_module, model = self.generate_multimodal_model(
+            [vision_model_config[1], audio_model_config[1]],
+            [vision_model_config[2], audio_model_config[2]],
+            language_model_config[1],
+            language_model_config[2],
+        )
+
+        vision_tp_size, audio_tp_size, language_tp_size = tp_size
+        for rank in range(world_size):
+            plugin = self.generate_multimodal_plugin(
+                [vision_model_name, audio_model_name],
+                language_model_name,
+                [vision_tp_size, audio_tp_size],
+                language_tp_size,
+            )
+            per_rank_model = copy.deepcopy(model)
+            dist.init_process_group(
+                backend="fake", store=FakeStore(), rank=rank, world_size=world_size
+            )
+            module = plugin.configure(per_rank_model)[0]
+
+            stage_index = next(
+                stage_index
+                for ranks, stage_index in stage_indices.items()
+                if rank in ranks
+            )
+
+            if stage_index < 2:
+                # must only have vision encoder
+                assert len(list(module.module.encoder1_encoder.named_parameters())) == 0
                 assert len(list(module.module.language_model.named_parameters())) == 0
                 assert self.check_layers_cover_all_params(
                     expected_vision_module_layers_per_stage[vision_model_name][
@@ -363,15 +731,29 @@ class TestPluginInitializationWithFakeBackend:
                     ],
                     list(
                         name
-                        for name, _ in module.module.vision_encoder.named_parameters()
+                        for name, _ in module.module.encoder0_encoder.named_parameters()
+                    ),
+                )
+            elif stage_index < 4:
+                # must only have audio encoder
+                assert len(list(module.module.encoder0_encoder.named_parameters())) == 0
+                assert len(list(module.module.language_model.named_parameters())) == 0
+                assert self.check_layers_cover_all_params(
+                    expected_audio_module_layers_per_stage[audio_model_name][
+                        stage_index - 2
+                    ],
+                    list(
+                        name
+                        for name, _ in module.module.encoder1_encoder.named_parameters()
                     ),
                 )
             else:
                 # must only have language model
-                assert len(list(module.module.vision_encoder.named_parameters())) == 0
+                assert len(list(module.module.encoder0_encoder.named_parameters())) == 0
+                assert len(list(module.module.encoder1_encoder.named_parameters())) == 0
                 assert self.check_layers_cover_all_params(
                     expected_language_module_layers_per_stage[language_model_name][
-                        stage_index - 2
+                        stage_index - 4
                     ],
                     list(
                         name


### PR DESCRIPTION
This PR adds tests of multimodal models with more than one encoder (vision+audio) and its application to parallel plugin.
Only sharding and parallelization has been tested; this PR does not include additional implementation or required tests to execute such models which will be done after #16 is merged.