### PR TITLE
Bugfix/context parallel bitfield

### DIFF
--- a/cornstarch/shardformer/layers/context_parallel_bitfield_attention.py
+++ b/cornstarch/shardformer/layers/context_parallel_bitfield_attention.py
@@ -248,9 +248,9 @@ class ContextParallelBitfieldAttention(torch.autograd.Function):
                     async_op=True,
                 )
 
-            dq = torch.empty(
+            dq = torch.zeros(
                 (batch, seqlen_q, heads_stride * group_size, d),
-                dtype=q.dtype,
+                dtype=torch.float32,
                 device=q.device,
             )
             dkv = torch.empty(
@@ -307,7 +307,7 @@ class ContextParallelBitfieldAttention(torch.autograd.Function):
                     async_op=True,
                 )
 
-            dqs.append(dq)
+            dqs.append(dq.to(dtype=q.dtype))
             scattered_dkv[0][:, :, kv_head_index : kv_head_index + heads_stride] += dkv[
                 0
             ]

--- a/tests/test_kernel/test_bitfield_attention.py
+++ b/tests/test_kernel/test_bitfield_attention.py
@@ -169,17 +169,17 @@ def test_bitfield_attention(head_dim: int, seqlen: int, batch_size: int):
             dtype=torch.int64,
             device=device,
         )
-        # attention_mask[:, 12:24] = 1 << 1
-        # attention_mask[:, 36:56] = 1 << 2
+        attention_mask[:, 12:24] = 1 << 1
+        attention_mask[:, 36:56] = 1 << 2
 
         full_mask = torch.tril(
             torch.ones((batch_size, seqlen, seqlen), dtype=torch.bool, device=device),
             diagonal=0,
         )
-        # full_mask[:, 12:24, :] = False
-        # full_mask[:, 12:24, 12:24] = True
-        # full_mask[:, 36:56, :] = False
-        # full_mask[:, 36:56, 36:56] = True
+        full_mask[:, 12:24, :] = False
+        full_mask[:, 12:24, 12:24] = True
+        full_mask[:, 36:56, :] = False
+        full_mask[:, 36:56, 36:56] = True
 
         return attention_mask, full_mask
 


### PR DESCRIPTION
#65 introduces parallelized attention computation, which uses `triton.language.atomic_add` operations.
This operation does not support `bf16` buffer, thus the buffers need to use `torch.float32` (which is natural considering errors happening during accumulation). However, this change is not applied to context parallel bitfield attention.
This PR fixes the problem by properly using `torch.float32` for buffers that `triton.language.atomic_add` operates on.