### PR TITLE
Add an eval() function in the MultimodalModel class 

### DIFF
--- a/cornstarch/models/multimodal_language_model/modeling_multimodal_language_model.py
+++ b/cornstarch/models/multimodal_language_model/modeling_multimodal_language_model.py
@@ -819,6 +819,9 @@ class MultimodalModel(nn.Module):
             for p in self.language_model.parameters():
                 p.requires_grad_(llm_mode)
 
+    def eval(self):
+        super().train(False)
+
     def set_modality_token_ids(
         self, token_ids: dict[str, int], new_num_tokens: int = 0
     ):


### PR DESCRIPTION
This enables `model.eval()` execution, which is necessary to remove random elements (e.g., dropout) during the validation process.

Previously, even though we attempted to set the model to evaluation mode, it would still call `train()` and throw an error due to the missing `eval()` function. By adding the `eval()` function (see the code below), we can disable training and run without error.

```
def eval(self):
        super().train(False)
```

![image](https://github.com/user-attachments/assets/49d4d83c-7560-453e-b295-3c91796e6422)
