### PR TITLE
T003-CP-EQUIVALENCE: single-GPU context-parallel attention numerical equivalence

### DIFF
--- a/tasks/backlog.md
+++ b/tasks/backlog.md
@@ -37,3 +37,34 @@ interface lands.
   layers is unsupported; `test_parallelism_integration` uses an all-full-
   attention MoE config for EP+PP, and `test_expert_parallel_qwen` covers
   linear-attention EP without PP.
+
+## B4 — Causal-LM context-parallel numerical equivalence
+- **Deferred from:** T003-CP-EQUIVALENCE.
+- **Reason:** the CP all-gather flash-attention kernel
+  (`cornstarch/distributed/context_parallel/attention.py`) hardcodes
+  `causal=False` (`_flash_attn_forward(..., causal=False)`) and splits the
+  sequence uniformly, so it cannot reproduce a causal language model under CP.
+  T003 therefore tests CP equivalence only at the **attention-function level**
+  against a non-causal full-sequence SDPA reference
+  (`tests/distributed/test_numerical_equivalence.py::TestContextParallelEquivalence`).
+- **Scope to resume:** add causal masking to the CP kernel and a load-balanced
+  causal split (zigzag / makespan-style assignment so each rank gets a balanced
+  share of the triangular work), then assert a full causal-LM forward+backward
+  CP equivalence vs the single-GPU reference.
+
+## B5 — CP kernel backward side-stream race (latent kernel bug)
+- **Found during:** T003-CP-EQUIVALENCE.
+- **Symptom:** in `ContextParallelFlashAttention.backward`, the per-head-group
+  `dkv` (a `torch.empty`) is `.clone()`d on the default stream immediately after
+  an `async_op=True` `reduce_scatter` enqueued on the side stream, while the only
+  `wait_stream(side_stream)` happens *after* the loop. The clone can read the
+  buffer before the side-stream copy lands → intermittent corrupted `dk` /
+  occasional NaN. It surfaced under the gloo CPU-bridged single-GPU test;
+  whether it also bites real NCCL multi-GPU runs is unconfirmed.
+- **T003 workaround (test-only):** the equivalence test pins the kernel's overlap
+  stream to the current stream (`_serialize_cp_stream`) so the collectives run
+  serially with compute. This removes the race without changing kernel math and
+  lets forward+backward parity hold at 5e-3.
+- **Scope to resume:** fix the ordering in the kernel itself — `wait_stream` (or
+  per-iteration event sync) before each `dkv.clone()`, or write reduce-scatter
+  output into a non-`empty` buffer — then drop the test workaround.

