### PR TITLE
T006: PP-driven rank co-location + ParallelConfig PP interface

### DIFF
--- a/cornstarch/distributed/parallel_config.py
+++ b/cornstarch/distributed/parallel_config.py
@@ -21,7 +21,15 @@ class ParallelConfig:
     Degrees
     -------
     - ``tensor_parallel_size`` (``tp``): DTensor column/row weight sharding.
-    - ``pipeline_parallel_size`` (``pp``): number of pipeline stages.
+    - ``pipeline_parallel_size`` (``pp``): the user's **pipeline-parallelism
+      intent**, not just a degree. ``None`` (the default) means this module is
+      **not** a pipeline stage, so it is **co-located** with the other registered
+      modules on a shared rank range (each rank runs every modality). A positive
+      integer ``k`` means the module occupies ``k`` pipeline stages and is
+      **disaggregated** onto its own rank range. All registered modules must agree
+      (all ``None`` ⇒ no pipeline parallelism; all positive ⇒ pipeline
+      parallelism); a mix is rejected by ``materialize()``. Cornstarch never
+      infers a stage count — the user states it.
     - ``context_parallel_size`` (``cp``): sequence is split across these ranks
       (data-side); requires a ``context_parallel_splitter``.
     - ``data_parallel_size`` (``dp``): replicas trained on different data shards.
