### PR TITLE
T004: tidy the Option C distributed UX (unified materialize, projector auto-follows, examples)

### DIFF
--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -31,7 +31,7 @@ tests call these directly; everything else is built on them.
 
 **Layer 2 — declarative per-modality plan (surface).**  Most users only touch
 this: describe each modality with a ``ParallelConfig``, register it on a
-``ParallelizationPlan``, and call ``.distribute()`` to get a ``ParallelContext``
+``ParallelizationPlan``, and call ``.materialize()`` to get a ``ParallelContext``
 that folds DP/CP into ``prepare_dataloader``, builds the schedule, and exposes
 ``sync_gradients``.
 """

--- a/cornstarch/distributed/parallel_config.py
+++ b/cornstarch/distributed/parallel_config.py
@@ -28,7 +28,7 @@ class ParallelConfig:
     - ``expert_parallel_size`` (``ep``): MoE experts sharded across these ranks.
 
     All process groups and ``DeviceMesh`` handles are constructed internally by
-    ``ParallelizationPlan.distribute()`` — callers never create or pass them
+    ``ParallelizationPlan.materialize()`` — callers never create or pass them
     directly.  When ``context_parallel_size > 1`` a splitter must be provided so
     the dataloader knows how to partition sequences across CP ranks.
     """

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -38,6 +38,7 @@ from cornstarch.distributed.pipeline_parallel.schedule import (
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.distributed.tensor_parallel import apply_tensor_parallel
 from cornstarch.models.model_base import CornstarchModelBase
+from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
 
 if TYPE_CHECKING:
     from cornstarch.models.multimodal.execution import (
@@ -256,9 +257,25 @@ class ParallelizationPlan:
         )
 
     def parallelize(
-        self, module: CornstarchModelBase, config: ParallelConfig
+        self,
+        module: CornstarchModelBase | CornstarchModalityEncoder,
+        config: ParallelConfig,
     ) -> None:
-        """Record a module-to-config binding for later distribution."""
+        """Record a module-to-config binding for later distribution.
+
+        Only Cornstarch models and ``CornstarchModalityEncoder`` units are
+        accepted. A bare Hugging Face encoder (or any other module) is rejected:
+        it has no projector lifecycle and no ``_section_names()`` for the
+        ``apply_*`` helpers to walk. Wrap such an encoder with
+        ``build_modality_encoder(encoder, language_model, modality=...)`` first.
+        """
+        if not isinstance(module, (CornstarchModelBase, CornstarchModalityEncoder)):
+            raise TypeError(
+                f"parallelize() requires a CornstarchModelBase or "
+                f"CornstarchModalityEncoder, got {type(module).__name__}. Wrap a "
+                f"raw Hugging Face encoder with build_modality_encoder(encoder, "
+                f"language_model, modality=...) before parallelizing it."
+            )
         self._modules.append(module)
         self._configs.append(config)
 
@@ -333,17 +350,28 @@ class ParallelizationPlan:
             )
             meshes[id(module)] = mesh
 
+            # The model-side parallelisms (TP/CP/PP/EP) walk a Cornstarch model's
+            # `_section_names()`/`hf_config`. For a modality encoder that lives on
+            # its inner `.encoder`; the projector stays replicated (no registered
+            # TP family) and CP/PP/EP do not apply to it. `materialize` is still
+            # called on the modality encoder so the projector follows along.
+            apply_target = (
+                module.encoder
+                if isinstance(module, CornstarchModalityEncoder)
+                else module
+            )
+
             if config.tensor_parallel_size > 1:
-                apply_tensor_parallel(module, mesh.tp_mesh)
+                apply_tensor_parallel(apply_target, mesh.tp_mesh)
             if config.context_parallel_size > 1:
-                apply_context_parallel(module, mesh.cp_group)
+                apply_context_parallel(apply_target, mesh.cp_group)
             if config.pipeline_parallel_size > 1:
-                apply_pipeline_parallel(module, mesh)
+                apply_pipeline_parallel(apply_target, mesh)
 
             module.materialize(device, dtype=dtype)
 
             if config.expert_parallel_size > 1:
-                apply_expert_parallel(module, mesh.ep_group)
+                apply_expert_parallel(apply_target, mesh.ep_group)
 
         dp_size_final, dp_rank, dp_group, grad_sync = self._build_dp_handles(
             meshes

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -3,7 +3,7 @@
 This is the ergonomic layer that most users touch.  They describe each
 modality's parallel degrees with a :class:`ParallelConfig`, register the
 modules with :meth:`ParallelizationPlan.parallelize`, then call
-:meth:`ParallelizationPlan.distribute` once.  ``distribute`` returns a
+:meth:`ParallelizationPlan.materialize` once.  ``materialize`` returns a
 :class:`ParallelContext` that folds the data-side parallelisms (DP sampler +
 CP sequence split) into ``prepare_dataloader``, builds the training schedule,
 and exposes gradient synchronization — so the training loop stays plain
@@ -50,7 +50,7 @@ _DEFAULT_CP_SPLIT_KEYS = ("input_ids", "labels", "attention_mask", "position_ids
 
 
 class ParallelContext:
-    """Runtime handle returned by :meth:`ParallelizationPlan.distribute`.
+    """Runtime handle returned by :meth:`ParallelizationPlan.materialize`.
 
     Holds the per-modality meshes, the data-parallel sampler coordinates, the
     configured CP splitters, and the cross-modality gradient synchronizer.  Use
@@ -239,7 +239,7 @@ class ParallelizationPlan:
             context_parallel_splitter=UniformContextParallelSplitter(),
         ))
 
-        ctx = plan.distribute(device, dtype=torch.bfloat16)
+        ctx = plan.materialize(device, dtype=torch.bfloat16)
         loader = ctx.prepare_dataloader(dataset, batch_size=16, collate_fn=collate)
         schedule = ctx.create_schedule(exec_plan, output_future,
                                        num_microbatches=8, microbatch_size=2)
@@ -262,7 +262,7 @@ class ParallelizationPlan:
         self._modules.append(module)
         self._configs.append(config)
 