--- a/tasks/done/T003-CP-EQUIVALENCE.md
+++ b/tasks/done/T003-CP-EQUIVALENCE.md
@@ -1,0 +1,132 @@
+## Task ID: T003-CP-EQUIVALENCE
+## Type: IMPLEMENTATION (single-GPU CP numerical-equivalence test; tests must be green)
+## Goal: replace the skipped (>=2 GPU) context-parallel numerical-equivalence test
+with a single-GPU test, following the legacy single-GPU CP testing approach.
+
+In T002-PARALLELISM the CP numerical-equivalence test
+(`tests/distributed/test_numerical_equivalence.py::TestContextParallelEquivalence`)
+was guarded to require >=2 CUDA devices and therefore skips on this 1-GPU box.
+The legacy suite tested CP on a single GPU and we should do the same.
+
+## Feasibility (already verified — do not re-litigate)
+- **It works on one GPU.** `GlooDistributedTestBase` spawns `world_size`
+  processes and sets `torch.cuda.set_device(rank % device_count())`; with one
+  GPU every rank shares `cuda:0`. The collectives run on the **gloo** backend
+  (CPU) via the `gloo_utils` patches, which bridge CUDA tensors through CPU
+  (`all_gather_gloo` / `reduce_scatter_gloo` copy to CPU, communicate, copy
+  back), while flash-attention computes on the shared GPU.
+- **Confirmed empirically** against the *new*
+  `cornstarch.distributed.context_parallel.attention.ContextParallelFlashAttention`:
+  a 2-rank gloo run on a single GPU passed forward **and** backward parity at
+  `rtol=atol=5e-3` (bf16) vs a full-sequence reference. The exact shape of the
+  passing probe is the legacy `TestFlashAttentionContextParallelismClass`
+  (`tests_old/test_shardformer/test_context_parallel.py`, lines 401-493).
+- **Scope limit (important).** The new CP kernel hardcodes `causal=False`
+  (`attention.py`: `_flash_attn_forward(..., causal=False)`). So CP equivalence
+  is testable at the **attention-function level** against a *non-causal*
+  reference (`scaled_dot_product_attention(..., is_causal=False)`), exactly as
+  the legacy flash-attn CP test did. A full **causal language-model** CP
+  equivalence is NOT feasible with the current kernel (it would need causal
+  masking + a load-balanced split); that is a separate, larger item — see
+  Backlog note below, do NOT attempt it here.
+
+## What you must read
+- tests_old/test_shardformer/test_context_parallel.py
+  (`TestFlashAttentionContextParallelismClass`, the single-GPU pattern to follow)
+- cornstarch/distributed/context_parallel/attention.py
+  (`ContextParallelFlashAttention`, `context_parallel_flash_attention`,
+  `_allgather_kv` — note `causal=False`, `softmax_scale = d ** -0.5`,
+  `heads_stride`)
+- tests/distributed/distributed_base.py (GlooDistributedTestBase, the CUDA
+  device-per-rank setup and the dynamo-disable already added)
+- tests/distributed/gloo_utils.py (all_gather_gloo / reduce_scatter_gloo —
+  confirm they handle the attention's `async_op=True` calls and CUDA tensors)
+- tests/distributed/test_numerical_equivalence.py
+  (the current skipped `TestContextParallelEquivalence` to replace)
+
+## What you must produce
+1. **A single-GPU CP attention numerical-equivalence test** in
+   `tests/distributed/` (either a new `test_context_parallel_attention.py` or by
+   replacing `TestContextParallelEquivalence` in
+   `test_numerical_equivalence.py`). It must:
+   - subclass `GlooDistributedTestBase` with `world_size = 2`;
+   - `@unittest.skipUnless(torch.cuda.is_available(), ...)` (single GPU is
+     enough — do NOT require >=2 devices);
+   - build full `q, k, v` of shape `(batch, seq, heads, dim)` on `cuda` in
+     bf16 (use `dim=64`, `heads=8`, which flash-attn supports);
+   - compute the reference with non-causal SDPA over the full sequence;
+   - chunk `q, k, v` along the sequence dim per rank, call
+     `ContextParallelFlashAttention.apply(local_q, local_k, local_v,
+     dist.GroupMember.WORLD)` (use the WORLD group as the CP group — no
+     `DeviceMesh`, which avoids the cuda-device-type + gloo-backend mismatch);
+   - assert `cp_out` matches `chunk(ref_out)[rank]` and that `cp_dq/dk/dv`
+     match `chunk(ref_d*)[rank]` (forward + backward), using `rtol=atol=5e-3`
+     (bf16 CP all-gather flash-attn accumulates differently than a single
+     matmul; 1e-3 is too tight here — verified). Justify the tolerance in a
+     comment, referencing that the broader project target is 1e-3 but CP
+     bf16 flash-attn needs 5e-3, matching the legacy test.
+   - parametrize over a few `(batch_size, seq_len)` like the legacy test
+     (e.g. bs in {1, 2}, seq in {128, 256, 1024}); keep seq divisible by
+     `world_size`.
+2. **Remove the >=2-GPU skip** path: delete or replace the old
+   `TestContextParallelEquivalence` so CP equivalence actually runs on this box.
+   If kept in `test_numerical_equivalence.py`, drop the
+   `skipUnless(device_count() >= 2)` and the `DeviceMesh(device_type="cuda")`
+   usage in favor of the WORLD-group attention-level test above.
+3. **(Optional, only if cheap)** also exercise the HF dispatch wrapper
+   `context_parallel_flash_attention(module=None, query, key, value, cp_group=...)`
+   (the `(b, h, s, d)` -> `(b, s, h, d)` transpose path) for one shape, to cover
+   the registered-attention entry point, not just the raw autograd Function.
+4. **Backlog note**: append an item to `tasks/backlog.md` recording that
+   full **causal-LM** CP numerical equivalence is deferred because the CP
+   flash-attention kernel is non-causal (`causal=False`) and lacks
+   load-balanced causal splitting; resuming it means adding causal support
+   (and likely the zigzag/makespan split) to the CP kernel.
+
+## What you must NOT do
+- Do NOT require >=2 GPUs; the test must run on a single GPU via 2 gloo ranks.
+- Do NOT try to make a full causal language model match under CP — the kernel
+  is non-causal; that is out of scope and goes to the backlog.
+- Do NOT change the CP kernel's behavior (no adding causal support in this task).
+- Do NOT import from `cornstarch_old`; port the *pattern*, not the legacy code
+  (the legacy `ContextParallelFlashAttention` lives in `cornstarch_old`).
+- Do NOT add a `DeviceMesh` with `device_type="cuda"` under the gloo backend in
+  the test; use `dist.GroupMember.WORLD` as the CP group.
+
+## On Ambiguity
+Per CLAUDE.md: write your interpretation to this file under a BLOCK section and
+stop. Do not guess on interface decisions.
+
+## RESOLVED (2026-06-21): backward `dk` instability was a kernel race, not bf16
+
+First diagnosis was that backward `dk` failed `5e-3` by 3–10× due to bf16
+cross-rank gradient reduction, and the user approved loosening backward to
+`5e-2`. Deeper investigation **disproved that**: the real cause is a side-stream
+race in `ContextParallelFlashAttention.backward`. The per-head `dkv` (a
+`torch.empty`) is `.clone()`d on the default stream right after an
+`async_op=True` `reduce_scatter` on the kernel's side stream, with the only
+`wait_stream` *after* the loop — so the clone intermittently reads
+uninitialized memory (corrupted `dk`, occasional NaN).
+
+Evidence: pinning the kernel's overlap stream to the current stream (serializing
+the collectives — no math change, the side stream is a pure perf optimization)
+makes worst-case backward grad diff **≤ 0.00098 with zero NaNs over 80+ runs**
+across all shapes. So backward parity holds at the task's intended **5e-3**.
+
+Final implementation:
+- `_serialize_cp_stream()` pins `ContextParallelFlashAttention._stream` to the
+  current stream (test-only; documented). This removes the race.
+- Forward **and** backward asserted at `rtol=atol=5e-3` (the spec value), not the
+  approved `5e-2` — the `5e-2` is unnecessary once the race is gone, and `5e-3`
+  matches the Done Condition and the legacy test exactly.
+- The latent kernel race is recorded as **B5** in `tasks/backlog.md`.
+
+## Done Condition
+- `tests/distributed/` contains a CP numerical-equivalence test that runs (not
+  skips) on a single GPU and asserts forward + backward parity vs a non-causal
+  full-sequence reference at `rtol=atol=5e-3` bf16.
+- The previous >=2-GPU-gated `TestContextParallelEquivalence` no longer skips on
+  a 1-GPU machine (replaced or removed).
+- `pytest tests/distributed/test_numerical_equivalence.py` (or the new test
+  file) is green on this box; `pytest tests` remains green.
+- The deferred causal-LM CP equivalence is recorded in `tasks/backlog.md`.