@@ -34,7 +42,7 @@ class ParallelConfig:
     """
 
     tensor_parallel_size: int = 1
-    pipeline_parallel_size: int = 1
+    pipeline_parallel_size: int | None = None
     context_parallel_size: int = 1
     data_parallel_size: int = 1
     expert_parallel_size: int = 1
@@ -43,13 +51,16 @@ class ParallelConfig:
     def __post_init__(self) -> None:
         for name in (
             "tensor_parallel_size",
-            "pipeline_parallel_size",
             "context_parallel_size",
             "data_parallel_size",
             "expert_parallel_size",
         ):
             if getattr(self, name) < 1:
                 raise ValueError(f"{name} must be >= 1.")
+        # ``pipeline_parallel_size`` is ``None`` (co-locate, no PP) or a positive
+        # stage count (disaggregate); it is never < 1.
+        if self.pipeline_parallel_size is not None and self.pipeline_parallel_size < 1:
+            raise ValueError("pipeline_parallel_size must be None or >= 1.")
         if self.context_parallel_size > 1 and self.context_parallel_splitter is None:
             raise ValueError(
                 "context_parallel_splitter must be provided when "
@@ -57,10 +68,20 @@ class ParallelConfig:
             )
 
     @property
+    def uses_pipeline_parallel(self) -> bool:
+        """Whether this module is a pipeline stage (``pipeline_parallel_size`` set)."""
+        return self.pipeline_parallel_size is not None
+
+    @property
+    def num_pp_stages(self) -> int:
+        """Pipeline stage count for rank math (``None`` ⇒ 1, i.e. not pipelined)."""
+        return self.pipeline_parallel_size if self.pipeline_parallel_size is not None else 1
+
+    @property
     def ranks_per_replica(self) -> int:
         """Ranks one data-parallel replica of this modality consumes."""
         return (
-            self.pipeline_parallel_size
+            self.num_pp_stages
             * self.context_parallel_size
             * self.tensor_parallel_size
             * self.expert_parallel_size

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -72,6 +72,7 @@ class ParallelContext:
         dp_rank: int,
         dp_group: Optional[dist.ProcessGroup],
         gradient_synchronizer: Optional[GradientSynchronizer],
+        uses_pipeline_parallel: bool = False,
     ) -> None:
         self._modules = modules
         self._configs = configs
@@ -81,10 +82,21 @@ class ParallelContext:
         self._dp_rank = dp_rank
         self._dp_group = dp_group
         self._gradient_synchronizer = gradient_synchronizer
+        self._uses_pipeline_parallel = uses_pipeline_parallel
 
     # ------------------------------------------------------------------
     # Accessors
     # ------------------------------------------------------------------
+
+    @property
+    def uses_pipeline_parallel(self) -> bool:
+        """Whether modules are disaggregated into pipeline stages (vs co-located).
+
+        True iff every registered ``ParallelConfig.pipeline_parallel_size`` is a
+        positive int. When False, all modules are co-located on shared ranks and
+        the training loop runs the plan directly (no schedule).
+        """
+        return self._uses_pipeline_parallel
 
     @property
     def dp_size(self) -> int:
@@ -330,40 +342,27 @@ class ParallelizationPlan:
         world_size = len(global_ranks)
         my_rank = dist.get_rank()
 
-        ranks_per_replica = sum(cfg.ranks_per_replica for cfg in self._configs)
-        if ranks_per_replica == 0:
+        if not self._configs:
             raise ValueError("No modules registered with parallelize().")
-        if world_size % ranks_per_replica != 0:
-            raise ValueError(
-                f"world_size ({world_size}) is not divisible by the sum of "
-                f"per-modality ranks_per_replica ({ranks_per_replica})."
-            )
-        dp_size = world_size // ranks_per_replica
+
+        pipelined, dp_size, module_ranks = self._assign_ranks(
+            global_ranks, world_size
+        )
 
         for cfg in self._configs:
             if cfg.data_parallel_size != dp_size:
                 raise ValueError(
                     f"ParallelConfig.data_parallel_size={cfg.data_parallel_size} "
-                    f"does not match the computed dp_size={dp_size} "
-                    f"(world_size / sum(ranks_per_replica))."
+                    f"does not match the computed dp_size={dp_size}."
                 )
 
-        modality_sizes = [cfg.ranks_per_replica for cfg in self._configs]
         meshes: dict[int, ModalProcessGroupMesh] = {}
         layouts: dict[int, MeshLayout] = {}
 
         for mod_idx, (module, config) in enumerate(
             zip(self._modules, self._configs)
         ):
-            modality_size = modality_sizes[mod_idx]
-            modality_offset = sum(modality_sizes[:mod_idx])
-
-            modality_ranks: list[int] = []
-            for replica in range(dp_size):
-                base = replica * ranks_per_replica + modality_offset
-                modality_ranks.extend(
-                    global_ranks[base : base + modality_size]
-                )
+            modality_ranks = module_ranks[mod_idx]
 
             # Record every modality's rank layout on every rank (pure
             # arithmetic, no collectives) so the cross-mesh schedule can pair
@@ -371,7 +370,7 @@ class ParallelizationPlan:
             layouts[id(module)] = MeshLayout(
                 global_ranks=tuple(modality_ranks),
                 dp_size=dp_size,
-                num_pp_stages=config.pipeline_parallel_size,
+                num_pp_stages=config.num_pp_stages,
                 cp_size=config.context_parallel_size,
                 tp_size=config.tensor_parallel_size,
                 ep_size=config.expert_parallel_size,
@@ -386,7 +385,7 @@ class ParallelizationPlan:
                 dp_size=dp_size,
                 cp_size=config.context_parallel_size,
                 tp_size=config.tensor_parallel_size,
-                num_pp_stages=config.pipeline_parallel_size,
+                num_pp_stages=config.num_pp_stages,
                 ep_size=config.expert_parallel_size,
             )
             meshes[id(module)] = mesh
@@ -406,7 +405,7 @@ class ParallelizationPlan:
                 apply_tensor_parallel(apply_target, mesh.tp_mesh)
             if config.context_parallel_size > 1:
                 apply_context_parallel(apply_target, mesh.cp_group)
-            if config.pipeline_parallel_size > 1:
+            if config.num_pp_stages > 1:
                 apply_pipeline_parallel(apply_target, mesh)
 
             module.materialize(device, dtype=dtype)
@@ -427,7 +426,84 @@ class ParallelizationPlan:
             dp_rank=dp_rank,
             dp_group=dp_group,
             gradient_synchronizer=grad_sync,
+            uses_pipeline_parallel=pipelined,
         )
+
+    def _assign_ranks(
+        self, global_ranks: list[int], world_size: int
+    ) -> tuple[bool, int, list[list[int]]]:
+        """Classify the PP intent and assign each module its global ranks.
+
+        Returns ``(pipelined, dp_size, module_ranks)`` where ``module_ranks[i]``
+        is the replica-major rank list for module ``i``.
+
+        - **All** ``pipeline_parallel_size is None`` → not pipelined: every module
+          is **co-located** on the *same* replica rank range (each rank runs every
+          modality). Requires equal ``ranks_per_replica`` across modules.
+        - **All** positive ints → pipelined: modules are **disaggregated** onto
+          disjoint rank ranges (``sum(ranks_per_replica)`` per replica), as before.
+        - A mix is rejected.
+        """
+        pp_flags = [cfg.uses_pipeline_parallel for cfg in self._configs]
+        if all(pp_flags):
+            pipelined = True
+        elif not any(pp_flags):
+            pipelined = False
+        else:
+            named = ", ".join(
+                f"{type(m).__name__}(pipeline_parallel_size="
+                f"{c.pipeline_parallel_size})"
+                for m, c in zip(self._modules, self._configs)
+            )
+            raise ValueError(
+                "All registered modules must agree on pipeline parallelism: "
+                "either every ParallelConfig.pipeline_parallel_size is None "
+                "(co-located, no pipeline parallelism) or every one is a positive "
+                f"int (disaggregated, pipeline parallelism). Got a mix: {named}."
+            )
+
+        if pipelined:
+            ranks_per_replica = sum(cfg.ranks_per_replica for cfg in self._configs)
+            if world_size % ranks_per_replica != 0:
+                raise ValueError(
+                    f"world_size ({world_size}) is not divisible by the sum of "
+                    f"per-modality ranks_per_replica ({ranks_per_replica})."
+                )
+            dp_size = world_size // ranks_per_replica
+            sizes = [cfg.ranks_per_replica for cfg in self._configs]
+            module_ranks: list[list[int]] = []
+            for mod_idx in range(len(self._configs)):
+                size = sizes[mod_idx]
+                offset = sum(sizes[:mod_idx])
+                ranks: list[int] = []
+                for replica in range(dp_size):
+                    base = replica * ranks_per_replica + offset
+                    ranks.extend(global_ranks[base : base + size])
+                module_ranks.append(ranks)
+            return pipelined, dp_size, module_ranks
+
+        # Co-located: all modules share one replica rank range.
+        distinct = {cfg.ranks_per_replica for cfg in self._configs}
+        if len(distinct) != 1:
+            named = ", ".join(
+                f"{type(m).__name__}={c.ranks_per_replica}"
+                for m, c in zip(self._modules, self._configs)
+            )
+            raise ValueError(
+                "Co-located modules (pipeline_parallel_size=None) must have equal "
+                f"ranks_per_replica (tp*cp*ep); got {named}. Use equal tp/cp/ep, "
+                "or set a positive pipeline_parallel_size to disaggregate them."
+            )
+        ranks_per_replica = distinct.pop()
+        if world_size % ranks_per_replica != 0:
+            raise ValueError(
+                f"world_size ({world_size}) is not divisible by the shared "
+                f"co-located ranks_per_replica ({ranks_per_replica})."
+            )
+        dp_size = world_size // ranks_per_replica
+        # Every module spans the full replica layout (all ranks).
+        module_ranks = [list(global_ranks) for _ in self._configs]
+        return pipelined, dp_size, module_ranks
 
     def _build_dp_handles(
         self, meshes: dict[int, ModalProcessGroupMesh]

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -157,7 +157,15 @@ def pretrain(
     plan = ParallelizationPlan(global_ranks=list(range(world_size)))
     plan.parallelize(
         modality_encoder,
-        ParallelConfig(tensor_parallel_size=vision_tp, data_parallel_size=dp),
+        # pipeline_parallel_size=1 marks the encoder as its own pipeline stage so
+        # it is disaggregated onto its own ranks (one stage), feeding the language
+        # model — every registered module must agree on pipeline parallelism, so
+        # this is positive whenever the language model's is.
+        ParallelConfig(
+            tensor_parallel_size=vision_tp,
+            pipeline_parallel_size=1,
+            data_parallel_size=dp,
+        ),
     )
     plan.parallelize(
         language_model,

--- a/tasks/done/T006-CONFIG-PP-COLOCATION.md
+++ b/tasks/done/T006-CONFIG-PP-COLOCATION.md
@@ -1,0 +1,120 @@
+## Task ID: T006-CONFIG-PP-COLOCATION
+## Type: IMPLEMENTATION (`pytest tests` must stay green)
+## Goal: make the user's pipeline-parallelism intent **explicit** through
+`ParallelConfig.pipeline_parallel_size`, and have `ParallelizationPlan.materialize`
+assign ranks accordingly: **co-locate** all modules on shared ranks when PP is not
+used, **disaggregate** them onto disjoint rank ranges when it is. Cornstarch must
+**never infer** how many stages a module needs.
+
+## Motivation
+- Today every modality always gets a *disjoint* rank range
+  (`ranks_per_replica = sum(cfg.ranks_per_replica)`), so even a VLM with no
+  pipeline parallelism is split across meshes and a bare
+  `output_future.execute()` on an encoder-only rank hits the language model on
+  `meta`. The downstream goal (T008: "no schedule when PP is not used") needs the
+  no-PP case to run encoder→merge→LLM **locally on every rank**, i.e. modules
+  co-located.
+- Whether to co-locate or disaggregate is the user's call and must be explicit;
+  Cornstarch must not guess stage counts.
+
+## Design decision (CONFIRMED with the user)
+`ParallelConfig.pipeline_parallel_size`:
+- `None` (new default) → this module is **not** a pipeline stage → **co-locate**.
+- positive int `k` → this module occupies `k` pipeline stages → **disaggregate**.
+
+Across all registered modules (checked in `materialize`):
+- **all `None`** → no PP → every module **co-located** on the same replica rank
+  range (each rank runs every modality; `num_pp_stages == 1`).
+- **all positive** → PP used → modules **disaggregated** onto disjoint rank
+  ranges (the current `sum(ranks_per_replica)` layout).
+- **any mix** → raise a clear error.
+
+`ParallelContext` exposes **`uses_pipeline_parallel: bool`** (True iff
+disaggregated/PP) so T008's call sites can branch (schedule vs direct execute).
+
+## What you must read
+- `cornstarch/distributed/parallel_config.py`
+  (`ParallelConfig` fields, `__post_init__` validation, `ranks_per_replica`).
+- `cornstarch/distributed/parallelization.py`
+  (`ParallelizationPlan.materialize` rank math + `_build_dp_handles`;
+  `ParallelContext` accessors / `_meshes` / `_layouts`; `MeshLayout`).
+- `cornstarch/distributed/process_group_mesh.py`
+  (`ModalProcessGroupMesh` constructor: `(dp, pp, cp, tp, ep)` reshape).
+- `tests/distributed/test_parallelism_integration.py` (passes
+  `pipeline_parallel_size=pp ∈ {1,2}`),
+  `tests/distributed/test_parallelization_plan.py` (`ParallelConfig()` /
+  `ParallelConfig(tensor_parallel_size=...)` with default pp),
+  `tests/distributed/test_multimodal_distributed.py` (T005 VLM, currently
+  disjoint), `tests/distributed/test_numerical_equivalence.py`,
+  `examples/distributed/pretrain_llm.py` / `pretrain_vlm.py`.
+
+## Commits
+### Commit 1 — `ParallelConfig.pipeline_parallel_size` becomes `int | None = None`
+- `parallel_config.py`: type → `int | None`, default `None`. `__post_init__`:
+  skip the `>= 1` check when `None`; keep `>= 1` for the other sizes and for a
+  non-`None` pp. `ranks_per_replica`: treat `None` as `1`.
+- Docstring: document `None` = co-locate (no PP) vs positive = disaggregate (PP).
+
+### Commit 2 — PP-driven rank assignment + `uses_pipeline_parallel`
+- In `materialize`, classify the registered configs:
+  - all `pipeline_parallel_size is None` → **co-located**.
+  - all positive ints → **disaggregated**.
+  - mixed → `raise ValueError(...)` naming the offending modules.
+- **Disaggregated** (unchanged behavior): per-modality disjoint ranges via
+  `sum(ranks_per_replica)`, `num_pp_stages = cfg.pipeline_parallel_size`.
+- **Co-located:** all modules share one replica rank range. Require every module's
+  `ranks_per_replica` (== `tp*cp*ep`, since pp is `None`→1) to be **equal**
+  (`R`); else raise (mixed-degree co-location / replication is out of scope —
+  state it). `dp = world_size / R`. Each module's `MeshLayout`/mesh is built over
+  the **same** global ranks with `(dp, num_pp_stages=1, cp, tp, ep)`, so every
+  rank belongs to every module's mesh and materializes every module.
+- `ParallelContext`: store the mode and expose
+  `uses_pipeline_parallel: bool` (True for disaggregated). `_build_dp_handles`
+  stays correct in both modes (co-located: all meshes share the same dp group).
+- Keep `MeshLayout` (added in T005) populated for every module in both modes.
+
+### Commit 3 — converge call sites to the explicit pp interface
+- `examples/distributed/pretrain_llm.py` / `pretrain_vlm.py`: pass
+  `pipeline_parallel_size=None` when the user wants no PP (default), a positive int
+  to pipeline. (Do not change the schedule wiring here — that is T008; this commit
+  only makes the configs explicit and keeps the examples running.)
+- `tests/distributed/test_parallelism_integration.py`: the non-PP combos should
+  use `pipeline_parallel_size=None` (co-located, no PP); the PP combos keep a
+  positive value. `test_parallelization_plan.py`: `ParallelConfig()` now means
+  co-locate — adjust expectations if any.
+- `test_multimodal_distributed.py` (T005): its VLM currently relies on disjoint
+  ranks; set the configs to positive `pipeline_parallel_size` so it stays
+  disaggregated (the cross-mesh `CompiledSchedule` path is unchanged until T008).
+
+## Tests
+- `ParallelConfig`: `pipeline_parallel_size` defaults to `None`; `None` →
+  `ranks_per_replica` treats it as 1; negative/zero still rejected.
+- `materialize` mode classification: all-`None` co-located, all-positive
+  disaggregated, mixed raises; `ctx.uses_pipeline_parallel` reflects it.
+- Co-located run (gloo CPU, `world_size<=2`): a 1-module LM and a 2-module VLM
+  (equal `ranks_per_replica`) materialize every module on every rank and one
+  `execute()`+`backward()` produces finite loss + grads on every rank.
+- Co-located with unequal `ranks_per_replica` raises a clear error.
+- Existing disaggregated tests (T005 VLM, PP integration, numerical equivalence)
+  stay green.
+- `pytest tests` green.
+
+## What you must NOT do
+- Do NOT infer stage counts; only the user's `pipeline_parallel_size` decides.
+- Do NOT change CP/TP/PP/EP/DP numerical behavior.
+- Do NOT touch the schedule classes (that is T008); this task is rank assignment +
+  config only. (`create_schedule` may still be called as today by existing
+  tests/examples; leave it until T008.)
+- Do NOT import from `cornstarch_old`.
+
+## Done Condition
+- `pipeline_parallel_size` is `int | None`, default `None`, with the co-locate /
+  disaggregate / mixed-error semantics; `ctx.uses_pipeline_parallel` exposed.
+- Co-located materialization puts every module on every replica rank; the no-PP
+  VLM can run encoder→merge→LLM locally.
+- `pytest tests` green; branch pushed; PR opened against `feat/T002-parallelism`;
+  this file moved to `tasks/done/T006-CONFIG-PP-COLOCATION.md` with the PR URL.
+
+## HUMAN COMMENTS
+- PR targets `feat/T002-parallelism`; auto-merge into it after green so T007/T008
+  build cleanly (the user authorized auto-merging the prerequisites).

--- a/tasks/done/T006-CONFIG-PP-COLOCATION.md
+++ b/tasks/done/T006-CONFIG-PP-COLOCATION.md
@@ -118,3 +118,6 @@ disaggregated/PP) so T008's call sites can branch (schedule vs direct execute).
 ## HUMAN COMMENTS
 - PR targets `feat/T002-parallelism`; auto-merge into it after green so T007/T008
   build cleanly (the user authorized auto-merging the prerequisites).
+
+## PR
+https://github.com/cornstarch-org/Cornstarch/pull/73 (base: feat/T002-parallelism)

--- a/tests/distributed/test_colocation.py
+++ b/tests/distributed/test_colocation.py
@@ -1,0 +1,170 @@
+"""Co-located (no-pipeline-parallel) materialization through the Option C surface.
+
+When every ``ParallelConfig.pipeline_parallel_size`` is ``None`` the modules are
+**co-located**: every rank materializes every modality and runs the whole
+``encoder -> merge -> language model`` plan locally (no cross-rank transfer, no
+schedule).  Data parallelism replicates that across ranks.  These tests pin that
+behavior; the disaggregated (pipeline-parallel) path is covered by
+``test_parallelism_integration`` / ``test_multimodal_distributed``.
+"""
+from __future__ import annotations
+
+import unittest
+
+import torch
+import torch.distributed as dist
+
+from tests.distributed.distributed_base import GlooDistributedTestBase
+from tests.model.model_configs import clip_vision_config, llama_config
+
+from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import (
+    CornstarchExecutionPlan,
+    build_modality_encoder,
+    from_hf_config,
+)
+
+IMAGE_TOKEN_ID = 0
+
+
+def _is_materialized(module) -> bool:
+    return not any(p.is_meta for p in module.parameters())
+
+
+def _has_grad(module) -> bool:
+    return any(p.grad is not None for p in module.parameters())
+
+
+class TestColocatedLanguageModel(GlooDistributedTestBase):
+    """A no-PP LM is co-located + data-parallel: every rank holds the whole model."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_step(self) -> None:
+        model = from_hf_config(
+            llama_config(), model_kind="language", attn_implementation="eager"
+        )
+        model.set_random_init()
+
+        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        plan.parallelize(model, ParallelConfig(data_parallel_size=self.world_size))
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+
+        self.assertFalse(ctx.uses_pipeline_parallel)
+        self.assertTrue(_is_materialized(model), "model should be real on every rank")
+        model.train()
+
+        torch.manual_seed(dist.get_rank())
+        vocab = model.hf_config.vocab_size
+        batch = {
+            "input_ids": torch.randint(0, vocab, (2, 16)),
+            "labels": torch.randint(0, vocab, (2, 16)),
+        }
+
+        exec_plan = CornstarchExecutionPlan()
+        merged = exec_plan.merge_modality_encoder_outputs(
+            language_model=model,
+            input_ids=batch["input_ids"],
+            labels=batch["labels"],
+            modality_token_ids={},
+            encoder_outputs={},
+        )
+        output_future = exec_plan.run_language_model(module=model, inputs=merged)
+
+        # No schedule: run the plan directly on this rank, like the
+        # non-distributed example.
+        output = output_future.execute()
+        loss = output.loss
+        loss.backward()
+        ctx.sync_gradients()
+
+        self.assertTrue(loss.isfinite().all())
+        self.assertTrue(_has_grad(model))
+
+
+class TestColocatedVLM(GlooDistributedTestBase):
+    """A no-PP VLM co-locates encoder + LM on every rank and runs locally."""
+
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_step(self) -> None:
+        vision_config = clip_vision_config()
+        vision_config.image_size = 8
+        vision_config.patch_size = 2
+        vision_config.num_hidden_layers = 2
+
+        language_model = from_hf_config(
+            llama_config(), model_kind="language", attn_implementation="eager"
+        )
+        vision_encoder = from_hf_config(
+            vision_config, model_kind="vision", attn_implementation="eager"
+        )
+        modality_encoder = build_modality_encoder(
+            vision_encoder, language_model, modality="vision"
+        )
+        language_model.set_random_init()
+        modality_encoder.set_random_init()
+
+        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        # All pipeline_parallel_size=None -> co-located on the same ranks.
+        plan.parallelize(
+            modality_encoder, ParallelConfig(data_parallel_size=self.world_size)
+        )
+        plan.parallelize(
+            language_model, ParallelConfig(data_parallel_size=self.world_size)
+        )
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+
+        self.assertFalse(ctx.uses_pipeline_parallel)
+        # Both modalities live on every rank.
+        self.assertTrue(_is_materialized(language_model))
+        self.assertTrue(_is_materialized(modality_encoder))
+        language_model.train()
+        modality_encoder.train()
+
+        torch.manual_seed(dist.get_rank())
+        vocab = language_model.hf_config.vocab_size
+        num_image_tokens = (vision_config.image_size // vision_config.patch_size) ** 2 + 1
+        input_ids = torch.randint(1, vocab, (2, num_image_tokens + 3))
+        input_ids[:, :num_image_tokens] = IMAGE_TOKEN_ID
+        batch = {
+            "input_ids": input_ids,
+            "labels": input_ids.clone(),
+            "pixel_values": torch.randn(
+                2, 3, vision_config.image_size, vision_config.image_size
+            ),
+        }
+
+        exec_plan = CornstarchExecutionPlan()
+        vision_outputs = exec_plan.run_modality_encoder(
+            module=modality_encoder, pixel_values=batch["pixel_values"]
+        )
+        merged = exec_plan.merge_modality_encoder_outputs(
+            language_model=language_model,
+            input_ids=batch["input_ids"],
+            labels=batch["labels"],
+            modality_token_ids={"vision": IMAGE_TOKEN_ID},
+            encoder_outputs={"vision": vision_outputs},
+        )
+        output_future = exec_plan.run_language_model(
+            module=language_model, inputs=merged
+        )
+
+        # Co-located: the whole encoder -> merge -> LM plan runs locally; no
+        # cross-rank transfer, no schedule.
+        output = output_future.execute()
+        loss = output.loss
+        loss.backward()
+        ctx.sync_gradients()
+
+        self.assertTrue(loss.isfinite().all())
+        self.assertTrue(_has_grad(language_model))
+        self.assertTrue(_has_grad(modality_encoder))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -131,11 +131,11 @@ class TestCrossMeshVLMStep(GlooDistributedTestBase):
         plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
         plan.parallelize(
             modality_encoder,
-            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
         )
         plan.parallelize(
             language_model,
-            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
         )
         ctx = plan.materialize("cpu", dtype=torch.float32)
         language_model.train()
@@ -186,11 +186,11 @@ class TestCrossMeshVLMTensorParallel(GlooDistributedTestBase):
         plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
         plan.parallelize(
             modality_encoder,
-            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
         )
         plan.parallelize(
             language_model,
-            ParallelConfig(tensor_parallel_size=2, data_parallel_size=1),
+            ParallelConfig(tensor_parallel_size=2, pipeline_parallel_size=1, data_parallel_size=1),
         )
         ctx = plan.materialize("cpu", dtype=torch.float32)
         language_model.train()
@@ -227,11 +227,11 @@ class TestCrossMeshFlexibility(GlooDistributedTestBase):
         plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
         plan.parallelize(
             modality_encoder,
-            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
         )
         plan.parallelize(
             language_model,
-            ParallelConfig(tensor_parallel_size=1, data_parallel_size=1),
+            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
         )
         ctx = plan.materialize("cpu", dtype=torch.float32)
         language_model.train()

--- a/tests/distributed/test_parallelization_plan.py
+++ b/tests/distributed/test_parallelization_plan.py
@@ -32,3 +32,96 @@ def test_parallelize_accepts_cornstarch_model_and_modality_encoder() -> None:
     plan = ParallelizationPlan(global_ranks=[0])
     plan.parallelize(language_model, ParallelConfig())
     plan.parallelize(modality_encoder, ParallelConfig())
+
+
+def test_parallel_config_pipeline_parallel_size_defaults_to_none() -> None:
+    """``pipeline_parallel_size`` defaults to None (co-locate / no PP)."""
+    config = ParallelConfig()
+    assert config.pipeline_parallel_size is None
+    assert config.uses_pipeline_parallel is False
+    assert config.num_pp_stages == 1  # None counts as a single stage for rank math
+    assert config.ranks_per_replica == 1
+
+
+def test_parallel_config_positive_pipeline_parallel_size_is_pp() -> None:
+    """A positive ``pipeline_parallel_size`` means pipeline parallelism is used."""
+    config = ParallelConfig(tensor_parallel_size=2, pipeline_parallel_size=2)
+    assert config.uses_pipeline_parallel is True
+    assert config.num_pp_stages == 2
+    assert config.ranks_per_replica == 4
+
+
+def test_parallel_config_rejects_non_positive_pipeline_parallel_size() -> None:
+    """``pipeline_parallel_size`` is either None or a positive int."""
+    with pytest.raises(ValueError, match="pipeline_parallel_size"):
+        ParallelConfig(pipeline_parallel_size=0)
+
+
+def test_assign_ranks_colocates_when_no_pipeline_parallel() -> None:
+    """All-None ``pipeline_parallel_size`` co-locates every module on shared ranks."""
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    vision_encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+    plan = ParallelizationPlan(global_ranks=[0, 1])
+    plan.parallelize(modality_encoder, ParallelConfig(data_parallel_size=2))
+    plan.parallelize(language_model, ParallelConfig(data_parallel_size=2))
+
+    pipelined, dp_size, module_ranks = plan._assign_ranks([0, 1], 2)
+    assert pipelined is False
+    assert dp_size == 2
+    assert module_ranks == [[0, 1], [0, 1]]  # both modules span all ranks
+
+
+def test_assign_ranks_disaggregates_when_pipeline_parallel() -> None:
+    """All-positive ``pipeline_parallel_size`` disaggregates onto disjoint ranks."""
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    vision_encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+    plan = ParallelizationPlan(global_ranks=[0, 1])
+    plan.parallelize(
+        modality_encoder, ParallelConfig(pipeline_parallel_size=1, data_parallel_size=1)
+    )
+    plan.parallelize(
+        language_model, ParallelConfig(pipeline_parallel_size=1, data_parallel_size=1)
+    )
+
+    pipelined, dp_size, module_ranks = plan._assign_ranks([0, 1], 2)
+    assert pipelined is True
+    assert dp_size == 1
+    assert module_ranks == [[0], [1]]  # disjoint
+
+
+def test_assign_ranks_rejects_mixed_pipeline_intent() -> None:
+    """A mix of None and positive ``pipeline_parallel_size`` is rejected."""
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    vision_encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+    plan = ParallelizationPlan(global_ranks=[0, 1])
+    plan.parallelize(modality_encoder, ParallelConfig(data_parallel_size=1))
+    plan.parallelize(
+        language_model, ParallelConfig(pipeline_parallel_size=1, data_parallel_size=1)
+    )
+    with pytest.raises(ValueError, match="agree on pipeline parallelism"):
+        plan._assign_ranks([0, 1], 2)
+
+
+def test_assign_ranks_rejects_unequal_colocated_ranks_per_replica() -> None:
+    """Co-located modules must have equal ranks_per_replica (tp*cp*ep)."""
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    vision_encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    modality_encoder = build_modality_encoder(
+        vision_encoder, language_model, modality="vision"
+    )
+    plan = ParallelizationPlan(global_ranks=[0, 1])
+    plan.parallelize(modality_encoder, ParallelConfig(data_parallel_size=1))  # rpr=1
+    plan.parallelize(
+        language_model, ParallelConfig(tensor_parallel_size=2, data_parallel_size=1)
+    )  # rpr=2
+    with pytest.raises(ValueError, match="equal\\s+ranks_per_replica"):
+        plan._assign_ranks([0, 1], 2)


### PR DESCRIPTION
## Summary
First of three tasks (T006 → T007 → T008) that rework the distributed schedule layer. This one makes the user's **pipeline-parallelism intent explicit** and assigns ranks accordingly.

- `ParallelConfig.pipeline_parallel_size`: `int = 1` → **`int | None = None`**.
  - `None` (default) → module is **not** a pipeline stage → **co-locate** on shared ranks (each rank runs every modality).
  - positive int `k` → module occupies `k` pipeline stages → **disaggregate** onto its own ranks.
- `materialize()` classifies the registered configs: all-`None` ⇒ co-located, all-positive ⇒ disaggregated (the existing disjoint layout), a **mix ⇒ error**. Cornstarch never infers a stage count.
- Co-location requires equal `ranks_per_replica` across modules (else a clear error); each module's mesh is built over the same ranks with one stage.
- `ParallelContext.uses_pipeline_parallel` is exposed so a caller can branch between a schedule (PP) and a direct local run (no PP).

## Why
The downstream goal (T008: "no schedule when PP is not used") needs the no-PP case to run `encoder → merge → LLM` **locally on every rank**, which is impossible while every modality is forced onto disjoint ranks. This task provides the co-located rank assignment and the explicit switch.

## Testing
- `tests/distributed` — 60 passed (added 6 `ParallelConfig`/`_assign_ranks` unit tests + 2 gloo co-location tests; existing disaggregated PP/EP/TP/DP + cross-mesh VLM unchanged).
- `tests` (non-distributed) — 106 passed.
- `ruff check` clean.

## Scope notes
- Schedule classes are **not** touched here (that is T008); `create_schedule` still behaves as before for existing call sites.
- Mixed-degree co-location (unequal `ranks_per_replica`, e.g. vision tp=1 + llm tp=2 co-located) is intentionally rejected for now; use disaggregation (positive `pipeline_parallel_size`) for that, or equal tp/cp/ep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ4nazu3FyUMBzEbmxgVL