### PR TITLE
Resolve the issue #52: `position_embeddings` argument error when running in eval mode.

### DIFF
--- a/cornstarch/models/multimodal_language_model/modeling_multimodal_language_model.py
+++ b/cornstarch/models/multimodal_language_model/modeling_multimodal_language_model.py
@@ -1088,10 +1088,10 @@ class MultimodalModel(nn.Module):
         language_model_arguments = list(
             inspect.signature(self.language_model.forward).parameters.keys()
         )
-        if "kwargs" not in language_model_arguments:
-            for key in list(language_model_inputs.keys()):
-                if key not in language_model_arguments:
-                    language_model_inputs.pop(key)
+        # if "kwargs" not in language_model_arguments:
+        for key in list(language_model_inputs.keys()):
+            if key not in language_model_arguments:
+                language_model_inputs.pop(key)
 
         return self.language_model(**language_model_inputs)
 


### PR DESCRIPTION
- **Issue**: [#52](https://github.com/cornstarch-org/Cornstarch/issues/52)  
- **Context**: This issue occurs in `modeling_qwen2.py` (possibly due to an older Transformers version).  
- **Details**: As of Transformers 4.47, `position_embeddings` is required for all models. However, the Qwen2 LLM does not have `position_embeddings`, causing this issue. If a Hugging Face model does not follow that format, we need to skip checking the `kwargs` argument.