--- a/tasks/done/T003-CP-EQUIVALENCE.md
+++ b/tasks/done/T003-CP-EQUIVALENCE.md
@@ -1,3 +1,6 @@
+## Status: DONE — PR https://github.com/cornstarch-org/Cornstarch/pull/70
+## (base: feat/T002-parallelism; T003 builds on T002's CP kernel + test file)
+
 ## Task ID: T003-CP-EQUIVALENCE
 ## Type: IMPLEMENTATION (single-GPU CP numerical-equivalence test; tests must be green)
 ## Goal: replace the skipped (>=2 GPU) context-parallel numerical-equivalence test

--- a/tests/distributed/test_numerical_equivalence.py
+++ b/tests/distributed/test_numerical_equivalence.py
@@ -15,7 +15,13 @@ not rely on sharded checkpoint load, which is intentionally out of scope.
 
 All tests use the gloo backend so they run on CPU.  Context parallelism's
 all-gather flash-attention kernel is CUDA-only, so its numerical-equivalence
-test is guarded to require >=2 visible CUDA devices and otherwise skips.
+test runs the collectives on gloo (CPU, bridged via ``gloo_utils``) while the
+flash-attention compute happens on the shared GPU.  Two gloo ranks share a
+single ``cuda:0``, so the CP test runs on a one-GPU box (it only needs CUDA to
+be available, not >=2 devices).  CP equivalence is asserted at the
+attention-function level against a *non-causal* full-sequence SDPA reference,
+because the CP kernel hardcodes ``causal=False`` (see ``tasks/backlog.md`` for
+the deferred causal-LM CP equivalence).
 """
 from __future__ import annotations
 
@@ -25,6 +31,11 @@ import torch
 import torch.distributed as dist
 import torch.nn as nn
 from torch.distributed.tensor import DTensor, distribute_tensor
+from torch.nn.functional import scaled_dot_product_attention as sdpa
+from torch.testing._internal.common_utils import (
+    instantiate_parametrized_tests,
+    parametrize,
+)
 
 from tests.distributed.distributed_base import GlooDistributedTestBase
 from tests.model.model_configs import llama_config, qwen3_5_moe_config
@@ -252,51 +263,184 @@ class TestDataParallelEquivalence(GlooDistributedTestBase):
         torch.testing.assert_close(dp_grad, ref_grad, atol=ATOL, rtol=RTOL)
 
 
+# CP flash-attn accumulates over an all-gathered K/V sequence in a different
+# order than a single full-sequence SDPA matmul, so both forward and backward
+# parity hold at 5e-3 — looser than the project-wide 1e-3 target but matching
+# the legacy single-GPU CP flash-attn test (tests_old/.../test_context_parallel.py).
+CP_ATOL = 5e-3
+CP_RTOL = 5e-3
+
+
+def _serialize_cp_stream() -> None:
+    """Pin the CP kernel's overlap stream to the current stream.
+
+    The kernel overlaps its all-gather / reduce-scatter on a dedicated side CUDA
+    stream and only re-syncs at the very end of backward.  Under the gloo CPU
+    bridge that runs these collectives, the per-head ``dkv`` buffer (a
+    ``torch.empty``) is cloned on the default stream before the side stream's
+    reduce-scatter copy lands, so the clone races and reads uninitialized memory
+    (intermittent NaN / corrupted dk).  Forcing the kernel onto the current
+    stream serializes the collectives with the compute, which removes the race
+    without changing the kernel's math (the side stream is purely a perf
+    optimization).  This makes the single-GPU test deterministic and lets
+    backward parity hold at the same 5e-3 as forward.
+    """
+    from cornstarch.distributed.context_parallel.attention import (
+        ContextParallelFlashAttention,
+    )
+
+    ContextParallelFlashAttention._stream = torch.cuda.current_stream()
+
+
 @unittest.skipUnless(
-    torch.cuda.is_available() and torch.cuda.device_count() >= 2,
-    "context-parallel attention uses CUDA flash-attn and needs >=2 GPUs",
+    torch.cuda.is_available(),
+    "context-parallel attention uses CUDA flash-attn (gloo bridges the "
+    "collectives, so a single GPU shared by 2 ranks is enough)",
 )
+@instantiate_parametrized_tests
 class TestContextParallelEquivalence(GlooDistributedTestBase):
+    """Single-GPU CP attention parity vs a non-causal full-sequence SDPA.
+
+    Two gloo ranks share ``cuda:0``.  Each rank holds a sequence-dim chunk of
+    Q/K/V; ``ContextParallelFlashAttention`` all-gathers K/V (over gloo, on CPU)
+    and runs flash-attention on the GPU.  The rank's output and Q/K/V gradients
+    must match the corresponding chunk of the full-sequence reference.
+    """
+
     @property
     def world_size(self) -> int:
         return 2
 
-    def test_cp_matches_single(self):  # pragma: no cover - needs >=2 GPUs
-        from cornstarch.distributed.context_parallel import apply_context_parallel
-        from cornstarch.distributed.context_parallel.splitters import (
-            UniformContextParallelSplitter,
+    @parametrize("batch_size", [1, 2], name_fn=lambda x: f"bs={x}")
+    @parametrize("seq_len", [128, 256, 1024], name_fn=lambda x: f"seq={x}")
+    def test_cp_attention_matches_single(self, batch_size: int, seq_len: int):
+        from cornstarch.distributed.context_parallel.attention import (
+            ContextParallelFlashAttention,
         )
 
-        mesh = ModalProcessGroupMesh(
-            device_type="cuda", global_ranks=[0, 1],
-            dp_size=1, cp_size=2, tp_size=1, num_pp_stages=1,
+        _serialize_cp_stream()
+
+        nheads, dim = 8, 64  # dim=64 / heads=8 are flash-attn-supported shapes
+        assert seq_len % self.world_size == 0
+
+        # Full-sequence Q/K/V, identical on every rank (seed reset in _run).
+        query, key, value = torch.unbind(
+            torch.randn(
+                (3, batch_size, seq_len, nheads, dim),
+                device="cuda",
+                dtype=DTYPE,
+            ).normal_(mean=0, std=0.5),
         )
-        device = f"cuda:{torch.cuda.current_device()}"
+        for t in (query, key, value):
+            t.requires_grad_()
 
-        ref = _ref_params(_build_llm())
-        ref_model = _build_llm().to(device)
-        batch = _batch()
-        batch = {k: v.to(device) for k, v in batch.items()}
-        ref_loss = _loss(ref_model, batch)
+        # Reference: non-causal SDPA over the full sequence. SDPA wants
+        # (b, h, s, d); the CP kernel uses (b, s, h, d).
+        ref_out = sdpa(
+            query.transpose(1, 2),
+            key.transpose(1, 2),
+            value.transpose(1, 2),
+            is_causal=False,
+        ).transpose(1, 2)
 
-        model = _build_llm()
-        apply_context_parallel(model, mesh.cp_group)
-        _copy_full_into(model, ref)
-        model.to(device)
+        local_q = (
+            torch.chunk(query, self.world_size, dim=1)[self.rank]
+            .requires_grad_()
+            .contiguous()
+        )
+        local_k = (
+            torch.chunk(key, self.world_size, dim=1)[self.rank]
+            .requires_grad_()
+            .contiguous()
+        )
+        local_v = (
+            torch.chunk(value, self.world_size, dim=1)[self.rank]
+            .requires_grad_()
+            .contiguous()
+        )
 
-        splitter = UniformContextParallelSplitter()
-        mask = torch.ones_like(batch["input_ids"], dtype=torch.float32)
-        splitter.compute_offsets(mask, mesh.cp_group)
-        local = {
-            "input_ids": splitter.split(batch["input_ids"], mesh.cp_group),
-            "labels": splitter.split(batch["labels"], mesh.cp_group),
-        }
-        cp_loss = _loss(model, local)
-        # Per-rank CP loss is over the local shard; gather and average.
-        losses = [torch.zeros_like(cp_loss) for _ in range(self.world_size)]
-        dist.all_gather(losses, cp_loss.detach())
+        # WORLD group as the CP group: avoids a DeviceMesh(device_type="cuda")
+        # under the gloo backend (cuda-device-type + gloo-backend mismatch).
+        cp_out = ContextParallelFlashAttention.apply(
+            local_q, local_k, local_v, dist.GroupMember.WORLD
+        )
+
         torch.testing.assert_close(
-            torch.stack(losses).mean(), ref_loss, atol=ATOL, rtol=RTOL
+            torch.chunk(ref_out, self.world_size, dim=1)[self.rank],
+            cp_out,
+            atol=CP_ATOL,
+            rtol=CP_RTOL,
+        )
+
+        # Backward parity: each rank's dq/dk/dv match its chunk of the ref grads.
+        dout = torch.randn_like(ref_out).normal_(mean=0, std=0.5)
+        ref_dq, ref_dk, ref_dv = torch.autograd.grad(
+            ref_out, [query, key, value], dout
+        )
+
+        cp_dout = torch.chunk(dout, self.world_size, dim=1)[self.rank].contiguous()
+        cp_dq, cp_dk, cp_dv = torch.autograd.grad(
+            cp_out, [local_q, local_k, local_v], cp_dout
+        )
+
+        torch.testing.assert_close(
+            torch.chunk(ref_dq, self.world_size, dim=1)[self.rank].contiguous(),
+            cp_dq,
+            atol=CP_ATOL,
+            rtol=CP_RTOL,
+        )
+        torch.testing.assert_close(
+            torch.chunk(ref_dk, self.world_size, dim=1)[self.rank].contiguous(),
+            cp_dk,
+            atol=CP_ATOL,
+            rtol=CP_RTOL,
+        )
+        torch.testing.assert_close(
+            torch.chunk(ref_dv, self.world_size, dim=1)[self.rank].contiguous(),
+            cp_dv,
+            atol=CP_ATOL,
+            rtol=CP_RTOL,
+        )
+
+    def test_cp_attention_hf_dispatch_wrapper(self):
+        """Cover the HF dispatch entry point (the (b, h, s, d) transpose path)."""
+        from cornstarch.distributed.context_parallel.attention import (
+            context_parallel_flash_attention,
+        )
+
+        _serialize_cp_stream()
+
+        batch_size, nheads, seq_len, dim = 2, 8, 256, 64
+        assert seq_len % self.world_size == 0
+
+        # HF layout is (b, h, s, d); the wrapper transposes to (b, s, h, d).
+        query, key, value = torch.unbind(
+            torch.randn(
+                (3, batch_size, nheads, seq_len, dim),
+                device="cuda",
+                dtype=DTYPE,
+            ).normal_(mean=0, std=0.5),
+        )
+
+        ref_out = sdpa(query, key, value, is_causal=False)
+
+        local_q = torch.chunk(query, self.world_size, dim=2)[self.rank].contiguous()
+        local_k = torch.chunk(key, self.world_size, dim=2)[self.rank].contiguous()
+        local_v = torch.chunk(value, self.world_size, dim=2)[self.rank].contiguous()
+
+        cp_out, _ = context_parallel_flash_attention(
+            module=None,
+            query=local_q,
+            key=local_k,
+            value=local_v,
+            cp_group=dist.GroupMember.WORLD,
+        )
+
+        torch.testing.assert_close(
+            torch.chunk(ref_out, self.world_size, dim=2)[self.rank],
+            cp_out,
+            atol=CP_ATOL,
+            rtol=CP_RTOL,
         )
 
 


### PR DESCRIPTION
## Summary

Replaces the skipped (>=2 GPU) context-parallel numerical-equivalence test with a **single-GPU** attention-level CP equivalence test, following the legacy single-GPU CP testing approach.

- `tests/distributed/test_numerical_equivalence.py::TestContextParallelEquivalence` now runs (not skips) on a 1-GPU box via 2 gloo ranks sharing `cuda:0`.
- Asserts forward + `dq`/`dk`/`dv` backward parity of `ContextParallelFlashAttention` vs a non-causal full-sequence SDPA reference at `rtol=atol=5e-3` (bf16), parametrized over `bs ∈ {1,2}`, `seq ∈ {128,256,1024}`.
- Adds a forward check of the `context_parallel_flash_attention` HF dispatch wrapper (the `(b,h,s,d) -> (b,s,h,d)` path).
- Uses `dist.GroupMember.WORLD` as the CP group (no cuda `DeviceMesh` under gloo).

## Notable finding: CP backward side-stream race

Backward `dk` was intermittently corrupted (occasional NaN). Root cause is **not** bf16 reduction precision but a race in `ContextParallelFlashAttention.backward`: the per-head `dkv` (`torch.empty`) is `.clone()`d on the default stream before the side-stream `reduce_scatter` copy lands, with the only `wait_stream` after the loop. Pinning the kernel's overlap stream to the current stream (math-neutral — the side stream is a perf optimization) removes the race; worst-case backward diff then ≤ 0.001 with zero NaN over 80+ runs, so parity holds at the intended 5e-3. The latent kernel bug is recorded as backlog **B5** to fix in the kernel later.

## Scope / deferred

Full **causal-LM** CP equivalence is deferred (backlog **B4**): the CP flash-attention kernel hardcodes `causal=False` and lacks a load-balanced causal split, so CP equivalence is only testable at the attention-function level against a non-causal reference.

## Acceptance criteria

- [x] CP equivalence test runs (not skips) on a single GPU, asserting forward + backward parity vs a non-causal full-sequence reference at `rtol=atol=5e-3` bf16.
- [x] Previous >=2-GPU-gated `TestContextParallelEquivalence` no longer skips (replaced).
- [x] `pytest tests/distributed/test_numerical_equivalence.py` green (11 passed); `pytest tests` green (149 passed).
- [x] Deferred causal-LM CP equivalence recorded in `tasks/backlog.md` (B4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ4nazu3FyUMBzEbmxgVL