-    def distribute(
+    def materialize(
         self,
         device: str | torch.device = "cuda",
         dtype: torch.dtype | None = None,

--- a/cornstarch/models/__init__.py
+++ b/cornstarch/models/__init__.py
@@ -19,6 +19,7 @@ from cornstarch.models.multimodal import (
     CornstarchMultimodalConfig,
     CornstarchProjector,
     ExecutionFuture,
+    build_modality_encoder,
 )
 from cornstarch.models.vision_encoder import CornstarchVisionEncoder
 
@@ -36,6 +37,7 @@ __all__ = [
     "ExecutionFuture",
     "RepeatedLayerCompileConfig",
     "RepeatedLayerOffloadConfig",
+    "build_modality_encoder",
     "from_hf_config",
     "from_pretrained_config",
     "load_hf_state_dict",

--- a/cornstarch/models/lazy_init.py
+++ b/cornstarch/models/lazy_init.py
@@ -21,15 +21,18 @@ class InitializationPlan:
 
     The plan is intentionally data-only. ``empty`` allocates real tensors without
     filling them, ``random`` asks modules to run their default initialization, and
-    ``checkpoint`` assigns weights from an already-loaded state dict or a
-    safetensors checkpoint path. Keeping this choice separate from construction
-    lets callers stage HF weights before materialization and keeps model classes
-    free of ad hoc loading flags.
+    ``checkpoint`` assigns weights from one of three sources: an already-loaded
+    state dict, a local safetensors checkpoint path, or a Hugging Face Hub
+    identifier (``model_name_or_path``) whose ``*.safetensors`` shards are
+    downloaded and merged at materialization time. Keeping this choice separate
+    from construction lets callers stage HF weights before materialization and
+    keeps model classes free of ad hoc loading flags.
     """
 
     mode: str
     state_dict: Mapping[str, torch.Tensor] | None = None
     checkpoint_path: str | Path | None = None
+    model_name_or_path: str | None = None
 
     def __post_init__(self) -> None:
         if self.mode not in _VALID_MODES:
@@ -37,11 +40,16 @@ class InitializationPlan:
                 f"Unknown InitializationPlan mode {self.mode!r}. "
                 f"Valid modes are: {sorted(_VALID_MODES)}"
             )
-        if self.mode == "checkpoint" and self.state_dict is not None and self.checkpoint_path is not None:
-            raise ValueError(
-                "InitializationPlan.checkpoint() accepts either state_dict or "
-                "checkpoint_path, not both."
+        if self.mode == "checkpoint":
+            sources = sum(
+                source is not None
+                for source in (self.state_dict, self.checkpoint_path, self.model_name_or_path)
             )
+            if sources > 1:
+                raise ValueError(
+                    "InitializationPlan.checkpoint() accepts at most one of "
+                    "state_dict, checkpoint_path, or model_name_or_path."
+                )
 
     @classmethod
     def empty(cls) -> InitializationPlan:
@@ -58,6 +66,17 @@ class InitializationPlan:
         cls,
         state_dict: Mapping[str, torch.Tensor] | None = None,
         checkpoint_path: str | Path | None = None,
+        model_name_or_path: str | None = None,
     ) -> InitializationPlan:
-        """Create a plan that materializes tensors from checkpoint weights."""
-        return cls(mode="checkpoint", state_dict=state_dict, checkpoint_path=checkpoint_path)
+        """Create a plan that materializes tensors from checkpoint weights.
+
+        Exactly one source is used: a pre-loaded ``state_dict``, a local
+        ``checkpoint_path`` to a safetensors file, or a Hugging Face Hub
+        ``model_name_or_path`` to download and merge.
+        """
+        return cls(
+            mode="checkpoint",
+            state_dict=state_dict,
+            checkpoint_path=checkpoint_path,
+            model_name_or_path=model_name_or_path,
+        )

--- a/cornstarch/models/model_base.py
+++ b/cornstarch/models/model_base.py
@@ -118,11 +118,23 @@ class CornstarchModelBase(nn.Module):
         self,
         state_dict: Mapping[str, torch.Tensor] | None = None,
         checkpoint_path: str | Path | None = None,
+        model_name_or_path: str | None = None,
     ) -> None:
-        """Configure materialization to assign weights from a state dict or file."""
+        """Configure materialization to assign weights from checkpoint sources.
+
+        Exactly one source is used: a pre-loaded Hugging Face ``state_dict``, a
+        local safetensors ``checkpoint_path``, or a Hugging Face Hub
+        ``model_name_or_path`` whose ``*.safetensors`` shards are downloaded and
+        merged at ``materialize()`` time. The same materialize path serves a
+        plain model and a TP/PP-sharded (DTensor) one.
+        """
         if state_dict is not None:
             state_dict = self._state_mapper.hf_to_cornstarch_state_dict(state_dict)
-        self._init_plan = InitializationPlan.checkpoint(state_dict=state_dict, checkpoint_path=checkpoint_path)
+        self._init_plan = InitializationPlan.checkpoint(
+            state_dict=state_dict,
+            checkpoint_path=checkpoint_path,
+            model_name_or_path=model_name_or_path,
+        )
 
     def materialize(
         self,
@@ -142,7 +154,7 @@ class CornstarchModelBase(nn.Module):
         device = torch.device(device)
         if self._init_plan.mode == "checkpoint":
             state_dict = self._load_checkpoint_state_dict(device, dtype)
-            self.load_state_dict(state_dict, strict=True, assign=True)
+            self._load_checkpoint_into_model(state_dict, device, dtype)
             self._copy_deterministic_meta_buffers(device)
         elif self._init_plan.mode == "random":
             self._copy_deterministic_meta_buffers(device)
@@ -295,7 +307,16 @@ class CornstarchModelBase(nn.Module):
     def _load_checkpoint_state_dict(
         self, device: torch.device, dtype: torch.dtype | None = None
     ) -> Mapping[str, torch.Tensor]:
-        """Load staged checkpoint tensors onto the materialization device."""
+        """Load staged checkpoint tensors onto the materialization device.
+
+        Resolves the configured checkpoint source (a pre-mapped ``state_dict``, a
+        local safetensors ``checkpoint_path``, or a Hugging Face Hub
+        ``model_name_or_path``), translates Hugging Face keys to Cornstarch keys,
+        and moves the tensors onto the materialization device (in ``dtype`` for
+        floating-point tensors). The returned state dict holds *full* (non-DTensor)
+        tensors; sharding for parallelized models happens in
+        ``_load_checkpoint_into_model``.
+        """
         if self._init_plan.state_dict is not None:
             return {
                 key: tensor.to(
@@ -305,12 +326,21 @@ class CornstarchModelBase(nn.Module):
                 )
                 for key, tensor in self._init_plan.state_dict.items()
             }
-        if self._init_plan.checkpoint_path is None:
-            raise RuntimeError("Checkpoint initialization requires a state_dict or checkpoint_path.")
-        checkpoint_device = "cpu" if self.uses_layer_offload else str(device)
-        state_dict = self._state_mapper.hf_to_cornstarch_state_dict(
-            load_file(str(self._init_plan.checkpoint_path), device=checkpoint_device)
-        )
+
+        if self._init_plan.model_name_or_path is not None:
+            raw = self._download_and_load_safetensors(
+                self._init_plan.model_name_or_path, device
+            )
+        elif self._init_plan.checkpoint_path is not None:
+            checkpoint_device = "cpu" if self.uses_layer_offload else str(device)
+            raw = load_file(str(self._init_plan.checkpoint_path), device=checkpoint_device)
+        else:
+            raise RuntimeError(
+                "Checkpoint initialization requires a state_dict, checkpoint_path, "
+                "or model_name_or_path."
+            )
+
+        state_dict = self._state_mapper.hf_to_cornstarch_state_dict(raw)
         return {
             key: tensor.to(
                 device=self._materialization_device_for_tensor(key, device),
@@ -319,6 +349,97 @@ class CornstarchModelBase(nn.Module):
             )
             for key, tensor in state_dict.items()
         }
+
+    @staticmethod
+    def _download_and_load_safetensors(
+        model_name_or_path: str, device: torch.device
+    ) -> dict[str, torch.Tensor]:
+        """Download and merge all ``*.safetensors`` shards from the HF Hub.
+
+        Lists the repository's safetensors siblings, downloads each shard, and
+        merges them into a single Hugging Face-keyed state dict on the
+        materialization device (CPU when the requested device is ``meta``).
+        """
+        from huggingface_hub import HfApi, hf_hub_download
+
+        api = HfApi()
+        siblings = api.model_info(model_name_or_path).siblings or []
+        safetensor_files = sorted(
+            sibling.rfilename
+            for sibling in siblings
+            if sibling.rfilename.endswith(".safetensors")
+        )
+        if not safetensor_files:
+            raise FileNotFoundError(
+                f"No .safetensors files found in '{model_name_or_path}'."
+            )
+
+        load_device = "cpu" if device.type == "meta" else str(device)
+        merged: dict[str, torch.Tensor] = {}
+        for filename in safetensor_files:
+            local_path = hf_hub_download(model_name_or_path, filename)
+            merged.update(load_file(local_path, device=load_device))
+        return merged
+
+    def _load_checkpoint_into_model(
+        self,
+        state_dict: Mapping[str, torch.Tensor],
+        device: torch.device,
+        dtype: torch.dtype | None,
+    ) -> None:
+        """Assign checkpoint tensors into this model, sharding DTensor params.
+
+        For a plain (non-parallelized) model this is a strict ``assign``-load.
+        For a tensor-parallel model, ``apply_tensor_parallel`` has recorded
+        DTensor sharding specs on the meta parameters; a strict ``assign``-load of
+        a *full* tensor would drop that wrapping and leave every rank with the
+        whole weight. Instead each DTensor-owning module is materialized first via
+        ``to_empty`` (which preserves the sharding spec), then the
+        correctly-sharded slice of each full checkpoint tensor is copied in with
+        ``distribute_tensor``. The remaining plain params (and any persistent
+        buffers carried in the checkpoint) are ``assign``-loaded; non-persistent
+        deterministic buffers are intentionally left meta so the caller's
+        ``_copy_deterministic_meta_buffers`` can fill them just as on the plain
+        path.
+        """
+        from torch.distributed.tensor import DTensor, distribute_tensor
+
+        params = dict(self.named_parameters(remove_duplicate=False))
+        # Preserve named_parameters() order: distribute_tensor() runs a collective
+        # and every rank must issue the calls in the same order.
+        dtensor_keys = [
+            name for name, param in params.items()
+            if isinstance(param.data, DTensor)
+        ]
+        if not dtensor_keys:
+            self.load_state_dict(state_dict, strict=True, assign=True)
+            return
+
+        dtensor_key_set = set(dtensor_keys)
+        with torch.no_grad():
+            # Materialize each DTensor-owning module so to_empty keeps its
+            # sharding spec, then copy this rank's distribute_tensor() slice in.
+            for key in dtensor_keys:
+                module_path = key.rpartition(".")[0]
+                module = self.get_submodule(module_path) if module_path else self
+                module.to_empty(
+                    device=self._materialization_device_for_tensor(module_path, device)
+                )
+                if dtype is not None:
+                    module.to(dtype=dtype)
+            for key in dtensor_keys:
+                target = params[key]
+                sharded = distribute_tensor(
+                    state_dict[key], target.data.device_mesh, target.data.placements
+                )
+                target.data.copy_(sharded)
+
+        # Assign the remaining plain params and persistent buffers; the DTensor
+        # keys were just handled and the deterministic buffers stay meta.
+        remaining = {
+            key: value for key, value in state_dict.items() if key not in dtensor_key_set
+        }
+        self.load_state_dict(remaining, strict=False, assign=True)
 
     def _copy_deterministic_meta_buffers(self, device: torch.device) -> None:
         """Materialize deterministic helper buffers that are not in checkpoints."""

--- a/cornstarch/models/multimodal/__init__.py
+++ b/cornstarch/models/multimodal/__init__.py
@@ -5,7 +5,10 @@ from cornstarch.models.multimodal.configuration import (
     CornstarchMultimodalConfig,
 )
 from cornstarch.models.multimodal.execution import CornstarchExecutionPlan, ExecutionFuture
-from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
+from cornstarch.models.multimodal.modeling import (
+    CornstarchModalityEncoder,
+    build_modality_encoder,
+)
 from cornstarch.models.multimodal.projector import CornstarchProjector
 
 __all__ = [
@@ -15,4 +18,5 @@ __all__ = [
     "CornstarchMultimodalConfig",
     "CornstarchProjector",
     "ExecutionFuture",
+    "build_modality_encoder",
 ]

--- a/cornstarch/models/multimodal/modeling.py
+++ b/cornstarch/models/multimodal/modeling.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 import torch
@@ -49,33 +50,6 @@ class CornstarchModalityEncoder(nn.Module):
         self.projector = projector
         self.modality = modality
 
-    @classmethod
-    def from_encoder_and_language_model(
-        cls,
-        encoder: CornstarchEncoderBase,
-        language_model: nn.Module,
-        modality: str | None = None,
-        projector_type: str = "linear",
-        **projector_kwargs: Any,
-    ) -> CornstarchModalityEncoder:
-        """Compose a modality encoder from still-lazy endpoint modules.
-
-        The source encoder and target language model only need to expose their
-        configs; neither has to be materialized. The generated projector is built
-        on the ``meta`` device so the whole modality unit preserves Cornstarch's
-        lazy construction invariant until ``materialize()`` is called.
-        """
-        with torch.device("meta"):
-            projector = CornstarchProjector(
-                CornstarchEncoderToLanguageProjectorConfig.from_encoder_and_language_configs(
-                    encoder.config,
-                    language_model.config,
-                    projector_type=projector_type,
-                    **projector_kwargs,
-                )
-            )
-        return cls(encoder, projector, modality=modality)
-
     @property
     def config(self) -> tuple[PretrainedConfig, CornstarchEncoderToLanguageProjectorConfig]:
         """Return the paired encoder and projector configs.
@@ -87,17 +61,50 @@ class CornstarchModalityEncoder(nn.Module):
         return self.encoder.config, self.projector.config
 
     def set_empty_init(self) -> None:
-        """Configure the wrapped encoder for uninitialized materialization."""
+        """Configure the wrapped encoder for uninitialized materialization.
+
+        The projector always materializes with ``reset_parameters`` regardless of
+        the encoder's init plan; it is a freshly composed bridge module with no
+        checkpoint of its own.
+        """
         self.encoder.set_empty_init()
 
     def set_random_init(self) -> None:
         """Configure the wrapped encoder for default random initialization."""
         self.encoder.set_random_init()
 
-    def materialize(self, device: str | torch.device = "cuda") -> CornstarchModalityEncoder:
-        """Materialize the grouped encoder and projector as one lifecycle unit."""
-        self.encoder.materialize(device)
-        self.projector.materialize(device)
+    def set_checkpoint_init(
+        self,
+        state_dict: Mapping[str, torch.Tensor] | None = None,
+        checkpoint_path: str | Path | None = None,
+        model_name_or_path: str | None = None,
+    ) -> None:
+        """Configure the wrapped encoder to load checkpoint weights.
+
+        Threads the checkpoint source (staged ``state_dict``, local
+        ``checkpoint_path``, or a Hugging Face Hub ``model_name_or_path``) to the
+        encoder. The projector has no checkpoint of its own and is always
+        randomly initialized at ``materialize()``.
+        """
+        self.encoder.set_checkpoint_init(
+            state_dict=state_dict,
+            checkpoint_path=checkpoint_path,
+            model_name_or_path=model_name_or_path,
+        )
+
+    def materialize(
+        self,
+        device: str | torch.device = "cuda",
+        dtype: torch.dtype | None = None,
+    ) -> CornstarchModalityEncoder:
+        """Materialize the grouped encoder and projector as one lifecycle unit.
+
+        Both submodules materialize on ``device`` in ``dtype`` so the projector
+        follows its encoder automatically — callers never materialize the
+        projector separately.
+        """
+        self.encoder.materialize(device, dtype=dtype)
+        self.projector.materialize(device, dtype=dtype)
         return self
 
     def forward(self, **kwargs: Any) -> Any:
@@ -111,6 +118,35 @@ class CornstarchModalityEncoder(nn.Module):
         encoder_outputs = self.encoder(**kwargs)
         hidden_states = _first_output_tensor(encoder_outputs)
         return self.projector(hidden_states)
+
+
+def build_modality_encoder(
+    encoder: CornstarchEncoderBase,
+    language_model: nn.Module,
+    modality: str | None = None,
+    projector_type: str = "linear",
+    **projector_kwargs: Any,
+) -> CornstarchModalityEncoder:
+    """Compose a modality encoder from still-lazy endpoint modules.
+
+    The source encoder and target language model only need to expose their
+    configs; neither has to be materialized. The generated projector is built on
+    the ``meta`` device so the whole modality unit preserves Cornstarch's lazy
+    construction invariant until ``materialize()`` is called. This is the public
+    way to wrap a raw encoder for parallelization — ``parallelize()`` only
+    accepts Cornstarch models and modality encoders, never a bare HF encoder
+    (which has no projector).
+    """
+    with torch.device("meta"):
+        projector = CornstarchProjector(
+            CornstarchEncoderToLanguageProjectorConfig.from_encoder_and_language_configs(
+                encoder.config,
+                language_model.config,
+                projector_type=projector_type,
+                **projector_kwargs,
+            )
+        )
+    return CornstarchModalityEncoder(encoder, projector, modality=modality)
 
 
 def _first_output_tensor(output: Any) -> torch.Tensor:

--- a/cornstarch/models/multimodal/projector.py
+++ b/cornstarch/models/multimodal/projector.py
@@ -56,14 +56,19 @@ class CornstarchProjector(nn.Module):
         else:
             raise ValueError(f"Unsupported projector_type: {config.projector_type}")
 
-    def materialize(self, device: str | torch.device = "cuda") -> CornstarchProjector:
+    def materialize(
+        self,
+        device: str | torch.device = "cuda",
+        dtype: torch.dtype | None = None,
+    ) -> CornstarchProjector:
         """Allocate meta projector tensors on a device and initialize them.
 
         Projectors are commonly generated while composing still-meta modality
         and language modules. This mirrors the Cornstarch model lifecycle for
         that smaller owned module: construction can remain allocation-free, and
         ``CornstarchModalityEncoder.materialize()`` later turns the projection
-        parameters into regular randomly initialized tensors.
+        parameters into regular randomly initialized tensors. When ``dtype`` is
+        given the projector is cast to it so it follows its encoder's dtype.
         """
         device = torch.device(device)
         tensors = list(self.parameters()) + list(self.buffers())
@@ -72,6 +77,8 @@ class CornstarchProjector(nn.Module):
             self.reset_parameters()
         else:
             self.to(device)
+        if dtype is not None:
+            self.to(dtype=dtype)
         return self
 
     def reset_parameters(self) -> None:

--- a/examples/common.py
+++ b/examples/common.py
@@ -7,7 +7,7 @@ from typing import Iterator
 
 import torch
 from PIL import Image
-from transformers import AutoConfig
+from transformers import AutoConfig, PretrainedConfig, PreTrainedTokenizerBase
 
 from cornstarch.models import RepeatedLayerOffloadConfig
 from cornstarch.models import build_modality_encoder as build_modality_encoder
@@ -36,7 +36,7 @@ def generate_sine_wave(
     return audio_signal.astype(np.float32)
 
 
-def decoder_start_token_id(audio_config) -> int:
+def decoder_start_token_id(audio_config: PretrainedConfig) -> int:
     return int(
         getattr(audio_config, "decoder_start_token_id", None)
         or getattr(audio_config, "bos_token_id", None)
@@ -44,12 +44,12 @@ def decoder_start_token_id(audio_config) -> int:
     )
 
 
-def vision_config_from_pretrained(model_name_or_path: str):
+def vision_config_from_pretrained(model_name_or_path: str) -> PretrainedConfig:
     config = AutoConfig.from_pretrained(model_name_or_path)
     return getattr(config, "vision_config", config)
 
 
-def clip_vision_sequence_length(vision_config) -> int:
+def clip_vision_sequence_length(vision_config: PretrainedConfig) -> int:
     return (int(vision_config.image_size) // int(vision_config.patch_size)) ** 2 + 1
 
 
@@ -59,7 +59,9 @@ def expand_modality_tokens(text: str, token_counts: dict[str, int]) -> str:
     return text
 
 
-def configure_special_tokens(tokenizer, tokens: list[str]) -> dict[str, int]:
+def configure_special_tokens(
+    tokenizer: PreTrainedTokenizerBase, tokens: list[str]
+) -> dict[str, int]:
     tokenizer.pad_token = tokenizer.eos_token
     tokenizer.add_special_tokens({"additional_special_tokens": tokens})
     return {token: int(tokenizer.convert_tokens_to_ids(token)) for token in tokens}
@@ -67,7 +69,7 @@ def configure_special_tokens(tokenizer, tokens: list[str]) -> dict[str, int]:
 
 def tokenize_text_batch(
     texts: list[str],
-    tokenizer,
+    tokenizer: PreTrainedTokenizerBase,
     device: torch.device,
 ) -> dict[str, torch.Tensor]:
     language_inputs = tokenizer(texts, padding=True, return_tensors="pt")

--- a/examples/common.py
+++ b/examples/common.py
@@ -9,10 +9,8 @@ import torch
 from PIL import Image
 from transformers import AutoConfig
 
-from cornstarch.models import (
-    CornstarchModalityEncoder,
-    RepeatedLayerOffloadConfig,
-)
+from cornstarch.models import RepeatedLayerOffloadConfig
+from cornstarch.models import build_modality_encoder as build_modality_encoder
 
 
 IMAGE_TOKEN = "<image>"
@@ -81,20 +79,6 @@ def tokenize_text_batch(
         "input_ids": language_inputs["input_ids"].to(device=device),
         "labels": labels.to(device=device),
     }
-
-
-def build_modality_encoder(
-    encoder,
-    language_model,
-    modality: str,
-    projector_type: str = "linear",
-) -> CornstarchModalityEncoder:
-    return CornstarchModalityEncoder.from_encoder_and_language_model(
-        encoder,
-        language_model,
-        modality=modality,
-        projector_type=projector_type,
-    )
 
 
 def layer_offload_config(

--- a/examples/distributed/common.py
+++ b/examples/distributed/common.py
@@ -1,28 +1,21 @@
-"""Shared helpers for the Option C distributed pretraining examples.
+"""Shared scaffolding for the Option C distributed pretraining examples.
 
-The whole point of the Option C surface is that the per-script boilerplate the
-earlier trial duplicated — rank math, the TP->CP->PP-then-materialize-then-EP
-ordering rule, sampler/splitter wiring, the grad-sync registration — now lives
-inside ``ParallelizationPlan`` / ``ParallelContext``.  These helpers only cover
-the genuinely shared scaffolding (process-group bring-up, a synthetic dataset,
-the criterion, and the training loop), so each ``pretrain_*`` script is just a
-declarative description of *which* modality gets *which* degrees.
+The Option C surface keeps the per-script boilerplate the earlier trial
+duplicated — rank math, the TP->CP->PP-then-materialize-then-EP ordering rule,
+sampler/splitter wiring, the grad-sync registration — inside
+``ParallelizationPlan`` / ``ParallelContext``.  What is left here is only the
+genuinely shared, non-parallelism scaffolding (process-group bring-up, a
+synthetic dataset, and the criterion).  Each ``pretrain_*`` script then reads
+top-to-bottom like ``examples/pretrain_vlm.py``: build the models, parallelize,
+materialize, and drive an explicit training loop with ``schedule.step``.
 """
 from __future__ import annotations
 
 import os
-from typing import Callable
 
 import torch
 import torch.distributed as dist
 from torch.utils.data import Dataset
-
-from cornstarch.distributed import ParallelContext
-from cornstarch.models import (
-    CornstarchExecutionPlan,
-    ExecutionFuture,
-    from_hf_config,
-)
 
 DTYPE = torch.bfloat16
 
@@ -67,62 +60,8 @@ class FakeTextDataset(Dataset):
         return {"input_ids": ids, "labels": ids.clone()}
 
 
-def build_language_model(model_name_or_path: str, attn_implementation: str = "sdpa"):
-    """Build a meta-device Cornstarch language model with a random init plan."""
-    from transformers import AutoConfig
-
-    config = AutoConfig.from_pretrained(model_name_or_path)
-    config = getattr(config, "text_config", config)
-    model = from_hf_config(
-        config, model_kind="language", attn_implementation=attn_implementation
-    )
-    model.set_random_init()
-    return model
-
-
 def causal_lm_criterion(output, batch) -> torch.Tensor:
     """Return the loss from a model output or a raw loss tensor (PP last stage)."""
     if isinstance(output, torch.Tensor):
         return output
     return output.loss if hasattr(output, "loss") else output["loss"]
-
-
-def build_language_model_plan(model) -> tuple[CornstarchExecutionPlan, ExecutionFuture]:
-    """Build the LM-only execution DAG (no modality encoders)."""
-    plan = CornstarchExecutionPlan()
-    merged = plan.merge_modality_encoder_outputs(
-        language_model=model,
-        input_ids=ExecutionFuture("input_ids"),
-        labels=ExecutionFuture("labels"),
-        modality_token_ids={},
-        encoder_outputs={},
-    )
-    output_future = plan.run_language_model(module=model, inputs=merged)
-    return plan, output_future
-
-
-def train_loop(
-    ctx: ParallelContext,
-    schedule,
-    loader,
-    optimizer: torch.optim.Optimizer,
-    criterion: Callable,
-    steps: int,
-) -> None:
-    """Run a plain PyTorch training loop over the Option C surface.
-
-    The only parallelism-aware calls are ``ctx.sync_gradients()`` after the
-    schedule step (DP all-reduce, EP shards skipped) and using the schedule's
-    ``step`` for forward+backward (which microbatches under PP).
-    """
-    step = 0
-    for batch in loader:
-        if step >= steps:
-            break
-        result = schedule.step(batch, criterion, optimizer, return_loss=True)
-        ctx.sync_gradients()
-        optimizer.step()
-        optimizer.zero_grad()
-        if result["loss"] is not None and dist.get_rank() == 0:
-            print(f"step {step}: loss {result['loss'].item():.4f}")
-        step += 1

--- a/examples/distributed/common.py
+++ b/examples/distributed/common.py
@@ -12,6 +12,7 @@ materialize, and drive an explicit training loop with ``schedule.step``.
 from __future__ import annotations
 
 import os
+from typing import Any
 
 import torch
 import torch.distributed as dist
@@ -54,13 +55,13 @@ class FakeTextDataset(Dataset):
     def __len__(self) -> int:
         return self.length
 
-    def __getitem__(self, index: int) -> dict:
+    def __getitem__(self, index: int) -> dict[str, torch.Tensor]:
         g = torch.Generator().manual_seed(index)
         ids = torch.randint(0, self.vocab_size, (self.seq_len,), generator=g)
         return {"input_ids": ids, "labels": ids.clone()}
 
 
-def causal_lm_criterion(output, batch) -> torch.Tensor:
+def causal_lm_criterion(output: Any, batch: dict[str, torch.Tensor]) -> torch.Tensor:
     """Return the loss from a model output or a raw loss tensor (PP last stage)."""
     if isinstance(output, torch.Tensor):
         return output

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -17,6 +17,8 @@ wiring here.
 """
 from __future__ import annotations
 
+from typing import Any, Callable
+
 import tyro
 
 import torch
@@ -30,7 +32,12 @@ from common import (
     init_distributed,
 )
 
-from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.distributed import (
+    ParallelConfig,
+    ParallelContext,
+    ParallelizationPlan,
+    TrainingSchedule,
+)
 from cornstarch.models import (
     CornstarchExecutionPlan,
     ExecutionFuture,
@@ -38,7 +45,13 @@ from cornstarch.models import (
 )
 
 
-def _training_step(schedule, ctx, batch, criterion, optimizer):
+def _training_step(
+    schedule: TrainingSchedule,
+    ctx: ParallelContext,
+    batch: dict[str, torch.Tensor],
+    criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
+    optimizer: torch.optim.Optimizer,
+) -> dict[str, Any]:
     """Run one schedule-driven training step and sync gradients across DP ranks.
 
     ``schedule.step`` runs forward + criterion + backward (or the 1F1B
@@ -91,7 +104,7 @@ def pretrain(
     dataset = FakeTextDataset(language_model.hf_config.vocab_size, seq_len)
     dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
-    def build_plan():
+    def build_plan() -> tuple[CornstarchExecutionPlan, ExecutionFuture]:
         exec_plan = CornstarchExecutionPlan()
         merged = exec_plan.merge_modality_encoder_outputs(
             language_model=language_model,

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -5,29 +5,36 @@ Run with torchrun, e.g. 8 GPUs as DP=2, PP=2, TP=2::
     torchrun --nproc_per_node=8 examples/distributed/pretrain_llm.py \
         --tp 2 --pp 2 --dp 2
 
-Everything parallelism-specific is expressed declaratively: one ``ParallelConfig``
-describes the LM's degrees, ``plan.materialize`` applies TP/PP (and EP for MoE)
-and materializes, and the returned ``ctx`` folds the DP sampler into the
-dataloader, builds the schedule, and exposes ``sync_gradients``.  There is no
-rank math, no ordering rule, and no grad-sync wiring in this script.
+This script reads top-to-bottom like the non-distributed
+``examples/pretrain_vlm.py``: build the model, set its init plan, build the
+execution plan, and run an explicit training loop.  Only five lines are
+distributed-specific: ``init_distributed()``, ``plan.parallelize`` +
+``plan.materialize`` (instead of ``model.materialize``),
+``ctx.prepare_dataloader`` (DP sampler + CP split folded in),
+``ctx.create_schedule`` + ``schedule.step`` (instead of inline
+execute/backward), and ``ctx.sync_gradients`` before the optimizer step.  There
+is no rank math, no ordering rule, and no grad-sync wiring here.
 """
 from __future__ import annotations
 
 import tyro
 
 import torch
+from transformers import AutoConfig
 
 from common import (
     DTYPE,
     FakeTextDataset,
-    build_language_model,
-    build_language_model_plan,
     causal_lm_criterion,
     init_distributed,
-    train_loop,
 )
 
 from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import (
+    CornstarchExecutionPlan,
+    ExecutionFuture,
+    from_hf_config,
+)
 
 
 def main(
@@ -45,12 +52,15 @@ def main(
 ) -> None:
     rank, world_size, device = init_distributed()
 
-    model = build_language_model(model_name_or_path)
-    vocab_size = model.hf_config.vocab_size
+    config = AutoConfig.from_pretrained(model_name_or_path)
+    config = getattr(config, "text_config", config)
+
+    language_model = from_hf_config(config, model_kind="language")
+    language_model.set_random_init()
 
     plan = ParallelizationPlan(global_ranks=list(range(world_size)))
     plan.parallelize(
-        model,
+        language_model,
         ParallelConfig(
             tensor_parallel_size=tp,
             pipeline_parallel_size=pp,
@@ -60,11 +70,26 @@ def main(
         ),
     )
     ctx = plan.materialize(device, dtype=DTYPE)
+    language_model.train()
 
-    dataset = FakeTextDataset(vocab_size, seq_len)
+    dataset = FakeTextDataset(language_model.hf_config.vocab_size, seq_len)
     loader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
-    exec_plan, output_future = build_language_model_plan(model)
+    def build_plan():
+        exec_plan = CornstarchExecutionPlan()
+        merged = exec_plan.merge_modality_encoder_outputs(
+            language_model=language_model,
+            input_ids=ExecutionFuture("input_ids"),
+            labels=ExecutionFuture("labels"),
+            modality_token_ids={},
+            encoder_outputs={},
+        )
+        output_future = exec_plan.run_language_model(
+            module=language_model, inputs=merged
+        )
+        return exec_plan, output_future
+
+    exec_plan, output_future = build_plan()
     schedule = ctx.create_schedule(
         exec_plan,
         output_future,
@@ -72,8 +97,20 @@ def main(
         microbatch_size=batch_size // num_microbatches if pp > 1 else 1,
     )
 
-    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
-    train_loop(ctx, schedule, loader, optimizer, causal_lm_criterion, steps)
+    optimizer = torch.optim.Adam(language_model.parameters(), lr=lr)
+    optimizer.zero_grad()
+
+    step = 0
+    for batch in loader:
+        if step >= steps:
+            break
+        result = schedule.step(batch, causal_lm_criterion, optimizer, return_loss=True)
+        ctx.sync_gradients()
+        optimizer.step()
+        optimizer.zero_grad()
+        if result["loss"] is not None and rank == 0:
+            print(f"step {step}: loss {result['loss'].item():.4f}")
+        step += 1
 
 
 if __name__ == "__main__":

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -6,21 +6,22 @@ Run with torchrun, e.g. 8 GPUs as DP=2, PP=2, TP=2::
         --tp 2 --pp 2 --dp 2
 
 This script reads top-to-bottom like the non-distributed
-``examples/pretrain_vlm.py``: build the model, set its init plan, build the
-execution plan, and run an explicit training loop.  Only five lines are
-distributed-specific: ``init_distributed()``, ``plan.parallelize`` +
-``plan.materialize`` (instead of ``model.materialize``),
-``ctx.prepare_dataloader`` (DP sampler + CP split folded in),
-``ctx.create_schedule`` + ``schedule.step`` (instead of inline
-execute/backward), and ``ctx.sync_gradients`` before the optimizer step.  There
-is no rank math, no ordering rule, and no grad-sync wiring here.
+``examples/pretrain_vlm.py`` — the training loop is intentionally identical.
+The only distributed-specific calls are pushed into ``_training_step``: the
+schedule's ``step`` runs forward + criterion + backward (or the 1F1B microbatch
+loop under PP) and ``ctx.sync_gradients`` all-reduces gradients across DP ranks.
+Building the model differs only in ``plan.parallelize`` + ``plan.materialize``
+(instead of ``model.materialize``) and ``ctx.prepare_dataloader`` (DP sampler +
+CP split folded in).  There is no rank math, no ordering rule, and no grad-sync
+wiring here.
 """
 from __future__ import annotations
 
 import tyro
 
 import torch
-from transformers import AutoConfig
+from tqdm import tqdm
+from transformers import AutoConfig, get_linear_schedule_with_warmup
 
 from common import (
     DTYPE,
@@ -37,7 +38,22 @@ from cornstarch.models import (
 )
 
 
-def main(
+def _training_step(schedule, ctx, batch, criterion, optimizer):
+    """Run one schedule-driven training step and sync gradients across DP ranks.
+
+    ``schedule.step`` runs forward + criterion + backward (or the 1F1B
+    microbatch loop under PP); ``ctx.sync_gradients`` all-reduces the DP
+    gradients before the optimizer step.  Hiding both parallelism-specific calls
+    here keeps the training loop identical to the non-distributed
+    ``examples/pretrain_vlm.py``.  Returns the schedule result whose ``"loss"``
+    is the step loss (``None`` on non-last pipeline stages).
+    """
+    result = schedule.step(batch, criterion, optimizer, return_loss=True)
+    ctx.sync_gradients()
+    return result
+
+
+def pretrain(
     model_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
     tp: int = 1,
     pp: int = 1,
@@ -73,7 +89,7 @@ def main(
     language_model.train()
 
     dataset = FakeTextDataset(language_model.hf_config.vocab_size, seq_len)
-    loader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
+    dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
     def build_plan():
         exec_plan = CornstarchExecutionPlan()
@@ -100,18 +116,28 @@ def main(
     optimizer = torch.optim.Adam(language_model.parameters(), lr=lr)
     optimizer.zero_grad()
 
-    step = 0
-    for batch in loader:
-        if step >= steps:
-            break
-        result = schedule.step(batch, causal_lm_criterion, optimizer, return_loss=True)
-        ctx.sync_gradients()
-        optimizer.step()
-        optimizer.zero_grad()
-        if result["loss"] is not None and rank == 0:
-            print(f"step {step}: loss {result['loss'].item():.4f}")
-        step += 1
+    num_warmup_steps = int(steps * 0.1)
+    lr_scheduler = get_linear_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=num_warmup_steps,
+        num_training_steps=steps,
+    )
+
+    dataloader_iter = iter(dataloader)
+    with tqdm(range(steps), disable=rank != 0) as pbar:
+        for _ in pbar:
+            batch = next(dataloader_iter)
+            outputs = _training_step(
+                schedule, ctx, batch, causal_lm_criterion, optimizer
+            )
+            loss = outputs["loss"]
+            if loss is not None:
+                pbar.set_postfix({"loss": loss.item()})
+
+            optimizer.step()
+            lr_scheduler.step()
+            optimizer.zero_grad()
 
 
 if __name__ == "__main__":
-    tyro.cli(main)
+    tyro.cli(pretrain)

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -6,7 +6,7 @@ Run with torchrun, e.g. 8 GPUs as DP=2, PP=2, TP=2::
         --tp 2 --pp 2 --dp 2
 
 Everything parallelism-specific is expressed declaratively: one ``ParallelConfig``
-describes the LM's degrees, ``plan.distribute`` applies TP/PP (and EP for MoE)
+describes the LM's degrees, ``plan.materialize`` applies TP/PP (and EP for MoE)
 and materializes, and the returned ``ctx`` folds the DP sampler into the
 dataloader, builds the schedule, and exposes ``sync_gradients``.  There is no
 rank math, no ordering rule, and no grad-sync wiring in this script.
@@ -59,7 +59,7 @@ def main(
             data_parallel_size=dp,
         ),
     )
-    ctx = plan.distribute(device, dtype=DTYPE)
+    ctx = plan.materialize(device, dtype=DTYPE)
 
     dataset = FakeTextDataset(vocab_size, seq_len)
     loader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -9,7 +9,7 @@ language model tensor + pipeline parallel, all replicated once (dp=1)::
 The point of Option C for multimodal models: each modality is described
 independently.  ``plan.parallelize`` is called once per modality with its own
 ``ParallelConfig`` (vision can be TP-only while the LLM is TP+PP), and
-``plan.distribute`` resolves the per-modality + DP-offset rank math, builds each
+``plan.materialize`` resolves the per-modality + DP-offset rank math, builds each
 modality's mesh, applies the model-side parallelisms, and materializes — no
 hand-written rank arithmetic in this script.
 
@@ -88,7 +88,7 @@ def main(
     language_model.set_random_init()
 
     # Per-modality declarative configs — vision and the LLM are parallelized
-    # independently; distribute() handles the cross-modality rank assignment.
+    # independently; materialize() handles the cross-modality rank assignment.
     plan = ParallelizationPlan(global_ranks=list(range(world_size)))
     plan.parallelize(
         vision_encoder,
@@ -102,7 +102,7 @@ def main(
             data_parallel_size=dp,
         ),
     )
-    ctx = plan.distribute(device, dtype=DTYPE)
+    ctx = plan.materialize(device, dtype=DTYPE)
 
     # Bridge the (already parallelized + materialized) vision encoder to the LLM
     # with a projector, then materialize the projector to match.

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -6,33 +6,34 @@ language model tensor + pipeline parallel, all replicated once (dp=1)::
     torchrun --nproc_per_node=4 examples/distributed/pretrain_vlm.py \
         --vision-tp 2 --llm-tp 2 --llm-pp 1
 
-The point of Option C for multimodal models: each modality is described
-independently.  ``plan.parallelize`` is called once per modality with its own
-``ParallelConfig`` (vision can be TP-only while the LLM is TP+PP), and
-``plan.materialize`` resolves the per-modality + DP-offset rank math, builds each
-modality's mesh, applies the model-side parallelisms, and materializes — no
-hand-written rank arithmetic in this script.
+This reads top-to-bottom like the non-distributed ``examples/pretrain_vlm.py``:
+build the modality encoder with ``build_modality_encoder``, set its init plan,
+build the execution plan, and run an explicit training loop.  The only
+distributed-specific lines are ``init_distributed()``, the per-modality
+``plan.parallelize`` + ``plan.materialize``, ``ctx.prepare_dataloader``,
+``ctx.create_schedule`` + ``schedule.step``, and ``ctx.sync_gradients``.
 
-This example parallelizes the inner ``CornstarchVisionEncoder`` and
-``CornstarchLanguageModel`` (both ``CornstarchModelBase``); the projector that
-bridges them is then built and materialized around the parallelized encoder.
+Each modality is described independently: ``plan.parallelize`` is called once
+per modality with its own ``ParallelConfig`` (vision can be TP-only while the
+LLM is TP+PP), and ``plan.materialize`` resolves the per-modality + DP-offset
+rank math and materializes both models.  The projector follows its encoder
+automatically — there is no standalone projector setup in this script.
 """
 from __future__ import annotations
 
 import tyro
 
 import torch
-import torch.distributed as dist
 from torch.utils.data import Dataset
 from transformers import AutoConfig
 
-from common import DTYPE, causal_lm_criterion, init_distributed, train_loop
+from common import DTYPE, causal_lm_criterion, init_distributed
 
 from cornstarch.distributed import ParallelConfig, ParallelizationPlan
 from cornstarch.models import (
     CornstarchExecutionPlan,
-    CornstarchModalityEncoder,
     ExecutionFuture,
+    build_modality_encoder,
     from_hf_config,
 )
 
@@ -84,14 +85,19 @@ def main(
 
     vision_encoder = from_hf_config(vision_config, model_kind="vision")
     language_model = from_hf_config(llm_config, model_kind="language")
-    vision_encoder.set_random_init()
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+
     language_model.set_random_init()
+    modality_encoder.set_random_init()
 
     # Per-modality declarative configs — vision and the LLM are parallelized
-    # independently; materialize() handles the cross-modality rank assignment.
+    # independently; materialize() handles the cross-modality rank assignment and
+    # materializes each modality encoder's projector alongside its encoder.
     plan = ParallelizationPlan(global_ranks=list(range(world_size)))
     plan.parallelize(
-        vision_encoder,
+        modality_encoder,
         ParallelConfig(tensor_parallel_size=vision_tp, data_parallel_size=dp),
     )
     plan.parallelize(
@@ -103,14 +109,8 @@ def main(
         ),
     )
     ctx = plan.materialize(device, dtype=DTYPE)
-
-    # Bridge the (already parallelized + materialized) vision encoder to the LLM
-    # with a projector, then materialize the projector to match.
-    modality_encoder = CornstarchModalityEncoder.from_encoder_and_language_model(
-        vision_encoder, language_model, modality="vision", projector_type="linear"
-    )
-    modality_encoder.projector.set_random_init()
-    modality_encoder.projector.materialize(device).to(dtype=DTYPE)
+    language_model.train()
+    modality_encoder.train()
 
     patches_per_side = int(vision_config.image_size) // int(vision_config.patch_size)
     num_image_tokens = patches_per_side * patches_per_side + 1  # + CLS token
@@ -121,18 +121,21 @@ def main(
     loader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
     def build_plan():
-        plan_exec = CornstarchExecutionPlan()
-        vision_outputs = plan_exec.run_modality_encoder(
+        exec_plan = CornstarchExecutionPlan()
+        vision_outputs = exec_plan.run_modality_encoder(
             module=modality_encoder, pixel_values=ExecutionFuture("pixel_values")
         )
-        merged = plan_exec.merge_modality_encoder_outputs(
+        merged = exec_plan.merge_modality_encoder_outputs(
             language_model=language_model,
             input_ids=ExecutionFuture("input_ids"),
             labels=ExecutionFuture("labels"),
             modality_token_ids={"vision": IMAGE_TOKEN_ID},
             encoder_outputs={"vision": vision_outputs},
         )
-        return plan_exec, plan_exec.run_language_model(module=language_model, inputs=merged)
+        output_future = exec_plan.run_language_model(
+            module=language_model, inputs=merged
+        )
+        return exec_plan, output_future
 
     exec_plan, output_future = build_plan()
     schedule = ctx.create_schedule(
@@ -144,7 +147,19 @@ def main(
 
     params = list(language_model.parameters()) + list(modality_encoder.parameters())
     optimizer = torch.optim.Adam(params, lr=lr)
-    train_loop(ctx, schedule, loader, optimizer, causal_lm_criterion, steps)
+    optimizer.zero_grad()
+
+    step = 0
+    for batch in loader:
+        if step >= steps:
+            break
+        result = schedule.step(batch, causal_lm_criterion, optimizer, return_loss=True)
+        ctx.sync_gradients()
+        optimizer.step()
+        optimizer.zero_grad()
+        if result["loss"] is not None and rank == 0:
+            print(f"step {step}: loss {result['loss'].item():.4f}")
+        step += 1
 
 
 if __name__ == "__main__":

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -6,12 +6,12 @@ language model tensor + pipeline parallel, all replicated once (dp=1)::
     torchrun --nproc_per_node=4 examples/distributed/pretrain_vlm.py \
         --vision-tp 2 --llm-tp 2 --llm-pp 1
 
-This reads top-to-bottom like the non-distributed ``examples/pretrain_vlm.py``:
-build the modality encoder with ``build_modality_encoder``, set its init plan,
-build the execution plan, and run an explicit training loop.  The only
-distributed-specific lines are ``init_distributed()``, the per-modality
-``plan.parallelize`` + ``plan.materialize``, ``ctx.prepare_dataloader``,
-``ctx.create_schedule`` + ``schedule.step``, and ``ctx.sync_gradients``.
+This reads top-to-bottom like the non-distributed ``examples/pretrain_vlm.py`` —
+the training loop is intentionally identical.  The only distributed-specific
+calls are pushed into ``_training_step`` (the schedule's ``step`` does forward +
+criterion + backward, and ``ctx.sync_gradients`` all-reduces DP gradients).
+Building the models differs only in the per-modality ``plan.parallelize`` +
+``plan.materialize`` and ``ctx.prepare_dataloader``.
 
 Each modality is described independently: ``plan.parallelize`` is called once
 per modality with its own ``ParallelConfig`` (vision can be TP-only while the
@@ -25,7 +25,8 @@ import tyro
 
 import torch
 from torch.utils.data import Dataset
-from transformers import AutoConfig
+from tqdm import tqdm
+from transformers import AutoConfig, get_linear_schedule_with_warmup
 
 from common import DTYPE, causal_lm_criterion, init_distributed
 
@@ -62,7 +63,22 @@ class FakeVLMDataset(Dataset):
         return {"input_ids": ids, "labels": ids.clone(), "pixel_values": pixel_values}
 
 
-def main(
+def _training_step(schedule, ctx, batch, criterion, optimizer):
+    """Run one schedule-driven training step and sync gradients across DP ranks.
+
+    ``schedule.step`` runs forward + criterion + backward (or the 1F1B
+    microbatch loop under PP); ``ctx.sync_gradients`` all-reduces the DP
+    gradients before the optimizer step.  Hiding both parallelism-specific calls
+    here keeps the training loop identical to the non-distributed
+    ``examples/pretrain_vlm.py``.  Returns the schedule result whose ``"loss"``
+    is the step loss (``None`` on non-last pipeline stages).
+    """
+    result = schedule.step(batch, criterion, optimizer, return_loss=True)
+    ctx.sync_gradients()
+    return result
+
+
+def pretrain(
     vision_name_or_path: str = "openai/clip-vit-base-patch32",
     llm_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
     vision_tp: int = 1,
@@ -118,7 +134,7 @@ def main(
     dataset = FakeVLMDataset(
         language_model.hf_config.vocab_size, seq_len, num_image_tokens, image_size
     )
-    loader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
+    dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
     def build_plan():
         exec_plan = CornstarchExecutionPlan()
@@ -149,18 +165,28 @@ def main(
     optimizer = torch.optim.Adam(params, lr=lr)
     optimizer.zero_grad()
 
-    step = 0
-    for batch in loader:
-        if step >= steps:
-            break
-        result = schedule.step(batch, causal_lm_criterion, optimizer, return_loss=True)
-        ctx.sync_gradients()
-        optimizer.step()
-        optimizer.zero_grad()
-        if result["loss"] is not None and rank == 0:
-            print(f"step {step}: loss {result['loss'].item():.4f}")
-        step += 1
+    num_warmup_steps = int(steps * 0.1)
+    lr_scheduler = get_linear_schedule_with_warmup(
+        optimizer,
+        num_warmup_steps=num_warmup_steps,
+        num_training_steps=steps,
+    )
+
+    dataloader_iter = iter(dataloader)
+    with tqdm(range(steps), disable=rank != 0) as pbar:
+        for _ in pbar:
+            batch = next(dataloader_iter)
+            outputs = _training_step(
+                schedule, ctx, batch, causal_lm_criterion, optimizer
+            )
+            loss = outputs["loss"]
+            if loss is not None:
+                pbar.set_postfix({"loss": loss.item()})
+
+            optimizer.step()
+            lr_scheduler.step()
+            optimizer.zero_grad()
 
 
 if __name__ == "__main__":
-    tyro.cli(main)
+    tyro.cli(pretrain)

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -21,6 +21,8 @@ automatically — there is no standalone projector setup in this script.
 """
 from __future__ import annotations
 
+from typing import Any, Callable
+
 import tyro
 
 import torch
@@ -30,7 +32,12 @@ from transformers import AutoConfig, get_linear_schedule_with_warmup
 
 from common import DTYPE, causal_lm_criterion, init_distributed
 
-from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.distributed import (
+    ParallelConfig,
+    ParallelContext,
+    ParallelizationPlan,
+    TrainingSchedule,
+)
 from cornstarch.models import (
     CornstarchExecutionPlan,
     ExecutionFuture,
@@ -45,7 +52,14 @@ IMAGE_TOKEN_ID = 0
 class FakeVLMDataset(Dataset):
     """Synthetic VLM batch: one image plus a caption with image placeholders."""
 
-    def __init__(self, vocab_size, seq_len, num_image_tokens, image_size, length=4096):
+    def __init__(
+        self,
+        vocab_size: int,
+        seq_len: int,
+        num_image_tokens: int,
+        image_size: tuple[int, int],
+        length: int = 4096,
+    ) -> None:
         self.vocab_size = vocab_size
         self.seq_len = seq_len
         self.num_image_tokens = num_image_tokens
@@ -63,7 +77,13 @@ class FakeVLMDataset(Dataset):
         return {"input_ids": ids, "labels": ids.clone(), "pixel_values": pixel_values}
 
 
-def _training_step(schedule, ctx, batch, criterion, optimizer):
+def _training_step(
+    schedule: TrainingSchedule,
+    ctx: ParallelContext,
+    batch: dict[str, torch.Tensor],
+    criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
+    optimizer: torch.optim.Optimizer,
+) -> dict[str, Any]:
     """Run one schedule-driven training step and sync gradients across DP ranks.
 
     ``schedule.step`` runs forward + criterion + backward (or the 1F1B
@@ -136,7 +156,7 @@ def pretrain(
     )
     dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
-    def build_plan():
+    def build_plan() -> tuple[CornstarchExecutionPlan, ExecutionFuture]:
         exec_plan = CornstarchExecutionPlan()
         vision_outputs = exec_plan.run_modality_encoder(
             module=modality_encoder, pixel_values=ExecutionFuture("pixel_values")

--- a/examples/pretrain_valm.py
+++ b/examples/pretrain_valm.py
@@ -14,8 +14,12 @@ from transformers import (
     AutoFeatureExtractor,
     AutoImageProcessor,
     AutoTokenizer,
+    PreTrainedTokenizerBase,
+    SequenceFeatureExtractor,
     get_linear_schedule_with_warmup,
 )
+from transformers.image_processing_utils import BaseImageProcessor
+from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from common import (
     AUDIO_TOKEN,
@@ -36,6 +40,8 @@ from common import (
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
+    CornstarchLanguageModel,
+    CornstarchModalityEncoder,
     from_hf_config,
 )
 
@@ -45,7 +51,7 @@ class FakeDataset(Dataset):
         self,
         image_size: tuple[int, int] = (720, 480),
         audio_duration: float = 10.0,
-    ):
+    ) -> None:
         self.image = generate_random_image(image_size)
         self.audio = generate_sine_wave(DEFAULT_AUDIO_SAMPLE_RATE, audio_duration, 440.0)
         self.text = IMAGE_TOKEN + AUDIO_TOKEN + " text" * 256
@@ -53,16 +59,16 @@ class FakeDataset(Dataset):
     def __len__(self) -> int:
         return 65536
 
-    def __getitem__(self, index: int) -> dict:
+    def __getitem__(self, index: int) -> dict[str, object]:
         del index
         return {"image": self.image, "audio": self.audio, "text": self.text}
 
 
 def _collate_valm(
     batches: list[dict],
-    image_processor,
-    audio_processor,
-    tokenizer,
+    image_processor: BaseImageProcessor,
+    audio_processor: SequenceFeatureExtractor,
+    tokenizer: PreTrainedTokenizerBase,
     image_sequence_length: int,
     audio_sequence_length: int,
     audio_decoder_start_token_id: int,
@@ -104,13 +110,13 @@ def _collate_valm(
 
 
 def _training_step(
-    language_model,
-    vision_module,
-    audio_module,
+    language_model: CornstarchLanguageModel,
+    vision_module: CornstarchModalityEncoder,
+    audio_module: CornstarchModalityEncoder,
     batch: dict[str, torch.Tensor],
     image_token_id: int,
     audio_token_id: int,
-):
+) -> CausalLMOutputWithPast:
     plan = CornstarchExecutionPlan()
     vision_outputs = plan.run_modality_encoder(
         module=vision_module,
@@ -140,7 +146,7 @@ def pretrain(
     use_layer_offload: bool = False,
     profile_output_path: Path | None = None,
     max_train_steps: int = 10,
-):
+) -> None:
     """Randomly initialize a vision-audio-language model with the new API."""
     torch.cuda.set_device(0)
     device = torch.device("cuda")

--- a/examples/pretrain_vlm.py
+++ b/examples/pretrain_vlm.py
@@ -13,8 +13,11 @@ from transformers import (
     AutoConfig,
     AutoImageProcessor,
     AutoTokenizer,
+    PreTrainedTokenizerBase,
     get_linear_schedule_with_warmup,
 )
+from transformers.image_processing_utils import BaseImageProcessor
+from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from common import (
     DTYPE,
@@ -31,28 +34,30 @@ from common import (
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
+    CornstarchLanguageModel,
+    CornstarchModalityEncoder,
     from_hf_config,
     RepeatedLayerCompileConfig,
 )
 
 
 class FakeDataset(Dataset):
-    def __init__(self, image_size: tuple[int, int]):
+    def __init__(self, image_size: tuple[int, int]) -> None:
         self.image = generate_random_image(image_size)
         self.text = IMAGE_TOKEN + " text" * 2048
 
     def __len__(self) -> int:
         return 65536
 
-    def __getitem__(self, index: int) -> dict:
+    def __getitem__(self, index: int) -> dict[str, object]:
         del index
         return {"image": self.image, "text": self.text}
 
 
 def _collate_vlm(
     batches: list[dict],
-    image_processor,
-    tokenizer,
+    image_processor: BaseImageProcessor,
+    tokenizer: PreTrainedTokenizerBase,
     image_sequence_length: int,
     device: torch.device,
 ) -> dict[str, torch.Tensor]:
@@ -72,11 +77,11 @@ def _collate_vlm(
 
 
 def _training_step(
-    language_model,
-    vision_module,
+    language_model: CornstarchLanguageModel,
+    vision_module: CornstarchModalityEncoder,
     batch: dict[str, torch.Tensor],
     image_token_id: int,
-):
+) -> CausalLMOutputWithPast:
     plan = CornstarchExecutionPlan()
     vision_outputs = plan.run_modality_encoder(
         module=vision_module,
@@ -99,7 +104,7 @@ def pretrain(
     use_layer_offload: bool = False,
     profile_output_path: Path | None = None,
     max_train_steps: int = 10,
-):
+) -> None:
     """Randomly initialize a VLM and pretrain it through the new Cornstarch API."""
     torch.cuda.set_device(0)
     device = torch.device("cuda")

--- a/tasks/done/T004-DISTRIBUTED-UX.md
+++ b/tasks/done/T004-DISTRIBUTED-UX.md
@@ -1,0 +1,255 @@
+## Task ID: T004-DISTRIBUTED-UX
+## Type: IMPLEMENTATION (interface + examples cleanup; `pytest tests` must stay green)
+## Goal: tidy the Option C distributed surface so (a) model materialization has a
+single empty/random/HF-checkpoint API that works for both non-parallel and
+parallelized models, (b) `ParallelizationPlan.distribute()` is renamed to
+`materialize()`, (c) the projector auto-follows its encoder (no manual projector
+setup; `from_encoder_and_language_model` removed; `parallelize()` only accepts
+Cornstarch models), and (d) the distributed examples read like the
+non-distributed `examples/pretrain_vlm.py` (no `train_loop` / `build_plan`
+helpers).
+
+Each of the four bullets below is **its own commit** (impl, then any test
+update, interleaved logically). Branch from the current
+`feat/T003-cp-equivalence` HEAD (it carries the distributed surface this builds
+on): `git checkout -b feat/T004-distributed-ux`.
+
+## What you must read
+- `cornstarch/models/model_base.py`
+  (`set_empty_init`/`set_random_init`/`set_checkpoint_init`, `materialize`,
+  `_load_checkpoint_state_dict`, `_materialize_empty` — note the DTensor branch)
+- `cornstarch/models/lazy_init.py` (`InitializationPlan` — empty/random/checkpoint)
+- `cornstarch/models/multimodal/modeling.py`
+  (`CornstarchModalityEncoder`, `from_encoder_and_language_model`, `materialize`,
+  `set_*_init` — note it subclasses `nn.Module`, not `CornstarchModelBase`, and
+  `materialize` takes no `dtype`)
+- `cornstarch/models/multimodal/projector.py` (`CornstarchProjector.materialize`
+  — also no `dtype`)
+- `cornstarch/distributed/parallelization.py`
+  (`ParallelizationPlan.parallelize`/`distribute`, `ParallelContext`)
+- `cornstarch/distributed/tensor_parallel/__init__.py` + `plans.py`
+  (`apply_tensor_parallel` walks `module._section_names()`)
+- `cornstarch/distributed/pipeline_parallel/schedule.py`
+  (`NonPipelineParallelSchedule.step` does execute+criterion+backward;
+  `OneForwardOneBackwardSchedule.step` does 1F1B)
+- `examples/pretrain_vlm.py` (the NON-distributed style to converge toward:
+  `build_modality_encoder`, `_training_step`, explicit loop)
+- `examples/common.py` (`build_modality_encoder` helper)
+- `examples/distributed/{common.py,pretrain_llm.py,pretrain_vlm.py}`
+  (`train_loop`, `build_language_model_plan`, inline `build_plan`)
+- `tests/distributed/test_parallelism_integration.py` (uses `plan.distribute`)
+- `tests/model/test_multimodal_model.py` and
+  `tests/model/test_multimodal_materialization.py`
+  (use `from_encoder_and_language_model`)
+
+## Reference: how `refactor_distributed` did this (already inspected)
+- `InitializationPlan.checkpoint` there has an extra `model_name_or_path` field;
+  `set_checkpoint_init(..., model_name_or_path=...)` plus a
+  `_download_and_load_safetensors(model_name_or_path, device)` (HfApi +
+  `hf_hub_download` + `load_file`, merge all `*.safetensors`) lets a model
+  materialize **directly from an HF Hub id**. That is the piece missing on this
+  branch (current `checkpoint` only takes `state_dict` / `checkpoint_path`).
+- Its distributed example sets the init mode (`set_checkpoint_init(...)` /
+  `set_random_init()`) **before** `materialize()`, and the same `materialize()`
+  path serves both the plain and the TP/PP-sharded model.
+
+---
+
+## Commit 1 — unified empty / random / HF-checkpoint materialization
+**Why:** there is currently no way to materialize a model from an HF Hub id, and
+the checkpoint path is unverified for parallelized (DTensor) models. The user
+wants one init/materialize API that works for a non-parallelized model AND a
+parallelized one.
+
+**Do:**
+1. `cornstarch/models/lazy_init.py`: add `model_name_or_path: str | None = None`
+   to `InitializationPlan` and to `InitializationPlan.checkpoint(...)`; extend the
+   `__post_init__` mutual-exclusion check to cover all three checkpoint sources
+   (at most one of `state_dict` / `checkpoint_path` / `model_name_or_path`).
+2. `cornstarch/models/model_base.py`:
+   - `set_checkpoint_init(self, state_dict=None, checkpoint_path=None,
+     model_name_or_path=None)` — thread the new arg through.
+   - In `_load_checkpoint_state_dict`, when `model_name_or_path` is set, download
+     + merge all `*.safetensors` from the Hub (port
+     `_download_and_load_safetensors` as a `@staticmethod`; `huggingface_hub`
+     `HfApi().model_info(...).siblings` + `hf_hub_download` + safetensors
+     `load_file`), then run the existing `hf_to_cornstarch_state_dict` mapping
+     and device/dtype move. Keep `state_dict` and `checkpoint_path` branches.
+   - **Parallelized (DTensor) correctness — required.** Verify the `"checkpoint"`
+     branch of `materialize()` works when TP recorded DTensor specs on meta
+     params. The current `load_state_dict(state_dict, strict=True, assign=True)`
+     with a *full* (non-DTensor) tensor will drop the DTensor wrapping / sharding.
+     Fix so each rank ends up with its **sharded slice**: e.g. for DTensor params
+     run `_materialize_empty` first (its `to_empty` branch preserves the DTensor),
+     then copy `distribute_tensor(full_src, p.device_mesh, p.placements)` into
+     each DTensor param (mirror the test helper `_copy_full_into` in
+     `tests/distributed/test_numerical_equivalence.py`), and `assign`-load the
+     plain params as today. Do not regress the non-parallel checkpoint path.
+3. Keep `empty` = uninitialized alloc and `random` = `reset_parameters` exactly
+   as they are; this commit only adds the Hub source + the DTensor checkpoint fix.
+
+**Test (same commit or immediately after):**
+- Non-parallel: `set_checkpoint_init(state_dict=...)` and (network-guarded /
+  monkeypatched) `model_name_or_path` round-trip a tiny model.
+- Parallel: in `tests/distributed/`, build a tiny LM, `apply_tensor_parallel`,
+  `set_checkpoint_init(state_dict=<full ref>)`, `materialize("cpu")`, and assert
+  each rank's DTensor shard equals `distribute_tensor(ref)` — i.e. the loss/grad
+  matches the non-parallel reference (reuse the gloo harness).
+- Gate any real Hub download behind availability so `pytest tests` stays offline-green.
+
+---
+
+## Commit 2 — rename `ParallelizationPlan.distribute()` → `materialize()`
+**Why:** consistency with `CornstarchModelBase.materialize()`; `distribute` reads
+like a collective.
+
+**Do:**
+- Rename the method in `cornstarch/distributed/parallelization.py`. It still
+  returns a `ParallelContext`. (Optional: keep a thin `distribute(...)` alias that
+  warns and forwards, but prefer a clean rename since this is pre-release —
+  decide and state it; default = no alias, update all call sites.)
+- Update the class docstring/usage block and `cornstarch/distributed/__init__.py`
+  and `parallel_config.py` docstrings (they say "`.distribute()`").
+- Update call sites: `tests/distributed/test_parallelism_integration.py:117`,
+  `examples/distributed/pretrain_llm.py`, `examples/distributed/pretrain_vlm.py`.
+- `grep -rn "\.distribute(" cornstarch tests examples` (excluding
+  `distribute_tensor` / `distribute_layers`) must come back clean afterward.
+
+---
+
+## Commit 3 — projector auto-follows the encoder; lock down `parallelize()` input
+**Why:** in `examples/distributed/pretrain_vlm.py:107-113` the projector is built,
+`set_random_init()`-ed, and `materialize()`-ed by hand AFTER the encoder is
+already parallelized+materialized — duplicated and error-prone. Initialization,
+materialization (device/dtype), and parallelization of the projector must follow
+its encoder automatically, with no separate user calls; and `parallelize()` must
+reject anything that isn't a Cornstarch model so users can't pass a bare HF
+encoder (which has no projector).
+
+**Do:**
+1. `cornstarch/models/multimodal/modeling.py` — make `CornstarchModalityEncoder`
+   a first-class lifecycle unit over `(encoder, projector)`:
+   - `set_empty_init` / `set_random_init` / **add** `set_checkpoint_init` →
+     propagate to BOTH `encoder` and `projector` (so no manual
+     `projector.set_random_init()`).
+   - `materialize(self, device="cuda", dtype=None)` → **add `dtype`** and
+     materialize BOTH encoder and projector in that dtype (encoder already takes
+     `dtype`; give `CornstarchProjector.materialize` a `dtype` param, or
+     `.to(dtype)` after — projector init stays `reset_parameters`).
+   - **Remove** `from_encoder_and_language_model`.
+2. Add a package-level builder `build_modality_encoder(encoder, language_model,
+   modality, projector_type="linear", **projector_kwargs)` (move the body of the
+   removed classmethod) and export it from `cornstarch/models/__init__.py`. Point
+   `examples/common.py:build_modality_encoder` at the package one (or delete the
+   example shim and import the package function).
+3. `cornstarch/distributed/parallelization.py`:
+   - `parallelize()` runtime-enforces
+     `isinstance(module, (CornstarchModelBase, CornstarchModalityEncoder))`,
+     else `TypeError` whose message tells the user to wrap a raw HF encoder with
+     `build_modality_encoder(...)`. (This is the misconfiguration guard: a bare
+     HF module — or any non-Cornstarch module — is rejected.)
+   - In `distribute`/`materialize`, when a registered module is a
+     `CornstarchModalityEncoder`, apply TP/CP/PP to its `.encoder` (the apply_*
+     helpers need `_section_names()`, which the inner encoder has — the modality
+     encoder itself does not), then call `module.materialize(device, dtype)` so
+     the projector materializes with it. Projector TP: `apply_tensor_parallel`
+     no-ops for an unregistered family, so the projector stays replicated for now
+     — acceptable; note it. EP/CP/PP don't apply to the projector.
+   - `GradientSynchronizer.register(module)` already walks `module.parameters()`,
+     so the modality encoder's projector params are DP-synced automatically; confirm.
+4. Update tests that used the classmethod
+   (`tests/model/test_multimodal_model.py:362`,
+   `tests/model/test_multimodal_materialization.py:33`) to `build_modality_encoder`.
+
+**Decision to record (interface):** prefer the delegation approach above (plan
+operates on `modality_encoder.encoder` for the apply_* step) over making
+`CornstarchModalityEncoder` subclass `CornstarchModelBase`. Subclassing would
+demand an `hf_config` / `hf_model_factory` / state-mapper for a composite that
+has none, and would broaden scope; delegation keeps `parallelize()` accepting
+both types while the modality encoder owns only its own `(encoder, projector)`
+lifecycle. If during implementation the apply_* helpers turn out to need the
+modality encoder to *be* a `CornstarchModelBase`, STOP and write a BLOCK section.
+
+---
+
+## Commit 4 — distributed examples mirror the non-distributed style
+**Why:** `examples/distributed/*` hide everything behind `train_loop` and
+`build_*_plan` in `common.py`, so they look nothing like `examples/pretrain_vlm.py`.
+The two should feel almost identical; only the parallelization and schedule
+lines may differ.
+
+**Interface analysis (do this first, record findings in the commit message):**
+- Non-distributed `examples/pretrain_vlm.py` builds a fresh
+  `CornstarchExecutionPlan` per step in `_training_step`, runs
+  `output_future.execute(...)`, then `loss.backward()`.
+- Distributed builds the plan once and drives it with a `TrainingSchedule`:
+  `NonPipelineParallelSchedule.step` already does exactly execute+criterion+
+  backward; `OneForwardOneBackwardSchedule.step` does the 1F1B microbatch loop.
+- Conclusion: the unifying training-step primitive **already exists** — it is
+  `schedule.step(batch, criterion, optimizer, return_loss=True)`. The only
+  structural delta the interface forces on a distributed script is: build the
+  models the same way, then (i) `init_distributed()`, (ii) `plan.parallelize()` +
+  `plan.materialize()` instead of `model.materialize()`, (iii)
+  `ctx.prepare_dataloader()` instead of a plain `DataLoader`, (iv) get a schedule
+  from `ctx.create_schedule()` and call `schedule.step()` instead of inline
+  `execute()`/`backward()`, (v) `ctx.sync_gradients()` before `optimizer.step()`.
+  No new interface is required to hit "almost identical"; if implementation
+  reveals a gap that still forces divergence beyond these five lines, treat that
+  as an interface bug, write a BLOCK section, and propose the fix (e.g. a small
+  `ctx.train_step(...)` wrapper) rather than papering over it in the example.
+
+**Do:**
+- Delete `train_loop` and `build_language_model_plan` from
+  `examples/distributed/common.py` (keep only genuinely shared scaffolding:
+  `init_distributed`, `DTYPE`, `FakeTextDataset`, `causal_lm_criterion`, and the
+  VLM dataset/collate if shared).
+- Rewrite `examples/distributed/pretrain_llm.py` and
+  `examples/distributed/pretrain_vlm.py` to follow `examples/pretrain_vlm.py`
+  top-to-bottom: build configs → `from_hf_config` → (`build_modality_encoder` for
+  VLM) → `set_random_init()` → `plan.parallelize(...)` → `ctx = plan.materialize(...)`
+  → `ctx.prepare_dataloader(...)` → build the execution plan inline (a small local
+  `_build_plan()`/`_training_step`-shaped function, NOT a common.py helper) →
+  `schedule = ctx.create_schedule(...)` → explicit `for batch in loader:` loop
+  doing `schedule.step(...)`, `ctx.sync_gradients()`, `optimizer.step()`,
+  `optimizer.zero_grad()` (optionally an lr scheduler, like the non-distributed one).
+- The VLM script must NOT do any standalone projector setup (Commit 3 makes the
+  projector follow the encoder): build the modality encoder with
+  `build_modality_encoder`, `parallelize(modality_encoder, ...)`, done.
+- Examples are not run by `pytest tests`; smoke-check at least one with
+  `torchrun --nproc_per_node=1 ... --steps 1` (or a 2-rank gloo CPU run) and note
+  the result in the commit message.
+
+---
+
+## What you must NOT do
+- Do NOT import from `cornstarch_old`.
+- Do NOT change CP/TP/PP/EP numerical behavior; this is an ergonomics/refactor task.
+- Do NOT collapse the four bullets into one commit; one commit per bullet.
+- Do NOT make `examples/pretrain_vlm.py` (the non-distributed one) depend on the
+  distributed package — convergence is distributed → non-distributed, not the reverse.
+- Do NOT introduce a separate checkpoint format; HF-native only.
+
+## On Ambiguity
+Per CLAUDE.md: if an interface decision is unclear (e.g. whether the modality
+encoder must subclass `CornstarchModelBase`, or whether to keep a deprecated
+`distribute` alias), write your interpretation under a BLOCK section here and stop.
+
+## Done Condition
+- `set_checkpoint_init(model_name_or_path=...)` materializes a model from an HF
+  Hub id, and checkpoint init produces correctly-sharded weights on a TP model
+  (new distributed test green).
+- `ParallelizationPlan.materialize()` replaces `distribute()`; no stale
+  `.distribute(` call sites remain.
+- `CornstarchModalityEncoder.from_encoder_and_language_model` is gone;
+  `build_modality_encoder` is the package builder; `parallelize()` rejects
+  non-Cornstarch modules; the VLM example has zero standalone projector calls.
+- `examples/distributed/*` contain no `train_loop` / `build_*_plan` helpers and
+  read like `examples/pretrain_vlm.py` apart from the five distributed lines.
+- `pytest tests` is green; branch pushed; PR opened against
+  `feat/T003-cp-equivalence` with the four commits; this file moved to
+  `tasks/done/T004-DISTRIBUTED-UX.md` with the PR URL.
+
+---
+
+## PR
+https://github.com/cornstarch-org/Cornstarch/pull/71

--- a/tests/distributed/test_numerical_equivalence.py
+++ b/tests/distributed/test_numerical_equivalence.py
@@ -133,6 +133,66 @@ class TestTensorParallelEquivalence(GlooDistributedTestBase):
         torch.testing.assert_close(embed_grad, ref_embed_grad, atol=ATOL, rtol=RTOL)
 
 
+class TestTensorParallelCheckpointInit(GlooDistributedTestBase):
+    """Checkpoint init on a TP model shards weights correctly per rank.
+
+    Drives the real materialize path: a meta model records DTensor specs via
+    ``apply_tensor_parallel``, then ``set_checkpoint_init`` with a *full*
+    (non-sharded) reference state dict materializes each rank's correctly-sharded
+    slice — exactly ``distribute_tensor(full)`` — and reproduces the non-parallel
+    loss.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_checkpoint_init_shards_weights(self):
+        mesh = ModalProcessGroupMesh(
+            device_type="cpu", global_ranks=[0, 1],
+            dp_size=1, cp_size=1, tp_size=2, num_pp_stages=1,
+        )
+
+        # Non-parallel reference: full weights + loss/grad.
+        ref_model = _build_llm()
+        batch = _batch()
+        ref_loss = _loss(ref_model, batch)
+        ref_loss.backward()
+        ref_embed_grad = ref_model.pre_decoder["embed_tokens"].weight.grad.clone()
+        ref_params = _ref_params(ref_model)
+        ref_hf_state_dict = ref_model.to_hf_state_dict()
+
+        # Fresh meta model -> record DTensor specs -> checkpoint init -> materialize.
+        torch.manual_seed(0)
+        config = llama_config()
+        config.vocab_size = VOCAB
+        config.tie_word_embeddings = False
+        model = from_hf_config(config, model_kind="language", attn_implementation="eager")
+        apply_tensor_parallel(model, mesh.tp_mesh)
+        model.set_checkpoint_init(state_dict=ref_hf_state_dict)
+        model.materialize("cpu", dtype=DTYPE)
+        model.train()
+
+        # Every DTensor param holds this rank's distribute_tensor() slice; plain
+        # params hold the full reference tensor.
+        for name, p in model.named_parameters():
+            full = ref_params[name]
+            if isinstance(p.data, DTensor):
+                expected = distribute_tensor(full, p.data.device_mesh, p.data.placements)
+                torch.testing.assert_close(
+                    p.data.to_local(), expected.to_local(), atol=ATOL, rtol=RTOL
+                )
+            else:
+                torch.testing.assert_close(p.data, full, atol=ATOL, rtol=RTOL)
+
+        # Loss/grad parity against the non-parallel reference.
+        tp_loss = _loss(model, batch)
+        torch.testing.assert_close(tp_loss, ref_loss, atol=ATOL, rtol=RTOL)
+        tp_loss.backward()
+        embed_grad = model.pre_decoder["embed_tokens"].weight.grad
+        torch.testing.assert_close(embed_grad, ref_embed_grad, atol=ATOL, rtol=RTOL)
+
+
 class TestPipelineParallelEquivalence(GlooDistributedTestBase):
     @property
     def world_size(self) -> int:

--- a/tests/distributed/test_parallelism_integration.py
+++ b/tests/distributed/test_parallelism_integration.py
@@ -1,7 +1,7 @@
 """End-to-end integration tests for the Option C ``ParallelizationPlan`` surface.
 
 Each combination builds a tiny model, drives it through the *declarative*
-surface (``ParallelizationPlan.parallelize`` -> ``.distribute`` ->
+surface (``ParallelizationPlan.parallelize`` -> ``.materialize`` ->
 ``ParallelContext.create_schedule`` / ``.sync_gradients``), runs one
 forward+backward step, and asserts the loss is finite and gradients exist.
 
@@ -114,7 +114,7 @@ def _run_combo(test: GlooDistributedTestBase, combo, moe: bool) -> None:
             expert_parallel_size=ep,
         ),
     )
-    ctx = plan.distribute("cpu", dtype=torch.float32)
+    ctx = plan.materialize("cpu", dtype=torch.float32)
 
     batch_size = max(4, pp * 2)
     torch.manual_seed(100 + dist.get_rank())

--- a/tests/distributed/test_parallelization_plan.py
+++ b/tests/distributed/test_parallelization_plan.py
@@ -1,0 +1,34 @@
+"""Unit tests for the ``ParallelizationPlan`` surface that need no process group.
+
+These exercise the declarative plan's input validation — specifically the
+misconfiguration guard that rejects a non-Cornstarch module (e.g. a bare HF
+encoder) before any distributed setup happens.
+"""
+from __future__ import annotations
+
+import pytest
+import torch.nn as nn
+
+from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import build_modality_encoder, from_hf_config
+from tests.model.model_configs import clip_vision_config, llama_config
+
+
+def test_parallelize_rejects_non_cornstarch_module() -> None:
+    """A bare ``nn.Module`` is rejected with a wrap-it hint, not silently accepted."""
+    plan = ParallelizationPlan(global_ranks=[0])
+    with pytest.raises(TypeError, match="build_modality_encoder"):
+        plan.parallelize(nn.Linear(4, 4), ParallelConfig())
+
+
+def test_parallelize_accepts_cornstarch_model_and_modality_encoder() -> None:
+    """Both a Cornstarch model and a modality encoder register without error."""
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    vision_encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+
+    plan = ParallelizationPlan(global_ranks=[0])
+    plan.parallelize(language_model, ParallelConfig())
+    plan.parallelize(modality_encoder, ParallelConfig())

--- a/tests/model/test_model_materialization.py
+++ b/tests/model/test_model_materialization.py
@@ -152,6 +152,56 @@ def test_offload_layers_to_cpu_skips_unmaterialized_layers(
     assert all(tensor.is_meta for tensor in meta_tensors)
 
 
+def _reference_hf_state_dict() -> dict[str, torch.Tensor]:
+    """Materialize a tiny Llama and return its Hugging Face-keyed weights."""
+    reference = from_hf_config(llama_config(), attn_implementation=ATTN_IMPLEMENTATION)
+    reference.set_random_init()
+    reference.materialize("cpu")
+    return {key: tensor.detach().clone() for key, tensor in reference.to_hf_state_dict().items()}
+
+
+def test_set_checkpoint_init_from_state_dict_round_trips() -> None:
+    """A staged HF state dict materializes into matching Cornstarch weights."""
+    hf_state_dict = _reference_hf_state_dict()
+
+    model = from_hf_config(llama_config(), attn_implementation=ATTN_IMPLEMENTATION)
+    model.set_checkpoint_init(state_dict=hf_state_dict)
+    model.materialize("cpu")
+
+    materialized = model.to_hf_state_dict()
+    assert set(materialized) == set(hf_state_dict)
+    for key, expected in hf_state_dict.items():
+        torch.testing.assert_close(materialized[key], expected)
+
+
+def test_set_checkpoint_init_from_hub_id_round_trips(monkeypatch) -> None:
+    """``model_name_or_path`` downloads + merges safetensors, then materializes.
+
+    The real Hub download is monkeypatched so ``pytest tests`` stays offline; the
+    code path under test (HF-to-Cornstarch mapping + device/dtype move + load) is
+    identical to a genuine Hub materialization.
+    """
+    hf_state_dict = _reference_hf_state_dict()
+
+    def _fake_download(model_name_or_path, device):
+        assert model_name_or_path == "fake/tiny-llama"
+        return {key: tensor.clone() for key, tensor in hf_state_dict.items()}
+
+    monkeypatch.setattr(
+        "cornstarch.models.model_base.CornstarchModelBase._download_and_load_safetensors",
+        staticmethod(_fake_download),
+    )
+
+    model = from_hf_config(llama_config(), attn_implementation=ATTN_IMPLEMENTATION)
+    model.set_checkpoint_init(model_name_or_path="fake/tiny-llama")
+    model.materialize("cpu")
+
+    materialized = model.to_hf_state_dict()
+    assert set(materialized) == set(hf_state_dict)
+    for key, expected in hf_state_dict.items():
+        torch.testing.assert_close(materialized[key], expected)
+
+
 def test_materialize_handles_duplicate_tied_parameter_names() -> None:
     """Verify tied Llama embeddings do not leave the LM head on meta."""
     cornstarch_model = from_hf_config(

--- a/tests/model/test_multimodal_materialization.py
+++ b/tests/model/test_multimodal_materialization.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import torch
 
-from cornstarch.models import CornstarchModalityEncoder, from_hf_config
+from cornstarch.models import build_modality_encoder, from_hf_config
 from tests.model.model_configs import clip_vision_config, llama_config
 
 
@@ -30,7 +30,7 @@ def test_modality_encoder_factory_preserves_lazy_materialization() -> None:
     _assert_all_meta(language_model)
     _assert_all_meta(vision_encoder)
 
-    vision_module = CornstarchModalityEncoder.from_encoder_and_language_model(
+    vision_module = build_modality_encoder(
         vision_encoder,
         language_model,
         modality="vision",

--- a/tests/model/test_multimodal_model.py
+++ b/tests/model/test_multimodal_model.py
@@ -10,9 +10,9 @@ from cornstarch.models import from_hf_config
 from cornstarch.models.multimodal import (
     CornstarchEncoderToLanguageProjectorConfig,
     CornstarchExecutionPlan,
-    CornstarchModalityEncoder,
     CornstarchProjector,
     ExecutionFuture,
+    build_modality_encoder,
 )
 from tests.model.model_configs import clip_vision_config, llama_config
 
@@ -359,7 +359,7 @@ def test_execution_plan_rejects_count_mismatch() -> None:
 def test_execution_plan_vlm() -> None:
     language_model = _materialized_language_model()
     vision_encoder = from_hf_config(clip_vision_config(), model_kind="vision")
-    vision_module = CornstarchModalityEncoder.from_encoder_and_language_model(
+    vision_module = build_modality_encoder(
         vision_encoder,
         language_model,
         modality="vision",


### PR DESCRIPTION
## Task ID: T004-DISTRIBUTED-UX
## Type: IMPLEMENTATION (interface + examples cleanup; `pytest tests` must stay green)
## Goal: tidy the Option C distributed surface so (a) model materialization has a
single empty/random/HF-checkpoint API that works for both non-parallel and
parallelized models, (b) `ParallelizationPlan.distribute()` is renamed to
`materialize()`, (c) the projector auto-follows its encoder (no manual projector
setup; `from_encoder_and_language_model` removed; `parallelize()` only accepts
Cornstarch models), and (d) the distributed examples read like the
non-distributed `examples/pretrain_vlm.py` (no `train_loop` / `build_plan`
helpers).

Each of the four bullets below is **its own commit** (impl, then any test
update, interleaved logically). Branch from the current
`feat/T003-cp-equivalence` HEAD (it carries the distributed surface this builds
on): `git checkout -b feat/T004-distributed-ux`.

## What you must read
- `cornstarch/models/model_base.py`
  (`set_empty_init`/`set_random_init`/`set_checkpoint_init`, `materialize`,
  `_load_checkpoint_state_dict`, `_materialize_empty` — note the DTensor branch)
- `cornstarch/models/lazy_init.py` (`InitializationPlan` — empty/random/checkpoint)
- `cornstarch/models/multimodal/modeling.py`
  (`CornstarchModalityEncoder`, `from_encoder_and_language_model`, `materialize`,
  `set_*_init` — note it subclasses `nn.Module`, not `CornstarchModelBase`, and
  `materialize` takes no `dtype`)
- `cornstarch/models/multimodal/projector.py` (`CornstarchProjector.materialize`
  — also no `dtype`)
- `cornstarch/distributed/parallelization.py`
  (`ParallelizationPlan.parallelize`/`distribute`, `ParallelContext`)
- `cornstarch/distributed/tensor_parallel/__init__.py` + `plans.py`
  (`apply_tensor_parallel` walks `module._section_names()`)
- `cornstarch/distributed/pipeline_parallel/schedule.py`
  (`NonPipelineParallelSchedule.step` does execute+criterion+backward;
  `OneForwardOneBackwardSchedule.step` does 1F1B)
- `examples/pretrain_vlm.py` (the NON-distributed style to converge toward:
  `build_modality_encoder`, `_training_step`, explicit loop)
- `examples/common.py` (`build_modality_encoder` helper)
- `examples/distributed/{common.py,pretrain_llm.py,pretrain_vlm.py}`
  (`train_loop`, `build_language_model_plan`, inline `build_plan`)
- `tests/distributed/test_parallelism_integration.py` (uses `plan.distribute`)
- `tests/model/test_multimodal_model.py` and
  `tests/model/test_multimodal_materialization.py`
  (use `from_encoder_and_language_model`)

## Reference: how `refactor_distributed` did this (already inspected)
- `InitializationPlan.checkpoint` there has an extra `model_name_or_path` field;
  `set_checkpoint_init(..., model_name_or_path=...)` plus a
  `_download_and_load_safetensors(model_name_or_path, device)` (HfApi +
  `hf_hub_download` + `load_file`, merge all `*.safetensors`) lets a model
  materialize **directly from an HF Hub id**. That is the piece missing on this
  branch (current `checkpoint` only takes `state_dict` / `checkpoint_path`).
- Its distributed example sets the init mode (`set_checkpoint_init(...)` /
  `set_random_init()`) **before** `materialize()`, and the same `materialize()`
  path serves both the plain and the TP/PP-sharded model.

---

## Commit 1 — unified empty / random / HF-checkpoint materialization
**Why:** there is currently no way to materialize a model from an HF Hub id, and
the checkpoint path is unverified for parallelized (DTensor) models. The user
wants one init/materialize API that works for a non-parallelized model AND a
parallelized one.

**Do:**
1. `cornstarch/models/lazy_init.py`: add `model_name_or_path: str | None = None`
   to `InitializationPlan` and to `InitializationPlan.checkpoint(...)`; extend the
   `__post_init__` mutual-exclusion check to cover all three checkpoint sources
   (at most one of `state_dict` / `checkpoint_path` / `model_name_or_path`).
2. `cornstarch/models/model_base.py`:
   - `set_checkpoint_init(self, state_dict=None, checkpoint_path=None,
     model_name_or_path=None)` — thread the new arg through.
   - In `_load_checkpoint_state_dict`, when `model_name_or_path` is set, download
     + merge all `*.safetensors` from the Hub (port
     `_download_and_load_safetensors` as a `@staticmethod`; `huggingface_hub`
     `HfApi().model_info(...).siblings` + `hf_hub_download` + safetensors
     `load_file`), then run the existing `hf_to_cornstarch_state_dict` mapping
     and device/dtype move. Keep `state_dict` and `checkpoint_path` branches.
   - **Parallelized (DTensor) correctness — required.** Verify the `"checkpoint"`
     branch of `materialize()` works when TP recorded DTensor specs on meta
     params. The current `load_state_dict(state_dict, strict=True, assign=True)`
     with a *full* (non-DTensor) tensor will drop the DTensor wrapping / sharding.
     Fix so each rank ends up with its **sharded slice**: e.g. for DTensor params
     run `_materialize_empty` first (its `to_empty` branch preserves the DTensor),
     then copy `distribute_tensor(full_src, p.device_mesh, p.placements)` into
     each DTensor param (mirror the test helper `_copy_full_into` in
     `tests/distributed/test_numerical_equivalence.py`), and `assign`-load the
     plain params as today. Do not regress the non-parallel checkpoint path.
3. Keep `empty` = uninitialized alloc and `random` = `reset_parameters` exactly
   as they are; this commit only adds the Hub source + the DTensor checkpoint fix.

**Test (same commit or immediately after):**
- Non-parallel: `set_checkpoint_init(state_dict=...)` and (network-guarded /
  monkeypatched) `model_name_or_path` round-trip a tiny model.
- Parallel: in `tests/distributed/`, build a tiny LM, `apply_tensor_parallel`,
  `set_checkpoint_init(state_dict=<full ref>)`, `materialize("cpu")`, and assert
  each rank's DTensor shard equals `distribute_tensor(ref)` — i.e. the loss/grad
  matches the non-parallel reference (reuse the gloo harness).
- Gate any real Hub download behind availability so `pytest tests` stays offline-green.

---

## Commit 2 — rename `ParallelizationPlan.distribute()` → `materialize()`
**Why:** consistency with `CornstarchModelBase.materialize()`; `distribute` reads
like a collective.

**Do:**
- Rename the method in `cornstarch/distributed/parallelization.py`. It still
  returns a `ParallelContext`. (Optional: keep a thin `distribute(...)` alias that
  warns and forwards, but prefer a clean rename since this is pre-release —
  decide and state it; default = no alias, update all call sites.)
- Update the class docstring/usage block and `cornstarch/distributed/__init__.py`
  and `parallel_config.py` docstrings (they say "`.distribute()`").
- Update call sites: `tests/distributed/test_parallelism_integration.py:117`,
  `examples/distributed/pretrain_llm.py`, `examples/distributed/pretrain_vlm.py`.
- `grep -rn "\.distribute(" cornstarch tests examples` (excluding
  `distribute_tensor` / `distribute_layers`) must come back clean afterward.

---

## Commit 3 — projector auto-follows the encoder; lock down `parallelize()` input
**Why:** in `examples/distributed/pretrain_vlm.py:107-113` the projector is built,
`set_random_init()`-ed, and `materialize()`-ed by hand AFTER the encoder is
already parallelized+materialized — duplicated and error-prone. Initialization,
materialization (device/dtype), and parallelization of the projector must follow
its encoder automatically, with no separate user calls; and `parallelize()` must
reject anything that isn't a Cornstarch model so users can't pass a bare HF
encoder (which has no projector).

**Do:**
1. `cornstarch/models/multimodal/modeling.py` — make `CornstarchModalityEncoder`
   a first-class lifecycle unit over `(encoder, projector)`:
   - `set_empty_init` / `set_random_init` / **add** `set_checkpoint_init` →
     propagate to BOTH `encoder` and `projector` (so no manual
     `projector.set_random_init()`).
   - `materialize(self, device="cuda", dtype=None)` → **add `dtype`** and
     materialize BOTH encoder and projector in that dtype (encoder already takes
     `dtype`; give `CornstarchProjector.materialize` a `dtype` param, or
     `.to(dtype)` after — projector init stays `reset_parameters`).
   - **Remove** `from_encoder_and_language_model`.
2. Add a package-level builder `build_modality_encoder(encoder, language_model,
   modality, projector_type="linear", **projector_kwargs)` (move the body of the
   removed classmethod) and export it from `cornstarch/models/__init__.py`. Point
   `examples/common.py:build_modality_encoder` at the package one (or delete the
   example shim and import the package function).
3. `cornstarch/distributed/parallelization.py`:
   - `parallelize()` runtime-enforces
     `isinstance(module, (CornstarchModelBase, CornstarchModalityEncoder))`,
     else `TypeError` whose message tells the user to wrap a raw HF encoder with
     `build_modality_encoder(...)`. (This is the misconfiguration guard: a bare
     HF module — or any non-Cornstarch module — is rejected.)
   - In `distribute`/`materialize`, when a registered module is a
     `CornstarchModalityEncoder`, apply TP/CP/PP to its `.encoder` (the apply_*
     helpers need `_section_names()`, which the inner encoder has — the modality
     encoder itself does not), then call `module.materialize(device, dtype)` so
     the projector materializes with it. Projector TP: `apply_tensor_parallel`
     no-ops for an unregistered family, so the projector stays replicated for now
     — acceptable; note it. EP/CP/PP don't apply to the projector.
   - `GradientSynchronizer.register(module)` already walks `module.parameters()`,
     so the modality encoder's projector params are DP-synced automatically; confirm.
4. Update tests that used the classmethod
   (`tests/model/test_multimodal_model.py:362`,
   `tests/model/test_multimodal_materialization.py:33`) to `build_modality_encoder`.

**Decision to record (interface):** prefer the delegation approach above (plan
operates on `modality_encoder.encoder` for the apply_* step) over making
`CornstarchModalityEncoder` subclass `CornstarchModelBase`. Subclassing would
demand an `hf_config` / `hf_model_factory` / state-mapper for a composite that
has none, and would broaden scope; delegation keeps `parallelize()` accepting
both types while the modality encoder owns only its own `(encoder, projector)`
lifecycle. If during implementation the apply_* helpers turn out to need the
modality encoder to *be* a `CornstarchModelBase`, STOP and write a BLOCK section.

---

## Commit 4 — distributed examples mirror the non-distributed style
**Why:** `examples/distributed/*` hide everything behind `train_loop` and
`build_*_plan` in `common.py`, so they look nothing like `examples/pretrain_vlm.py`.
The two should feel almost identical; only the parallelization and schedule
lines may differ.

**Interface analysis (do this first, record findings in the commit message):**
- Non-distributed `examples/pretrain_vlm.py` builds a fresh
  `CornstarchExecutionPlan` per step in `_training_step`, runs
  `output_future.execute(...)`, then `loss.backward()`.
- Distributed builds the plan once and drives it with a `TrainingSchedule`:
  `NonPipelineParallelSchedule.step` already does exactly execute+criterion+
  backward; `OneForwardOneBackwardSchedule.step` does the 1F1B microbatch loop.
- Conclusion: the unifying training-step primitive **already exists** — it is
  `schedule.step(batch, criterion, optimizer, return_loss=True)`. The only
  structural delta the interface forces on a distributed script is: build the
  models the same way, then (i) `init_distributed()`, (ii) `plan.parallelize()` +
  `plan.materialize()` instead of `model.materialize()`, (iii)
  `ctx.prepare_dataloader()` instead of a plain `DataLoader`, (iv) get a schedule
  from `ctx.create_schedule()` and call `schedule.step()` instead of inline
  `execute()`/`backward()`, (v) `ctx.sync_gradients()` before `optimizer.step()`.
  No new interface is required to hit "almost identical"; if implementation
  reveals a gap that still forces divergence beyond these five lines, treat that
  as an interface bug, write a BLOCK section, and propose the fix (e.g. a small
  `ctx.train_step(...)` wrapper) rather than papering over it in the example.

**Do:**
- Delete `train_loop` and `build_language_model_plan` from
  `examples/distributed/common.py` (keep only genuinely shared scaffolding:
  `init_distributed`, `DTYPE`, `FakeTextDataset`, `causal_lm_criterion`, and the
  VLM dataset/collate if shared).
- Rewrite `examples/distributed/pretrain_llm.py` and
  `examples/distributed/pretrain_vlm.py` to follow `examples/pretrain_vlm.py`
  top-to-bottom: build configs → `from_hf_config` → (`build_modality_encoder` for
  VLM) → `set_random_init()` → `plan.parallelize(...)` → `ctx = plan.materialize(...)`
  → `ctx.prepare_dataloader(...)` → build the execution plan inline (a small local
  `_build_plan()`/`_training_step`-shaped function, NOT a common.py helper) →
  `schedule = ctx.create_schedule(...)` → explicit `for batch in loader:` loop
  doing `schedule.step(...)`, `ctx.sync_gradients()`, `optimizer.step()`,
  `optimizer.zero_grad()` (optionally an lr scheduler, like the non-distributed one).
- The VLM script must NOT do any standalone projector setup (Commit 3 makes the
  projector follow the encoder): build the modality encoder with
  `build_modality_encoder`, `parallelize(modality_encoder, ...)`, done.
- Examples are not run by `pytest tests`; smoke-check at least one with
  `torchrun --nproc_per_node=1 ... --steps 1` (or a 2-rank gloo CPU run) and note
  the result in the commit message.

---

## What you must NOT do
- Do NOT import from `cornstarch_old`.
- Do NOT change CP/TP/PP/EP numerical behavior; this is an ergonomics/refactor task.
- Do NOT collapse the four bullets into one commit; one commit per bullet.
- Do NOT make `examples/pretrain_vlm.py` (the non-distributed one) depend on the
  distributed package — convergence is distributed → non-distributed, not the reverse.
- Do NOT introduce a separate checkpoint format; HF-native only.

## On Ambiguity
Per CLAUDE.md: if an interface decision is unclear (e.g. whether the modality
encoder must subclass `CornstarchModelBase`, or whether to keep a deprecated
`distribute` alias), write your interpretation under a BLOCK section here and stop.

## Done Condition
- `set_checkpoint_init(model_name_or_path=...)` materializes a model from an HF
  Hub id, and checkpoint init produces correctly-sharded weights on a TP model
  (new distributed test green).
- `ParallelizationPlan.materialize()` replaces `distribute()`; no stale
  `.distribute(` call sites remain.
- `CornstarchModalityEncoder.from_encoder_and_language_model` is gone;
  `build_modality_encoder` is the package builder; `parallelize()` rejects
  non-Cornstarch modules; the VLM example has zero standalone projector calls.
- `examples/distributed/*` contain no `train_loop` / `build_*_plan` helpers and
  read like `examples/pretrain_vlm.py` apart from the five distributed lines.
- `pytest tests` is green; branch pushed; PR opened against
  `feat/T003-cp-equivalence` with the four commits; this file moved to
  `tasks/done/T004-DISTRIBUTED-UX.md` with the PR URL.