### PR TITLE
Add test for multimodal 1f1b

### DIFF
--- a/cornstarch/plugin/multimodal_parallel_plugin/multimodal_1f1b.py
+++ b/cornstarch/plugin/multimodal_parallel_plugin/multimodal_1f1b.py
@@ -747,6 +747,8 @@ class MultimodalEncoderTrainingOneForwardOneBackwardSchedule(
         my_modal = self.stage_manager.stage_index_to_modal[
             self.stage_manager.pg_mesh.coords[0][self.stage_manager.pipeline_axis]
         ]
+        # If LLM exists, calculate the number of warmup microbatches considering
+        # LLM pipeline stages.
         if self.stage_manager.pg_mesh.llm_template is not None:
             llm_modal = self.stage_manager.pg_mesh.llm_template[0]
 


### PR DESCRIPTION
Existing test didn't check the correctness of multimodal 1f1b scheduling, ending up having weird behavior mentioned in #27.
This PR adds tests to check forward and backward are properly scheduled to resolve #27.