### PR TITLE
T005: per-step execution plan + cross-mesh compiled schedule

### DIFF
--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -54,6 +54,8 @@ from cornstarch.distributed.parallelization import (
 )
 from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
 from cornstarch.distributed.pipeline_parallel.schedule import (
+    CompiledSchedule,
+    MeshLayout,
     NonPipelineParallelSchedule,
     OneForwardOneBackwardSchedule,
     TrainingSchedule,
@@ -81,6 +83,8 @@ __all__ = [
     "TrainingSchedule",
     "NonPipelineParallelSchedule",
     "OneForwardOneBackwardSchedule",
+    "CompiledSchedule",
+    "MeshLayout",
     # expert parallel
     "apply_expert_parallel",
     # data parallel

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -31,6 +31,8 @@ from cornstarch.distributed.expert_parallel import apply_expert_parallel
 from cornstarch.distributed.parallel_config import ParallelConfig
 from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
 from cornstarch.distributed.pipeline_parallel.schedule import (
+    CompiledSchedule,
+    MeshLayout,
     NonPipelineParallelSchedule,
     OneForwardOneBackwardSchedule,
     TrainingSchedule,
@@ -65,6 +67,7 @@ class ParallelContext:
         modules: list[CornstarchModelBase],
         configs: list[ParallelConfig],
         meshes: dict[int, ModalProcessGroupMesh],
+        layouts: dict[int, MeshLayout],
         dp_size: int,
         dp_rank: int,
         dp_group: Optional[dist.ProcessGroup],
@@ -73,6 +76,7 @@ class ParallelContext:
         self._modules = modules
         self._configs = configs
         self._meshes = meshes
+        self._layouts = layouts
         self._dp_size = dp_size
         self._dp_rank = dp_rank
         self._dp_group = dp_group
@@ -184,11 +188,35 @@ class ParallelContext:
     ) -> TrainingSchedule:
         """Return a training schedule for the given execution plan.
 
-        If any registered modality uses pipeline parallelism, returns a
-        ``OneForwardOneBackwardSchedule`` driven by that modality's mesh;
-        otherwise returns a ``NonPipelineParallelSchedule`` that runs the full
-        DAG on every rank.
+        Schedule construction is cheap (DAG inspection + a rank-local program, no
+        collectives), so the caller is free to rebuild it per step — recovering
+        the per-batch flexibility the non-distributed plan already has.
+
+        Selection:
+
+        - **Multiple modalities on disjoint ranks** -> :class:`CompiledSchedule`,
+          which runs each node only on its owning mesh and compiles the cross-mesh
+          transfers that move a node's output to the ranks that consume it.  This
+          is what lets a VLM train with the vision encoder and the language model
+          on separate ranks (and lets a modality idle on a batch that omits it).
+        - **A single modality with pipeline parallelism** ->
+          :class:`OneForwardOneBackwardSchedule` (1F1B) driven by that mesh.
+        - **A single modality without pipeline parallelism** ->
+          :class:`NonPipelineParallelSchedule`, which runs the whole DAG locally.
         """
+        ranksets = {
+            self._layouts[id(module)].rankset
+            for module in self._modules
+            if id(module) in self._layouts
+        }
+        if len(ranksets) > 1:
+            return CompiledSchedule(
+                plan,
+                output_future,
+                {id(module): self._layouts[id(module)] for module in self._modules},
+                self._dp_size,
+            )
+
         for module in self._modules:
             mesh = self._meshes.get(id(module))
             if mesh is not None and mesh.num_stages > 1:
@@ -322,6 +350,7 @@ class ParallelizationPlan:
 
         modality_sizes = [cfg.ranks_per_replica for cfg in self._configs]
         meshes: dict[int, ModalProcessGroupMesh] = {}
+        layouts: dict[int, MeshLayout] = {}
 
         for mod_idx, (module, config) in enumerate(
             zip(self._modules, self._configs)
@@ -335,6 +364,18 @@ class ParallelizationPlan:
                 modality_ranks.extend(
                     global_ranks[base : base + modality_size]
                 )
+
+            # Record every modality's rank layout on every rank (pure
+            # arithmetic, no collectives) so the cross-mesh schedule can pair
+            # producer and consumer ranks for meshes this rank is not part of.
+            layouts[id(module)] = MeshLayout(
+                global_ranks=tuple(modality_ranks),
+                dp_size=dp_size,
+                num_pp_stages=config.pipeline_parallel_size,
+                cp_size=config.context_parallel_size,
+                tp_size=config.tensor_parallel_size,
+                ep_size=config.expert_parallel_size,
+            )
 
             if my_rank not in modality_ranks:
                 continue
@@ -381,6 +422,7 @@ class ParallelizationPlan:
             modules=self._modules,
             configs=self._configs,
             meshes=meshes,
+            layouts=layouts,
             dp_size=dp_size_final,
             dp_rank=dp_rank,
             dp_group=dp_group,

--- a/cornstarch/distributed/pipeline_parallel/p2p.py
+++ b/cornstarch/distributed/pipeline_parallel/p2p.py
@@ -29,6 +29,73 @@ def _deserialize(data: torch.Tensor, size: int) -> Any:
     return c10d._tensor_to_object(data.cpu(), size, group=dist.GroupMember.WORLD)
 
 
+def _build_p2p_ops(
+    send_tensor: torch.Tensor | None,
+    send_ranks: list[int],
+    recv_tensors: list[torch.Tensor],
+    recv_ranks: list[int],
+    send_first: bool,
+) -> list[dist.P2POp]:
+    """Build an ordered list of P2POps respecting ``send_first`` ordering."""
+    send_ops = []
+    if send_tensor is not None:
+        send_ops = [dist.P2POp(dist.isend, send_tensor, r) for r in send_ranks]
+    recv_ops = [
+        dist.P2POp(dist.irecv, recv_tensors[i], r) for i, r in enumerate(recv_ranks)
+    ]
+    if send_first:
+        return send_ops + recv_ops
+    return recv_ops + send_ops
+
+
+def exchange_objects(
+    send_obj: Any | None,
+    send_ranks: list[int],
+    recv_ranks: list[int],
+    device: torch.device,
+    send_first: bool = True,
+) -> list[Any]:
+    """Send ``send_obj`` to ``send_ranks`` and receive one object per ``recv_ranks``.
+
+    A backend-agnostic, mesh-free counterpart to
+    :meth:`PipelineP2PCommunication._exchange`: the peer ranks are passed
+    explicitly as **global** ranks rather than derived from a mesh, so this is
+    the transport used for cross-mesh execution-plan edges (a node on one
+    modality's mesh feeding a node on another's).  The same two-phase protocol
+    (size header, then payload) and the same ``send_first`` deadlock-avoidance
+    ordering are used as the pipeline-stage path.  Returns the received objects in
+    ``recv_ranks`` order (empty when ``recv_ranks`` is empty).
+    """
+    send_data: torch.Tensor | None = None
+    send_size: torch.Tensor | None = None
+    if send_obj is not None and send_ranks:
+        send_data, send_size = _serialize(send_obj, device)
+
+    # Phase 1 — exchange sizes.
+    recv_sizes = [
+        torch.zeros(1, dtype=torch.long, device=device) for _ in recv_ranks
+    ]
+    ops = _build_p2p_ops(send_size, send_ranks, recv_sizes, recv_ranks, send_first)
+    if ops:
+        for req in dist.batch_isend_irecv(ops):
+            req.wait()
+
+    # Phase 2 — exchange data.
+    recv_bufs = [
+        torch.empty(recv_sizes[i].item(), dtype=torch.uint8, device=device)
+        for i in range(len(recv_ranks))
+    ]
+    ops = _build_p2p_ops(send_data, send_ranks, recv_bufs, recv_ranks, send_first)
+    if ops:
+        for req in dist.batch_isend_irecv(ops):
+            req.wait()
+
+    return [
+        _deserialize(recv_bufs[i], recv_sizes[i].item())
+        for i in range(len(recv_ranks))
+    ]
+
+
 class PipelineP2PCommunication:
     """Backend-agnostic PP point-to-point communication.
 
@@ -45,26 +112,6 @@ class PipelineP2PCommunication:
             else "cpu"
         )
 
-    def _build_ops(
-        self,
-        send_tensor: torch.Tensor | None,
-        send_ranks: list[int],
-        recv_tensors: list[torch.Tensor],
-        recv_ranks: list[int],
-        send_first: bool,
-    ) -> list[dist.P2POp]:
-        """Build an ordered list of P2POps respecting ``send_first`` ordering."""
-        send_ops = []
-        if send_tensor is not None:
-            send_ops = [dist.P2POp(dist.isend, send_tensor, r) for r in send_ranks]
-        recv_ops = [
-            dist.P2POp(dist.irecv, recv_tensors[i], r)
-            for i, r in enumerate(recv_ranks)
-        ]
-        if send_first:
-            return send_ops + recv_ops
-        return recv_ops + send_ops
-
     def _exchange(
         self,
         send_obj: Any | None,
@@ -73,34 +120,9 @@ class PipelineP2PCommunication:
         send_first: bool = True,
     ) -> list[Any]:
         """Send ``send_obj`` to ``send_ranks`` and receive from ``recv_ranks``."""
-        send_data: torch.Tensor | None = None
-        send_size: torch.Tensor | None = None
-        if send_obj is not None and send_ranks:
-            send_data, send_size = _serialize(send_obj, self._device)
-
-        # Phase 1 — exchange sizes.
-        recv_sizes = [
-            torch.zeros(1, dtype=torch.long, device=self._device) for _ in recv_ranks
-        ]
-        ops = self._build_ops(send_size, send_ranks, recv_sizes, recv_ranks, send_first)
-        if ops:
-            for req in dist.batch_isend_irecv(ops):
-                req.wait()
-
-        # Phase 2 — exchange data.
-        recv_bufs = [
-            torch.empty(recv_sizes[i].item(), dtype=torch.uint8, device=self._device)
-            for i in range(len(recv_ranks))
-        ]
-        ops = self._build_ops(send_data, send_ranks, recv_bufs, recv_ranks, send_first)
-        if ops:
-            for req in dist.batch_isend_irecv(ops):
-                req.wait()
-
-        return [
-            _deserialize(recv_bufs[i], recv_sizes[i].item())
-            for i in range(len(recv_ranks))
-        ]
+        return exchange_objects(
+            send_obj, send_ranks, recv_ranks, self._device, send_first
+        )
 
     # ------------------------------------------------------------------
     # Public interface

--- a/cornstarch/distributed/pipeline_parallel/schedule.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule.py
@@ -22,18 +22,24 @@ execute it (single-shot vs. microbatch-pipelined 1F1B).
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import Any, Callable
 
 import torch
+import torch.distributed as dist
 import torch.nn as nn
 from torch.optim import Optimizer
 
-from cornstarch.distributed.pipeline_parallel.p2p import PipelineP2PCommunication
+from cornstarch.distributed.pipeline_parallel.p2p import (
+    PipelineP2PCommunication,
+    exchange_objects,
+)
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.models.multimodal.execution import (
     CornstarchExecutionPlan,
     ExecutionFuture,
     ExecutionNode,
+    _first_output_tensor,
 )
 
 
@@ -484,4 +490,297 @@ class OneForwardOneBackwardSchedule(TrainingSchedule):
         return {
             "loss": accum_loss,
             "outputs": _merge_batch(outputs) if outputs is not None else None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Mesh layout — a distributed-agnostic description of one modality's ranks
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MeshLayout:
+    """The rank assignment of one modality's ``ModalProcessGroupMesh``.
+
+    A ``ModalProcessGroupMesh`` is only *constructed* on the ranks that belong to
+    its modality, so a rank cannot ask another modality's mesh which global ranks
+    it owns.  The cross-mesh schedule needs exactly that — to compile a transfer
+    it must know, on *every* rank, where a producing modality's output lives and
+    which consuming-modality ranks need it.  ``MeshLayout`` is that purely
+    arithmetic description (no process groups, no collectives): it is computed for
+    *every* registered module on *every* rank from the same ``(dp, pp, cp, tp,
+    ep)`` reshape the mesh itself uses, so producer and consumer independently
+    derive the same rank pairing.
+    """
+
+    global_ranks: tuple[int, ...]
+    dp_size: int
+    num_pp_stages: int
+    cp_size: int
+    tp_size: int
+    ep_size: int
+
+    def _flat_index(self, dp: int, pp: int, cp: int, tp: int, ep: int) -> int:
+        # Mirror ModalProcessGroupMesh's (dp, pp, cp, tp, ep) replica-major /
+        # EP-minor reshape so the same coordinate resolves to the same rank.
+        return (
+            (((dp * self.num_pp_stages + pp) * self.cp_size + cp) * self.tp_size + tp)
+            * self.ep_size
+            + ep
+        )
+
+    def rank_at(self, dp: int, pp: int, cp: int, tp: int, ep: int) -> int:
+        """Return the global rank at a single ``(dp, pp, cp, tp, ep)`` coordinate."""
+        return self.global_ranks[self._flat_index(dp, pp, cp, tp, ep)]
+
+    def stage_ranks(self, dp: int, pp: int) -> list[int]:
+        """Return every global rank in one ``(dp, pp)`` slice (all cp/tp/ep)."""
+        return [
+            self.rank_at(dp, pp, cp, tp, ep)
+            for cp in range(self.cp_size)
+            for tp in range(self.tp_size)
+            for ep in range(self.ep_size)
+        ]
+
+    @property
+    def last_stage(self) -> int:
+        return self.num_pp_stages - 1
+
+    @property
+    def rankset(self) -> frozenset[int]:
+        return frozenset(self.global_ranks)
+
+
+# ---------------------------------------------------------------------------
+# Compiled cross-mesh schedule
+# ---------------------------------------------------------------------------
+
+class CompiledSchedule(TrainingSchedule):
+    """Runs a multi-mesh execution DAG, compiling cross-mesh transfers per batch.
+
+    This is the schedule used when an execution plan spans modalities that live
+    on **disjoint** rank ranges (Option C gives each modality its own slice of
+    the world).  ``NonPipelineParallelSchedule`` runs the *whole* DAG on every
+    rank, which breaks here: a modality's module is materialized only on its own
+    ranks and stays ``meta`` elsewhere, so running e.g. the vision encoder on the
+    language-model ranks raises a device error.
+
+    The plan stays a purely logical data-flow DAG (it knows nothing about ranks).
+    The schedule compiles, from that DAG plus the per-module :class:`MeshLayout`
+    map, a rank-local program:
+
+    - **Node activation.** A rank executes a node iff it belongs to that node's
+      owning mesh; otherwise the node is a no-op on that rank.  A modality whose
+      node is absent from this batch's plan (e.g. a text-only step) simply idles
+      on its ranks — that is how per-batch flexibility falls out for free.
+    - **Cross-mesh edges.** When a node ``A`` on mesh ``M_A`` produces a value
+      consumed by node ``B`` on a different mesh ``M_B``, a transfer is inserted.
+      The rank pairing is the cross-mesh analogue of a pipeline-stage boundary:
+
+        * Forward: the producer **representative** of ``M_A`` for data-parallel
+          replica ``d`` — its last-pipeline-stage ``(cp=tp=ep=0)`` rank — sends
+          the feature tensor to *every* first-pipeline-stage rank of ``M_B`` in
+          replica ``d`` (a broadcast, since the consuming layer needs the value
+          replicated across the consumer's TP/EP group).
+        * Backward: mirrored.  The consumer representative of ``M_B`` sends the
+          gradient back to every last-stage rank of ``M_A`` in replica ``d``;
+          each runs its local ``backward`` into the producing subgraph.
+
+      Replica ``d`` of the producer always pairs with replica ``d`` of the
+      consumer (DP size is identical across modalities by construction), so each
+      replica's batch shard stays on its own ranks.
+
+    Cross-mesh transfer is a graph break by design (like a PP boundary): the
+    received tensor is a fresh leaf, and the gradient is shipped back explicitly.
+    It is mathematically transparent — no parallelism math changes.
+
+    Scope: every mesh in a multi-mesh plan must be non-pipelined
+    (``num_pp_stages == 1``).  Single-mesh pipelining keeps using
+    :class:`OneForwardOneBackwardSchedule`; combining intra-mesh 1F1B with
+    cross-mesh microbatch coordination is intentionally left out.
+    """
+
+    def __init__(
+        self,
+        plan: CornstarchExecutionPlan,
+        output_future: ExecutionFuture,
+        layouts: dict[int, MeshLayout],
+        dp_size: int,
+    ) -> None:
+        self._plan = plan
+        self._output_future = output_future
+        self._layouts = layouts
+        self._dp_size = dp_size
+        self._my_rank = dist.get_rank()
+
+        for layout in layouts.values():
+            if layout.num_pp_stages > 1:
+                raise NotImplementedError(
+                    "CompiledSchedule (multi-mesh execution across disjoint "
+                    "modality ranks) does not support pipeline parallelism inside "
+                    "a modality yet; got a mesh with "
+                    f"num_pp_stages={layout.num_pp_stages}. Use pipeline "
+                    "parallelism only for a single-mesh (language-model-only) plan."
+                )
+
+    # ------------------------------------------------------------------
+    # Node -> owning mesh resolution
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _node_module(node: ExecutionNode) -> Any:
+        """Return the module whose mesh owns ``node``.
+
+        The merge node embeds text with the language model, so it belongs to the
+        language model's mesh; encoder/LM nodes carry their module directly.
+        """
+        if node.kind == "merge_modality_encoder_outputs":
+            return node.params["language_model"]
+        return node.params["module"]
+
+    def _node_layout(self, node: ExecutionNode) -> MeshLayout:
+        return self._layouts[id(self._node_module(node))]
+
+    # ------------------------------------------------------------------
+    # Cross-mesh transfers
+    # ------------------------------------------------------------------
+
+    def _forward_transfer(
+        self,
+        prod: MeshLayout,
+        cons: MeshLayout,
+        value: Any,
+        device: torch.device,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        """Move a producer node's output to the consumer mesh's ranks.
+
+        Returns ``(received, sent_feat)``: the consumer ranks get ``received``
+        (a fresh tensor); the producer representative gets ``sent_feat`` (the
+        graph tensor it sent, kept for the backward transfer).  At most one is
+        non-``None`` on any rank, since the meshes are disjoint.
+        """
+        received: torch.Tensor | None = None
+        sent_feat: torch.Tensor | None = None
+        for d in range(self._dp_size):
+            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
+            consumer_ranks = cons.stage_ranks(d, 0)
+            if self._my_rank == producer_rep:
+                feat = _first_output_tensor(value)
+                exchange_objects(feat.detach(), consumer_ranks, [], device)
+                sent_feat = feat
+            elif self._my_rank in consumer_ranks:
+                received = exchange_objects(None, [], [producer_rep], device)[0]
+        return received, sent_feat
+
+    def _backward_transfer(
+        self,
+        prod: MeshLayout,
+        cons: MeshLayout,
+        grad: Any,
+        device: torch.device,
+    ) -> Any | None:
+        """Ship a cross-mesh gradient from the consumer back to the producer.
+
+        Mirror of :meth:`_forward_transfer`: the consumer representative sends
+        the gradient to every last-stage producer rank (so each replicated
+        producer rank can run its own backward).  Returns the received gradient
+        on producer ranks, ``None`` elsewhere.
+        """
+        received_grad: Any | None = None
+        for d in range(self._dp_size):
+            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
+            producer_ranks = prod.stage_ranks(d, prod.last_stage)
+            if self._my_rank == consumer_rep:
+                exchange_objects(grad, producer_ranks, [], device)
+            elif self._my_rank in producer_ranks:
+                received_grad = exchange_objects(None, [], [consumer_rep], device)[0]
+        return received_grad
+
+    # ------------------------------------------------------------------
+    # Step
+    # ------------------------------------------------------------------
+
+    def step(
+        self,
+        batch: dict[str, torch.Tensor],
+        criterion: Callable[..., Any],
+        optimizer: Optimizer | None = None,
+        return_loss: bool = True,
+        return_outputs: bool = False,
+    ) -> dict:
+        device = _first_tensor_device(batch)
+        if device is None:
+            device = (
+                torch.device(f"cuda:{torch.cuda.current_device()}")
+                if torch.cuda.is_available() and torch.cuda.device_count() > 0
+                else torch.device("cpu")
+            )
+
+        ordered = self._plan._topological_nodes(self._output_future.name)
+        producer_of = {node.name: node for node in ordered}
+        values: dict[str, Any] = dict(batch) if isinstance(batch, dict) else {}
+
+        # Forward: run owned nodes, transferring cross-mesh inputs as we reach
+        # the consumer node.  ``edges`` records this rank's role per cross-mesh
+        # edge so the backward pass can mirror the transfers in reverse.
+        edges: list[dict[str, Any]] = []
+        for node in ordered:
+            node_layout = self._node_layout(node)
+            for dep in sorted(node.dependencies):
+                producer = producer_of.get(dep)
+                if producer is None:
+                    continue  # a raw batch input, present on every rank
+                prod_layout = self._node_layout(producer)
+                if prod_layout.rankset == node_layout.rankset:
+                    continue  # intra-mesh edge — no transfer
+                received, sent_feat = self._forward_transfer(
+                    prod_layout, node_layout, values.get(dep), device
+                )
+                if received is not None:
+                    received.requires_grad_(True)
+                    values[dep] = received
+                    edges.append(
+                        {
+                            "role": "consumer",
+                            "prod": prod_layout,
+                            "cons": node_layout,
+                            "leaf": received,
+                        }
+                    )
+                if sent_feat is not None:
+                    edges.append(
+                        {
+                            "role": "producer",
+                            "prod": prod_layout,
+                            "cons": node_layout,
+                            "feat": sent_feat,
+                        }
+                    )
+            if self._my_rank in node_layout.rankset:
+                values[node.name] = CornstarchExecutionPlan._execute_node(node, values)
+
+        # Loss + backward on the ranks that own the output node.
+        loss: torch.Tensor | None = None
+        output: Any | None = None
+        output_layout = self._node_layout(producer_of[self._output_future.name])
+        if self._my_rank in output_layout.rankset:
+            output = values[self._output_future.name]
+            loss = criterion(output, batch)
+            loss.backward()
+
+        # Backward: mirror the cross-mesh transfers in reverse.
+        for edge in reversed(edges):
+            if edge["role"] == "consumer":
+                self._backward_transfer(
+                    edge["prod"], edge["cons"], edge["leaf"].grad, device
+                )
+            else:
+                received_grad = self._backward_transfer(
+                    edge["prod"], edge["cons"], None, device
+                )
+                if received_grad is not None and edge["feat"].requires_grad:
+                    torch.autograd.backward(edge["feat"], received_grad)
+
+        return {
+            "loss": loss.detach() if (return_loss and loss is not None) else None,
+            "outputs": output if return_outputs else None,
         }

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -36,7 +36,6 @@ from cornstarch.distributed import (
     ParallelConfig,
     ParallelContext,
     ParallelizationPlan,
-    TrainingSchedule,
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
@@ -46,21 +45,40 @@ from cornstarch.models import (
 
 
 def _training_step(
-    schedule: TrainingSchedule,
+    language_model: Any,
     ctx: ParallelContext,
     batch: dict[str, torch.Tensor],
     criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
     optimizer: torch.optim.Optimizer,
+    num_microbatches: int,
+    microbatch_size: int,
 ) -> dict[str, Any]:
-    """Run one schedule-driven training step and sync gradients across DP ranks.
+    """Build the plan for this batch, run one schedule step, and sync gradients.
 
-    ``schedule.step`` runs forward + criterion + backward (or the 1F1B
-    microbatch loop under PP); ``ctx.sync_gradients`` all-reduces the DP
-    gradients before the optimizer step.  Hiding both parallelism-specific calls
-    here keeps the training loop identical to the non-distributed
-    ``examples/pretrain_vlm.py``.  Returns the schedule result whose ``"loss"``
-    is the step loss (``None`` on non-last pipeline stages).
+    Just like the non-distributed ``examples/pretrain_vlm.py``, the execution
+    plan is rebuilt **every step** — schedule construction is cheap (DAG analysis
+    plus a rank-local program, no collectives).  ``schedule.step`` runs forward +
+    criterion + backward (or the 1F1B microbatch loop under PP); then
+    ``ctx.sync_gradients`` all-reduces the DP gradients before the optimizer step.
+    Returns the schedule result whose ``"loss"`` is the step loss (``None`` on
+    non-last pipeline stages).
     """
+    plan = CornstarchExecutionPlan()
+    merged = plan.merge_modality_encoder_outputs(
+        language_model=language_model,
+        input_ids=ExecutionFuture("input_ids"),
+        labels=ExecutionFuture("labels"),
+        modality_token_ids={},
+        encoder_outputs={},
+    )
+    output_future = plan.run_language_model(module=language_model, inputs=merged)
+
+    schedule = ctx.create_schedule(
+        plan,
+        output_future,
+        num_microbatches=num_microbatches,
+        microbatch_size=microbatch_size,
+    )
     result = schedule.step(batch, criterion, optimizer, return_loss=True)
     ctx.sync_gradients()
     return result
@@ -104,28 +122,6 @@ def pretrain(
     dataset = FakeTextDataset(language_model.hf_config.vocab_size, seq_len)
     dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
-    def build_plan() -> tuple[CornstarchExecutionPlan, ExecutionFuture]:
-        exec_plan = CornstarchExecutionPlan()
-        merged = exec_plan.merge_modality_encoder_outputs(
-            language_model=language_model,
-            input_ids=ExecutionFuture("input_ids"),
-            labels=ExecutionFuture("labels"),
-            modality_token_ids={},
-            encoder_outputs={},
-        )
-        output_future = exec_plan.run_language_model(
-            module=language_model, inputs=merged
-        )
-        return exec_plan, output_future
-
-    exec_plan, output_future = build_plan()
-    schedule = ctx.create_schedule(
-        exec_plan,
-        output_future,
-        num_microbatches=num_microbatches if pp > 1 else 1,
-        microbatch_size=batch_size // num_microbatches if pp > 1 else 1,
-    )
-
     optimizer = torch.optim.Adam(language_model.parameters(), lr=lr)
     optimizer.zero_grad()
 
@@ -141,7 +137,13 @@ def pretrain(
         for _ in pbar:
             batch = next(dataloader_iter)
             outputs = _training_step(
-                schedule, ctx, batch, causal_lm_criterion, optimizer
+                language_model,
+                ctx,
+                batch,
+                causal_lm_criterion,
+                optimizer,
+                num_microbatches=num_microbatches if pp > 1 else 1,
+                microbatch_size=batch_size // num_microbatches if pp > 1 else 1,
             )
             loss = outputs["loss"]
             if loss is not None:

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -36,11 +36,9 @@ from cornstarch.distributed import (
     ParallelConfig,
     ParallelContext,
     ParallelizationPlan,
-    TrainingSchedule,
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
-    ExecutionFuture,
     build_modality_encoder,
     from_hf_config,
 )
@@ -78,21 +76,46 @@ class FakeVLMDataset(Dataset):
 
 
 def _training_step(
-    schedule: TrainingSchedule,
+    language_model: Any,
+    modality_encoder: Any,
     ctx: ParallelContext,
     batch: dict[str, torch.Tensor],
     criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
     optimizer: torch.optim.Optimizer,
 ) -> dict[str, Any]:
-    """Run one schedule-driven training step and sync gradients across DP ranks.
+    """Build the plan for this batch, run one schedule step, and sync gradients.
 
-    ``schedule.step`` runs forward + criterion + backward (or the 1F1B
-    microbatch loop under PP); ``ctx.sync_gradients`` all-reduces the DP
-    gradients before the optimizer step.  Hiding both parallelism-specific calls
-    here keeps the training loop identical to the non-distributed
-    ``examples/pretrain_vlm.py``.  Returns the schedule result whose ``"loss"``
-    is the step loss (``None`` on non-last pipeline stages).
+    The execution plan is rebuilt **every step** — the three plan-construction
+    lines below are byte-identical to the non-distributed
+    ``examples/pretrain_vlm.py``; only the ``schedule.step`` tail differs from its
+    ``output_future.execute()``.  Because the plan is rebuilt per batch, a step
+    whose ``batch`` omits ``pixel_values`` would simply drop the
+    ``run_modality_encoder("vision")`` node, and the vision encoder's ranks idle
+    for that step while the language-model ranks still train — the per-batch
+    flexibility the non-distributed plan already has.  (See
+    ``tests/distributed/test_multimodal_distributed.py`` for that flexibility
+    case on disjoint ranks.)
+
+    ``ctx.create_schedule`` returns a ``CompiledSchedule`` here because the vision
+    encoder and the language model live on **disjoint** ranks: it runs each node
+    only on its owning mesh and compiles the cross-mesh transfer that moves the
+    projected vision features to the language-model ranks that consume them.
     """
+    plan = CornstarchExecutionPlan()
+    vision_outputs = plan.run_modality_encoder(
+        module=modality_encoder,
+        pixel_values=batch["pixel_values"],
+    )
+    merged = plan.merge_modality_encoder_outputs(
+        language_model=language_model,
+        input_ids=batch["input_ids"],
+        labels=batch["labels"],
+        modality_token_ids={"vision": IMAGE_TOKEN_ID},
+        encoder_outputs={"vision": vision_outputs},
+    )
+    output_future = plan.run_language_model(module=language_model, inputs=merged)
+
+    schedule = ctx.create_schedule(plan, output_future)
     result = schedule.step(batch, criterion, optimizer, return_loss=True)
     ctx.sync_gradients()
     return result
@@ -156,31 +179,6 @@ def pretrain(
     )
     dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
 
-    def build_plan() -> tuple[CornstarchExecutionPlan, ExecutionFuture]:
-        exec_plan = CornstarchExecutionPlan()
-        vision_outputs = exec_plan.run_modality_encoder(
-            module=modality_encoder, pixel_values=ExecutionFuture("pixel_values")
-        )
-        merged = exec_plan.merge_modality_encoder_outputs(
-            language_model=language_model,
-            input_ids=ExecutionFuture("input_ids"),
-            labels=ExecutionFuture("labels"),
-            modality_token_ids={"vision": IMAGE_TOKEN_ID},
-            encoder_outputs={"vision": vision_outputs},
-        )
-        output_future = exec_plan.run_language_model(
-            module=language_model, inputs=merged
-        )
-        return exec_plan, output_future
-
-    exec_plan, output_future = build_plan()
-    schedule = ctx.create_schedule(
-        exec_plan,
-        output_future,
-        num_microbatches=num_microbatches if llm_pp > 1 else 1,
-        microbatch_size=batch_size // num_microbatches if llm_pp > 1 else 1,
-    )
-
     params = list(language_model.parameters()) + list(modality_encoder.parameters())
     optimizer = torch.optim.Adam(params, lr=lr)
     optimizer.zero_grad()
@@ -197,7 +195,12 @@ def pretrain(
         for _ in pbar:
             batch = next(dataloader_iter)
             outputs = _training_step(
-                schedule, ctx, batch, causal_lm_criterion, optimizer
+                language_model,
+                modality_encoder,
+                ctx,
+                batch,
+                causal_lm_criterion,
+                optimizer,
             )
             loss = outputs["loss"]
             if loss is not None:

--- a/tasks/done/T005-PER-STEP-EXECUTION-PLAN.md
+++ b/tasks/done/T005-PER-STEP-EXECUTION-PLAN.md
@@ -1,0 +1,204 @@
+## Task ID: T005-PER-STEP-EXECUTION-PLAN
+## Type: DESIGN + IMPLEMENTATION (`pytest tests` must stay green)
+## Goal: make `CornstarchExecutionPlan` usage identical for non-distributed and
+distributed training. The plan is rebuilt **per training step** (recovering the
+per-batch flexibility the non-distributed example already has) and is purely a
+*logical* data-flow DAG that is agnostic to distributed training. All knowledge
+of *which ranks are active* and *how data crosses ranks* is compiled into a
+`TrainingSchedule` that is generated **per batch** from that plan + the
+`ParallelContext` meshes. Runtime just runs the compiled schedule.
+
+## Motivation
+- Non-distributed `examples/pretrain_vlm.py::_training_step` builds a fresh
+  `CornstarchExecutionPlan` **every step** and calls
+  `output_future.execute(inputs=batch)`. This gives per-batch flexibility: a step
+  with no image simply omits the `run_modality_encoder("vision")` node.
+- Distributed `examples/distributed/pretrain_*.py` build the plan **once** before
+  the loop, bake it into a `TrainingSchedule` via `ctx.create_schedule(...)`, and
+  reuse that schedule for every step. The plan is never regenerated, so the
+  per-batch flexibility is lost and the execution DAG is frozen.
+- Worse, the current `NonPipelineParallelSchedule.step` runs the **whole DAG on
+  every rank** (`output_future.execute`). When modalities live on **disjoint
+  ranks** (Option C assigns each modality its own rank range), the vision encoder
+  is materialized only on the vision ranks and is still `meta` on the LLM ranks,
+  so running the full DAG there raises `Tensor on device cpu is not on the
+  expected device meta!`. This is the limitation recorded at the end of
+  `tasks/done/T004-DISTRIBUTED-UX.md` (commit "distributed examples mirror the
+  non-distributed style"); the VLM example parallelizes/materializes correctly
+  and reaches `schedule.step`, then fails here.
+
+This task fixes both: per-step plan rebuild **and** a schedule that compiles
+per-batch rank activation + cross-rank data movement from the DAG.
+
+## Design decision (records the user's choice)
+Two options were considered for the schedule:
+1. **Build one static schedule, activate a sub-DAG per step.** The schedule holds
+   the full model map; each step it analyzes which sub-DAG/ranks to activate.
+2. **Build a fresh schedule per batch (CHOSEN).** Each step builds a
+   `CornstarchExecutionPlan` for that batch; a schedule is compiled from that DAG
+   (which ranks run which node, and the P2P/broadcast edges that move a node's
+   output to the ranks that consume it). Runtime just runs the compiled schedule.
+
+Choice **2** is preferred because it makes `CornstarchExecutionPlan` usage
+identical whether or not the model is distributed: the plan is the logical data
+flow only, and *how* data is transferred under parallelism is governed entirely
+by the schedule. Per-step schedule construction must therefore be cheap (DAG
+analysis + a rank-local program, no collectives at build time).
+
+**Invariant to preserve:** `cornstarch/models/multimodal/execution.py` must not
+import anything from `cornstarch/distributed/`. `CornstarchExecutionPlan` /
+`ExecutionNode` / `ExecutionFuture` stay distributed-agnostic.
+
+## What you must read
+- `cornstarch/models/multimodal/execution.py`
+  (`CornstarchExecutionPlan`, `ExecutionNode` {`name`, `kind`, `params`,
+  `dependencies`}, `ExecutionFuture.execute`, `_topological_nodes`,
+  `_execute_nodes`, `_execute_node`, `_execute_until`) — the logical DAG.
+- `cornstarch/distributed/parallelization.py`
+  (`ParallelContext` — holds `self._meshes: dict[id(module) -> ModalProcessGroupMesh]`,
+  `self._modules`, `create_schedule`, `sync_gradients`; `ParallelizationPlan.materialize`).
+- `cornstarch/distributed/pipeline_parallel/schedule.py`
+  (`TrainingSchedule`, `NonPipelineParallelSchedule.step` = execute+criterion+
+  backward, `OneForwardOneBackwardSchedule` = 1F1B with `_StageModel` splitting
+  the DAG into pre-pipeline nodes + the LM node, `PipelineP2PCommunication`).
+- `cornstarch/distributed/pipeline_parallel/p2p.py` (P2P send/recv primitives —
+  the cross-rank transport to reuse for cross-mesh edges).
+- `cornstarch/distributed/process_group_mesh.py` (`ModalProcessGroupMesh`: per
+  modality, the dp/cp/tp/pp/ep axes, `is_first_stage`/`is_last_stage`,
+  `num_stages`, the rank set).
+- `examples/pretrain_vlm.py` (`_training_step` builds the plan per step) and
+  `examples/distributed/pretrain_vlm.py` / `pretrain_llm.py` (build the plan once
+  today — the call sites to converge).
+- `tests/distributed/test_parallelism_integration.py` (LM + EP composition over
+  the surface) and `tests/distributed/test_numerical_equivalence.py` (TP/PP/EP/DP
+  parity harness) — the green bar this must not regress.
+
+## Proposed approach (refine during implementation; write a BLOCK if an
+## interface decision is unclear, per CLAUDE.md)
+
+### Commit 1 — per-step plan rebuild in the distributed examples (no engine change yet)
+Move plan construction into `_training_step` for the LM-only case (single mesh,
+no cross-rank modality edge), so the example builds a fresh plan per step exactly
+like the non-distributed one, and the schedule is created per step from it.
+- `examples/distributed/pretrain_llm.py`: build `CornstarchExecutionPlan` +
+  `output_future` inside `_training_step` (or just before it), call
+  `ctx.create_schedule(plan, output_future, ...)` per step, then `schedule.step`.
+- Confirm `ctx.create_schedule` is cheap enough per step for the non-PP and PP
+  LM paths (it already only inspects the DAG). If PP per-step schedule rebuild is
+  too costly or stateful, note it and keep PP schedule cached (LM topology is
+  batch-invariant) while still rebuilding the *plan*.
+- Smoke-check the 2-rank gloo LM run still trains.
+
+### Commit 2 — schedule compiles per-batch rank activation + cross-mesh edges
+Teach the schedule layer to run a DAG whose nodes live on **different meshes**
+(disjoint rank ranges), which is what fixes the multimodal cross-rank failure.
+- Give `ParallelContext` a map from execution node -> owning mesh: a node's
+  module is in `node.params["module"]`; look up `self._meshes[id(module)]`. A
+  rank executes a node iff it is in that mesh's rank set; otherwise the node is a
+  no-op on that rank.
+- Compile cross-mesh edges from the DAG: when node A (mesh M_A) produces a future
+  consumed by node B (mesh M_B) and `M_A != M_B`, insert a transfer — the
+  designated producer rank(s) of M_A `send` the tensor and the consumer rank(s)
+  of M_B `recv` it (reuse `PipelineP2PCommunication` / `p2p.py`). Define the
+  rank-pairing rule (e.g. M_A last-PP-stage rank r -> M_B first-PP-stage rank r,
+  with DP/TP broadcast as needed) and record it; this is the core interface
+  decision — if it is ambiguous, STOP and write a BLOCK.
+- A rank with no active node for a batch (e.g. vision ranks on a text-only step)
+  does nothing. Backward mirrors the forward transfers (send grad back across the
+  cross-mesh edge).
+- Keep the existing single-mesh fast paths (`NonPipelineParallelSchedule` for one
+  non-PP module, `OneForwardOneBackwardSchedule` for one PP module) as the
+  degenerate cases of the compiled schedule, or subsume them — decide and state.
+
+### Commit 3 — converge the distributed VLM example onto the per-step plan
+- `examples/distributed/pretrain_vlm.py`: build the multimodal
+  `CornstarchExecutionPlan` per step inside `_training_step`, create the
+  per-batch schedule, run it. The plan-construction lines must be byte-identical
+  to `examples/pretrain_vlm.py` (only the execute-vs-schedule.step tail differs).
+- Demonstrate flexibility: a step whose batch lacks `pixel_values` builds a plan
+  with no vision node; vision ranks idle, LLM ranks train. Add this as the
+  motivating comment/example.
+- Smoke-check the 4-rank (or 2-rank gloo) VLM run trains end-to-end — this is the
+  acceptance signal that the cross-rank limitation is resolved.
+
+### Tests
+- A `tests/distributed/` test that builds a tiny VLM (vision encoder + LM on
+  disjoint ranks), parallelizes both via the Option C surface, builds the plan
+  per step, and asserts one forward+backward step produces a finite loss and
+  gradients on both meshes (mirror `_run_combo` in
+  `test_parallelism_integration.py`). This is the regression guard the VLM path
+  currently lacks.
+- A flexibility test: alternating batches with/without the vision modality both
+  run without error and only touch the expected parameters' grads.
+- Keep TP/PP/EP/DP numerical-equivalence green (no math change).
+
+## What you must NOT do
+- Do NOT make `cornstarch/models/multimodal/execution.py` import from
+  `cornstarch/distributed/` — the plan stays distributed-agnostic.
+- Do NOT change CP/TP/PP/EP/DP numerical behavior; this is a scheduling/ergonomics
+  change. Cross-mesh transfer must be mathematically transparent.
+- Do NOT make the non-distributed `examples/pretrain_vlm.py` depend on the
+  distributed package (convergence is distributed -> non-distributed).
+- Do NOT introduce a separate checkpoint format.
+
+## On Ambiguity
+Per CLAUDE.md: the cross-mesh rank-pairing/broadcast rule (Commit 2) is the main
+interface decision. If it is unclear how a producer mesh's output maps onto a
+consumer mesh's ranks under combined DP/TP/PP, write the interpretation under a
+BLOCK section here and stop rather than guessing.
+
+## Done Condition
+- Distributed `_training_step` builds `CornstarchExecutionPlan` per step; the
+  plan-construction code matches the non-distributed example.
+- A schedule is compiled per batch and governs all cross-rank data movement; the
+  execution plan contains zero distributed concepts.
+- The distributed VLM example trains end-to-end on disjoint modality ranks (the
+  T004 cross-rank limitation is gone); a batch without a modality idles that
+  modality's ranks.
+- New distributed VLM step + flexibility tests are green; TP/PP/EP/DP equivalence
+  unchanged; `pytest tests` green.
+- Branch pushed; PR opened against the appropriate base; this file moved to
+  `tasks/done/T005-PER-STEP-EXECUTION-PLAN.md` with the PR URL.
+
+## IMPLEMENTATION NOTES (recorded interface decision — Commit 2)
+
+The cross-mesh rank-pairing rule (the flagged ambiguity) was resolved as the
+cross-mesh analogue of a pipeline-stage boundary, encoded in `MeshLayout` +
+`CompiledSchedule` (`cornstarch/distributed/pipeline_parallel/schedule.py`):
+
+- A node executes on a rank iff that rank is in the node's owning mesh
+  (`run_modality_encoder` -> the encoder's mesh; `merge_*` and
+  `run_language_model` -> the language model's mesh). A rank with no active node
+  for a batch idles — this is the per-batch flexibility (text-only step).
+- For a cross-mesh edge `A (mesh M_A) -> B (mesh M_B)`, transfers pair
+  **data-parallel replica `d` of `M_A` with replica `d` of `M_B`** (dp size is
+  identical across modalities by construction, so each replica's batch shard
+  stays local):
+  - **Forward:** the producer *representative* of `M_A` for replica `d` — its
+    last-PP-stage `(cp=tp=ep=0)` rank — sends the feature tensor to *every*
+    first-PP-stage rank of `M_B` in replica `d`. The fan-out broadcast is needed
+    because the consuming layer needs the value replicated across the consumer's
+    TP/EP group; TP's column-parallel input is replicated in forward.
+  - **Backward:** mirrored. The consumer representative of `M_B` sends the
+    gradient back to *every* last-PP-stage rank of `M_A` in replica `d`; each
+    runs its local `backward` into the producing subgraph. Taking the gradient
+    from a single consumer representative is correct because TP all-reduces the
+    input gradient in backward (all consumer TP ranks hold the same gradient).
+- Transport reuses the PP P2P primitives, generalized to explicit global ranks
+  (`exchange_objects` in `p2p.py`). A cross-mesh edge is a graph break by design
+  (like a PP boundary): the received tensor is a fresh leaf and its gradient is
+  shipped back explicitly. The transfer is mathematically transparent — no
+  CP/TP/PP/EP/DP math changes.
+
+**Scope:** every mesh in a *multi-mesh* plan must be non-pipelined
+(`num_pp_stages == 1`); `CompiledSchedule` raises `NotImplementedError`
+otherwise. Single-mesh pipelining is unchanged (`OneForwardOneBackwardSchedule`).
+Combining intra-mesh 1F1B with cross-mesh microbatch coordination is left out
+(the VLM example default is `--llm-pp 1`). CP across a cross-mesh edge (sequence
+sharding of merged modality features) is likewise out of scope and untested.
+
+The `execution.py` invariant is preserved: it imports nothing from
+`cornstarch/distributed/`; all cross-rank logic lives in the schedule.
+
+## HUMAN COMMENTS
+- When done, PR should target `feat/T002-parallelism` branch.

--- a/tasks/done/T005-PER-STEP-EXECUTION-PLAN.md
+++ b/tasks/done/T005-PER-STEP-EXECUTION-PLAN.md
@@ -202,3 +202,6 @@ The `execution.py` invariant is preserved: it imports nothing from
 
 ## HUMAN COMMENTS
 - When done, PR should target `feat/T002-parallelism` branch.
+
+## PR
+https://github.com/cornstarch-org/Cornstarch/pull/72 (base: feat/T002-parallelism)

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -1,0 +1,280 @@
+"""Cross-mesh (disjoint-rank) multimodal training through the Option C surface.
+
+These tests cover the regression the language-only integration suite cannot: a
+VLM whose vision encoder and language model are parallelized onto **disjoint**
+rank ranges.  ``NonPipelineParallelSchedule`` runs the whole DAG on every rank,
+which fails here because the vision encoder is materialized only on the vision
+ranks (and stays ``meta`` on the language-model ranks).  ``CompiledSchedule``
+runs each node only on its owning mesh and compiles the cross-mesh transfer that
+moves the projected vision features to the ranks that consume them.
+
+Everything runs on CPU under gloo (``world_size <= 4``) so the suite stays cheap
+and offline.
+"""
+from __future__ import annotations
+
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from tests.distributed.distributed_base import GlooDistributedTestBase
+from tests.model.model_configs import clip_vision_config, llama_config
+
+from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import (
+    CornstarchExecutionPlan,
+    build_modality_encoder,
+    from_hf_config,
+)
+
+IMAGE_TOKEN_ID = 0
+
+
+def _tiny_vision_config():
+    config = clip_vision_config()
+    config.image_size = 8
+    config.patch_size = 2
+    config.num_hidden_layers = 2
+    return config
+
+
+def _build_models():
+    vision_config = _tiny_vision_config()
+    language_model = from_hf_config(
+        llama_config(), model_kind="language", attn_implementation="eager"
+    )
+    vision_encoder = from_hf_config(
+        vision_config, model_kind="vision", attn_implementation="eager"
+    )
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+    language_model.set_random_init()
+    modality_encoder.set_random_init()
+    return language_model, modality_encoder, vision_config
+
+
+def _num_vision_tokens(vision_config) -> int:
+    return (vision_config.image_size // vision_config.patch_size) ** 2 + 1
+
+
+def _make_batch(vision_config, vocab_size: int, batch_size: int = 2):
+    num_image_tokens = _num_vision_tokens(vision_config)
+    seq_len = num_image_tokens + 3
+    g = torch.Generator().manual_seed(0)
+    input_ids = torch.randint(1, vocab_size, (batch_size, seq_len), generator=g)
+    input_ids[:, :num_image_tokens] = IMAGE_TOKEN_ID
+    image_size = vision_config.image_size
+    pixel_values = torch.randn(
+        batch_size, 3, image_size, image_size, generator=g
+    )
+    return {
+        "input_ids": input_ids,
+        "labels": input_ids.clone(),
+        "pixel_values": pixel_values,
+    }
+
+
+def _build_vlm_plan(modality_encoder, language_model, batch):
+    """Build the per-step plan exactly like ``examples/pretrain_vlm.py``."""
+    plan = CornstarchExecutionPlan()
+    vision_outputs = plan.run_modality_encoder(
+        module=modality_encoder,
+        pixel_values=batch["pixel_values"],
+    )
+    merged = plan.merge_modality_encoder_outputs(
+        language_model=language_model,
+        input_ids=batch["input_ids"],
+        labels=batch["labels"],
+        modality_token_ids={"vision": IMAGE_TOKEN_ID},
+        encoder_outputs={"vision": vision_outputs},
+    )
+    language_outputs = plan.run_language_model(module=language_model, inputs=merged)
+    return plan, language_outputs
+
+
+def _build_text_only_plan(language_model, batch):
+    """A plan with no vision node — the per-batch flexibility case."""
+    plan = CornstarchExecutionPlan()
+    merged = plan.merge_modality_encoder_outputs(
+        language_model=language_model,
+        input_ids=batch["input_ids"],
+        labels=batch["labels"],
+        modality_token_ids={},
+        encoder_outputs={},
+    )
+    language_outputs = plan.run_language_model(module=language_model, inputs=merged)
+    return plan, language_outputs
+
+
+def _criterion(output, batch):
+    if isinstance(output, torch.Tensor):
+        return output
+    return output.loss if hasattr(output, "loss") else output["loss"]
+
+
+def _has_grad(module) -> bool:
+    return any(p.grad is not None for p in module.parameters())
+
+
+class TestCrossMeshVLMStep(GlooDistributedTestBase):
+    """A single forward+backward of a disjoint-rank VLM yields finite loss/grads."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_step(self) -> None:
+        language_model, modality_encoder, vision_config = _build_models()
+
+        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        plan.parallelize(
+            modality_encoder,
+            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+        )
+        plan.parallelize(
+            language_model,
+            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+        )
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+        language_model.train()
+        modality_encoder.train()
+
+        batch = _make_batch(vision_config, language_model.hf_config.vocab_size)
+
+        exec_plan, output_future = _build_vlm_plan(
+            modality_encoder, language_model, batch
+        )
+        schedule = ctx.create_schedule(exec_plan, output_future)
+
+        optimizer = torch.optim.SGD(
+            list(language_model.parameters()) + list(modality_encoder.parameters()),
+            lr=0.01,
+        )
+        result = schedule.step(batch, _criterion, optimizer, return_loss=True)
+        ctx.sync_gradients()
+
+        rank = dist.get_rank()
+        if rank == 0:
+            # Vision mesh: produces features, no loss, but receives grad back.
+            self.assertIsNone(result["loss"])
+            self.assertTrue(_has_grad(modality_encoder), "vision got no grad")
+        else:
+            # Language-model mesh: owns the output, computes a finite loss.
+            self.assertIsNotNone(result["loss"])
+            self.assertTrue(result["loss"].isfinite().all())
+            self.assertTrue(_has_grad(language_model), "language model got no grad")
+
+
+class TestCrossMeshVLMTensorParallel(GlooDistributedTestBase):
+    """Cross-mesh transfer broadcasts across the consumer's TP group and back.
+
+    The vision encoder stays single-rank (CLIP has no registered TP plan) while
+    the language model is tensor-parallel over two ranks, so the forward transfer
+    must fan the features out to *both* LM ranks and the backward must collapse
+    back to one producer.  Vision is rank 0; the LM is ranks 1 and 2.
+    """
+
+    @property
+    def world_size(self) -> int:
+        return 3
+
+    def test_step(self) -> None:
+        language_model, modality_encoder, vision_config = _build_models()
+
+        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        plan.parallelize(
+            modality_encoder,
+            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+        )
+        plan.parallelize(
+            language_model,
+            ParallelConfig(tensor_parallel_size=2, data_parallel_size=1),
+        )
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+        language_model.train()
+        modality_encoder.train()
+
+        batch = _make_batch(vision_config, language_model.hf_config.vocab_size)
+        exec_plan, output_future = _build_vlm_plan(
+            modality_encoder, language_model, batch
+        )
+        schedule = ctx.create_schedule(exec_plan, output_future)
+
+        result = schedule.step(batch, _criterion, return_loss=True)
+
+        rank = dist.get_rank()
+        if rank == 0:
+            self.assertIsNone(result["loss"])
+            self.assertTrue(_has_grad(modality_encoder), "vision got no grad")
+        else:
+            self.assertIsNotNone(result["loss"])
+            self.assertTrue(result["loss"].isfinite().all())
+            self.assertTrue(_has_grad(language_model), "language model got no grad")
+
+
+class TestCrossMeshFlexibility(GlooDistributedTestBase):
+    """Alternating image / text-only batches both train; vision idles on text."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_alternating_modalities(self) -> None:
+        language_model, modality_encoder, vision_config = _build_models()
+
+        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        plan.parallelize(
+            modality_encoder,
+            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+        )
+        plan.parallelize(
+            language_model,
+            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+        )
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+        language_model.train()
+        modality_encoder.train()
+
+        optimizer = torch.optim.SGD(
+            list(language_model.parameters()) + list(modality_encoder.parameters()),
+            lr=0.01,
+        )
+        rank = dist.get_rank()
+        vocab = language_model.hf_config.vocab_size
+
+        # --- Step 1: a batch WITH the vision modality. ---
+        optimizer.zero_grad()
+        batch = _make_batch(vision_config, vocab)
+        exec_plan, output_future = _build_vlm_plan(
+            modality_encoder, language_model, batch
+        )
+        schedule = ctx.create_schedule(exec_plan, output_future)
+        schedule.step(batch, _criterion, optimizer)
+        if rank == 0:
+            self.assertTrue(_has_grad(modality_encoder), "vision should train on image step")
+
+        # --- Step 2: a batch WITHOUT the vision modality. ---
+        optimizer.zero_grad()
+        text_batch = {
+            k: v for k, v in batch.items() if k != "pixel_values"
+        }
+        exec_plan, output_future = _build_text_only_plan(language_model, text_batch)
+        schedule = ctx.create_schedule(exec_plan, output_future)
+        result = schedule.step(text_batch, _criterion, optimizer)
+
+        if rank == 0:
+            # The vision mesh has no node this batch: it idles, no grad, no loss.
+            self.assertIsNone(result["loss"])
+            self.assertFalse(
+                _has_grad(modality_encoder), "vision should idle on a text-only step"
+            )
+        else:
+            self.assertIsNotNone(result["loss"])
+            self.assertTrue(result["loss"].isfinite().all())
+            self.assertTrue(_has_grad(language_model))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Makes `CornstarchExecutionPlan` usage identical for non-distributed and distributed training: the plan is rebuilt **per step** (a purely logical data-flow DAG, distributed-agnostic), and all knowledge of *which ranks are active* and *how data crosses ranks* is compiled **per batch** into a schedule from the plan + the `ParallelContext` meshes.

This also fixes the T004 cross-rank limitation: a VLM whose vision encoder and language model live on **disjoint** ranks now trains end-to-end (previously `NonPipelineParallelSchedule` ran the whole DAG on every rank and hit `Tensor on device cpu is not on the expected device meta!`).

## What changed
- **`p2p.py`** — extract a mesh-free `exchange_objects(send_obj, send_ranks, recv_ranks, device)` (the two-phase size+payload protocol) for cross-mesh transport; the PP class delegates to it.
- **`schedule.py`** — add `MeshLayout` (distributed-agnostic rank arithmetic for one modality, computed on every rank) and `CompiledSchedule`: runs each node only on its owning mesh and compiles cross-mesh edges into P2P transfers.
- **`parallelization.py`** — `materialize()` records a `MeshLayout` per module on every rank; `create_schedule()` returns `CompiledSchedule` for multi-mesh plans, keeping the single-mesh fast paths.
- **examples** — `pretrain_llm.py` / `pretrain_vlm.py` rebuild the plan per step inside `_training_step`; the VLM plan-construction lines are byte-identical to the non-distributed example.
- **tests** — `tests/distributed/test_multimodal_distributed.py`: cross-mesh VLM step (world=2 and world=3 consumer-TP), plus an alternating image/text-only flexibility test.

## Cross-mesh rank-pairing rule (recorded interface decision)
The cross-mesh analogue of a PP boundary: for edge `A(M_A) -> B(M_B)`, replica `d` of the producer pairs with replica `d` of the consumer. Forward, the producer representative (last-PP-stage `cp=tp=ep=0`) broadcasts the feature tensor to every first-stage rank of `M_B` in replica `d`; backward is mirrored (consumer rep -> all producer ranks). Mathematically transparent — no CP/TP/PP/EP/DP math changes. Full rationale in `tasks/done/T005-PER-STEP-EXECUTION-PLAN.md`.

**Scope:** every mesh in a multi-mesh plan must be non-pipelined; single-mesh PP is unchanged. CP across a cross-mesh edge is out of scope.

## Acceptance / testing
- `tests/distributed` — 51 passed (incl. the 3 new cross-mesh tests); TP/PP/EP/DP integration unchanged.
- `tests` (non-distributed) — 106 passed.
- `ruff check` clean.
- Smoke-checked on 2-rank gloo CPU: `pretrain_llm --tp 2` trains; `pretrain_vlm` on disjoint ranks trains end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ4nazu3FyUMBzEbmxgVL