### PR TITLE
T007: microbatch interface via collate_fn

### DIFF
--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -131,7 +131,7 @@ class ParallelContext:
         self,
         dataset: Dataset,
         batch_size: int,
-        collate_fn: Optional[Callable[[list], dict]] = None,
+        collate_fn: Optional[Callable[[list], "dict | list[dict]"]] = None,
         *,
         shuffle: bool = False,
         cp_split_keys: Sequence[str] = _DEFAULT_CP_SPLIT_KEYS,
@@ -144,6 +144,16 @@ class ParallelContext:
         becomes a ``collate_fn`` transform that slices the sequence dimension of
         ``cp_split_keys`` for the current CP rank.  The model is never touched —
         both parallelisms live entirely in the data pipeline.
+
+        **Microbatches.** ``collate_fn`` may return either a single batch ``dict``
+        or a ``list[dict]`` — the list of microbatches for one optimizer step.
+        Returning a list is how the user controls microbatching: Cornstarch never
+        splits modality tensors itself (only the user knows, e.g., how images map
+        to samples). The loader always yields a ``list[dict]`` (a bare ``dict`` is
+        wrapped as a single-element list), and the DP/CP transforms are applied to
+        each microbatch independently. Pipeline schedules consume this list as
+        their microbatches; without pipeline parallelism the training loop
+        iterates it with gradient accumulation.
         """
         sampler = None
         if self._dp_size > 1:
@@ -162,8 +172,7 @@ class ParallelContext:
             and id(m) in self._meshes
         ]
 
-        def wrapped_collate(samples: list) -> dict:
-            batch = collate_fn(samples) if collate_fn is not None else _default_collate(samples)
+        def apply_cp_split(batch: dict) -> dict:
             for splitter, cp_group in cp_targets:
                 mask = batch.get("attention_mask")
                 if mask is None:
@@ -177,6 +186,17 @@ class ParallelContext:
                     if isinstance(value, torch.Tensor) and value.ndim >= 2:
                         batch[key] = splitter.split(value, cp_group)
             return batch
+
+        def wrapped_collate(samples: list) -> list[dict]:
+            collated = (
+                collate_fn(samples)
+                if collate_fn is not None
+                else _default_collate(samples)
+            )
+            # Normalize to a microbatch list (a bare dict = a single microbatch),
+            # then apply the DP/CP transforms per microbatch.
+            microbatches = collated if isinstance(collated, list) else [collated]
+            return [apply_cp_split(mb) for mb in microbatches]
 
         return DataLoader(
             dataset,

--- a/examples/distributed/common.py
+++ b/examples/distributed/common.py
@@ -12,7 +12,7 @@ materialize, and drive an explicit training loop with ``schedule.step``.
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Callable
 
 import torch
 import torch.distributed as dist
@@ -66,3 +66,54 @@ def causal_lm_criterion(output: Any, batch: dict[str, torch.Tensor]) -> torch.Te
     if isinstance(output, torch.Tensor):
         return output
     return output.loss if hasattr(output, "loss") else output["loss"]
+
+
+def microbatch_collate(
+    num_microbatches: int,
+    collate_fn: Callable[[list], dict] | None = None,
+) -> Callable[[list], list[dict]]:
+    """Build a ``collate_fn`` that returns a **list of ``num_microbatches``** dicts.
+
+    Microbatching is the user's responsibility (Cornstarch never splits modality
+    tensors itself), and the chosen interface is "``collate_fn`` returns a list of
+    microbatches". This helper covers the simple case where every per-sample value
+    can be split along the sample (dim 0) axis — which holds for the synthetic
+    text and one-image-per-sample datasets here. A real VLM with a varying number
+    of images per sample would write its own ``collate_fn`` that keeps each
+    sample's pixels with its text while still returning a ``list[dict]``.
+
+    ``ctx.prepare_dataloader`` applies the DP-sampler / CP-split transforms to each
+    returned microbatch independently.
+    """
+
+    def collate(samples: list) -> list[dict]:
+        batch = collate_fn(samples) if collate_fn is not None else _default_collate(samples)
+        n = len(samples)
+        # ceil division so the last microbatch absorbs any remainder.
+        per = (n + num_microbatches - 1) // num_microbatches
+        microbatches: list[dict] = []
+        for start in range(0, n, per):
+            stop = min(start + per, n)
+            microbatches.append(
+                {
+                    key: value[start:stop] if isinstance(value, torch.Tensor) else value
+                    for key, value in batch.items()
+                }
+            )
+        return microbatches
+
+    return collate
+
+
+def _default_collate(samples: list) -> dict:
+    """Stack a list of dict samples into a batch dict (tensors stacked dim 0)."""
+    keys = samples[0].keys()
+    batch: dict[str, Any] = {}
+    for key in keys:
+        values = [s[key] for s in samples]
+        batch[key] = (
+            torch.stack(values, dim=0)
+            if isinstance(values[0], torch.Tensor)
+            else torch.tensor(values)
+        )
+    return batch

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -30,6 +30,7 @@ from common import (
     FakeTextDataset,
     causal_lm_criterion,
     init_distributed,
+    microbatch_collate,
 )
 
 from cornstarch.distributed import (
@@ -44,25 +45,8 @@ from cornstarch.models import (
 )
 
 
-def _training_step(
-    language_model: Any,
-    ctx: ParallelContext,
-    batch: dict[str, torch.Tensor],
-    criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
-    optimizer: torch.optim.Optimizer,
-    num_microbatches: int,
-    microbatch_size: int,
-) -> dict[str, Any]:
-    """Build the plan for this batch, run one schedule step, and sync gradients.
-
-    Just like the non-distributed ``examples/pretrain_vlm.py``, the execution
-    plan is rebuilt **every step** — schedule construction is cheap (DAG analysis
-    plus a rank-local program, no collectives).  ``schedule.step`` runs forward +
-    criterion + backward (or the 1F1B microbatch loop under PP); then
-    ``ctx.sync_gradients`` all-reduces the DP gradients before the optimizer step.
-    Returns the schedule result whose ``"loss"`` is the step loss (``None`` on
-    non-last pipeline stages).
-    """
+def _build_plan(language_model: Any):
+    """Build the (parallelism-agnostic) execution plan for an LM step."""
     plan = CornstarchExecutionPlan()
     merged = plan.merge_modality_encoder_outputs(
         language_model=language_model,
@@ -72,14 +56,43 @@ def _training_step(
         encoder_outputs={},
     )
     output_future = plan.run_language_model(module=language_model, inputs=merged)
+    return plan, output_future
 
-    schedule = ctx.create_schedule(
-        plan,
-        output_future,
-        num_microbatches=num_microbatches,
-        microbatch_size=microbatch_size,
-    )
-    result = schedule.step(batch, criterion, optimizer, return_loss=True)
+
+def _training_step(
+    language_model: Any,
+    ctx: ParallelContext,
+    microbatches: list[dict[str, torch.Tensor]],
+    criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
+    optimizer: torch.optim.Optimizer,
+) -> dict[str, Any]:
+    """Run one optimizer step over the ``collate_fn`` microbatch list.
+
+    ``CornstarchExecutionPlan`` is parallelism-agnostic, so the only thing that
+    differs is how the microbatches are consumed:
+
+    - **No pipeline parallelism** (modules co-located on every rank): iterate the
+      microbatches, running the plan locally and accumulating gradients — exactly
+      gradient accumulation, no schedule.
+    - **Pipeline parallelism**: hand the microbatch list to the schedule (the
+      schedule wiring is completed in T008).
+
+    ``ctx.sync_gradients`` all-reduces the DP gradients before the optimizer step.
+    """
+    plan, output_future = _build_plan(language_model)
+
+    if not ctx.uses_pipeline_parallel:
+        loss_total = None
+        for mb in microbatches:
+            output = output_future.execute(inputs=mb)
+            loss = criterion(output, mb) / len(microbatches)
+            loss.backward()
+            loss_total = loss.detach() if loss_total is None else loss_total + loss.detach()
+        ctx.sync_gradients()
+        return {"loss": loss_total}
+
+    schedule = ctx.create_schedule(plan, output_future)
+    result = schedule.step(microbatches, criterion, optimizer, return_loss=True)
     ctx.sync_gradients()
     return result
 
@@ -87,7 +100,7 @@ def _training_step(
 def pretrain(
     model_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
     tp: int = 1,
-    pp: int = 1,
+    pp: int | None = None,
     cp: int = 1,
     ep: int = 1,
     dp: int = 1,
@@ -120,7 +133,13 @@ def pretrain(
     language_model.train()
 
     dataset = FakeTextDataset(language_model.hf_config.vocab_size, seq_len)
-    dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
+    # collate_fn returns the microbatch list for one optimizer step.
+    dataloader = ctx.prepare_dataloader(
+        dataset,
+        batch_size=batch_size,
+        collate_fn=microbatch_collate(num_microbatches),
+        shuffle=True,
+    )
 
     optimizer = torch.optim.Adam(language_model.parameters(), lr=lr)
     optimizer.zero_grad()
@@ -135,15 +154,13 @@ def pretrain(
     dataloader_iter = iter(dataloader)
     with tqdm(range(steps), disable=rank != 0) as pbar:
         for _ in pbar:
-            batch = next(dataloader_iter)
+            microbatches = next(dataloader_iter)
             outputs = _training_step(
                 language_model,
                 ctx,
-                batch,
+                microbatches,
                 causal_lm_criterion,
                 optimizer,
-                num_microbatches=num_microbatches if pp > 1 else 1,
-                microbatch_size=batch_size // num_microbatches if pp > 1 else 1,
             )
             loss = outputs["loss"]
             if loss is not None:

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -30,7 +30,7 @@ from torch.utils.data import Dataset
 from tqdm import tqdm
 from transformers import AutoConfig, get_linear_schedule_with_warmup
 
-from common import DTYPE, causal_lm_criterion, init_distributed
+from common import DTYPE, causal_lm_criterion, init_distributed, microbatch_collate
 
 from cornstarch.distributed import (
     ParallelConfig,
@@ -75,48 +75,60 @@ class FakeVLMDataset(Dataset):
         return {"input_ids": ids, "labels": ids.clone(), "pixel_values": pixel_values}
 
 
-def _training_step(
-    language_model: Any,
-    modality_encoder: Any,
-    ctx: ParallelContext,
-    batch: dict[str, torch.Tensor],
-    criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
-    optimizer: torch.optim.Optimizer,
-) -> dict[str, Any]:
-    """Build the plan for this batch, run one schedule step, and sync gradients.
+def _build_plan(language_model: Any, modality_encoder: Any, mb: dict):
+    """Build the (parallelism-agnostic) plan for one VLM microbatch.
 
-    The execution plan is rebuilt **every step** — the three plan-construction
-    lines below are byte-identical to the non-distributed
-    ``examples/pretrain_vlm.py``; only the ``schedule.step`` tail differs from its
-    ``output_future.execute()``.  Because the plan is rebuilt per batch, a step
-    whose ``batch`` omits ``pixel_values`` would simply drop the
-    ``run_modality_encoder("vision")`` node, and the vision encoder's ranks idle
-    for that step while the language-model ranks still train — the per-batch
-    flexibility the non-distributed plan already has.  (See
-    ``tests/distributed/test_multimodal_distributed.py`` for that flexibility
-    case on disjoint ranks.)
-
-    ``ctx.create_schedule`` returns a ``CompiledSchedule`` here because the vision
-    encoder and the language model live on **disjoint** ranks: it runs each node
-    only on its owning mesh and compiles the cross-mesh transfer that moves the
-    projected vision features to the language-model ranks that consume them.
+    The three plan-construction lines match the non-distributed
+    ``examples/pretrain_vlm.py``; ``mb`` is one microbatch from the user's
+    ``collate_fn`` list.
     """
     plan = CornstarchExecutionPlan()
     vision_outputs = plan.run_modality_encoder(
         module=modality_encoder,
-        pixel_values=batch["pixel_values"],
+        pixel_values=mb["pixel_values"],
     )
     merged = plan.merge_modality_encoder_outputs(
         language_model=language_model,
-        input_ids=batch["input_ids"],
-        labels=batch["labels"],
+        input_ids=mb["input_ids"],
+        labels=mb["labels"],
         modality_token_ids={"vision": IMAGE_TOKEN_ID},
         encoder_outputs={"vision": vision_outputs},
     )
     output_future = plan.run_language_model(module=language_model, inputs=merged)
+    return plan, output_future
 
+
+def _training_step(
+    language_model: Any,
+    modality_encoder: Any,
+    ctx: ParallelContext,
+    microbatches: list[dict[str, torch.Tensor]],
+    criterion: Callable[[Any, dict[str, torch.Tensor]], torch.Tensor],
+    optimizer: torch.optim.Optimizer,
+) -> dict[str, Any]:
+    """Run one optimizer step over the ``collate_fn`` microbatch list.
+
+    Without pipeline parallelism the encoder and language model are co-located on
+    every rank, so the whole ``encoder -> merge -> language model`` plan runs
+    locally per microbatch and gradients accumulate (no schedule). With pipeline
+    parallelism the encoder and language model are disaggregated onto separate
+    ranks and the microbatch list is driven by the schedule (wired in T008).
+    ``ctx.sync_gradients`` all-reduces the DP gradients before the optimizer step.
+    """
+    if not ctx.uses_pipeline_parallel:
+        loss_total = None
+        for mb in microbatches:
+            _, output_future = _build_plan(language_model, modality_encoder, mb)
+            output = output_future.execute()
+            loss = criterion(output, mb) / len(microbatches)
+            loss.backward()
+            loss_total = loss.detach() if loss_total is None else loss_total + loss.detach()
+        ctx.sync_gradients()
+        return {"loss": loss_total}
+
+    plan, output_future = _build_plan(language_model, modality_encoder, microbatches[0])
     schedule = ctx.create_schedule(plan, output_future)
-    result = schedule.step(batch, criterion, optimizer, return_loss=True)
+    result = schedule.step(microbatches, criterion, optimizer, return_loss=True)
     ctx.sync_gradients()
     return result
 
@@ -126,7 +138,7 @@ def pretrain(
     llm_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
     vision_tp: int = 1,
     llm_tp: int = 1,
-    llm_pp: int = 1,
+    llm_pp: int | None = None,
     dp: int = 1,
     batch_size: int = 4,
     seq_len: int = 128,
@@ -151,19 +163,18 @@ def pretrain(
     language_model.set_random_init()
     modality_encoder.set_random_init()
 
-    # Per-modality declarative configs — vision and the LLM are parallelized
-    # independently; materialize() handles the cross-modality rank assignment and
-    # materializes each modality encoder's projector alongside its encoder.
+    # Per-modality declarative configs. All modules must agree on pipeline
+    # parallelism: when ``llm_pp`` is None there is no PP and the encoder + LLM are
+    # co-located on every rank (each rank runs the whole model); when ``llm_pp`` is
+    # a positive int the encoder becomes its own leading pipeline stage
+    # (``pipeline_parallel_size=1``) disaggregated from the pipelined LLM.
+    vision_pp = 1 if llm_pp is not None else None
     plan = ParallelizationPlan(global_ranks=list(range(world_size)))
     plan.parallelize(
         modality_encoder,
-        # pipeline_parallel_size=1 marks the encoder as its own pipeline stage so
-        # it is disaggregated onto its own ranks (one stage), feeding the language
-        # model — every registered module must agree on pipeline parallelism, so
-        # this is positive whenever the language model's is.
         ParallelConfig(
             tensor_parallel_size=vision_tp,
-            pipeline_parallel_size=1,
+            pipeline_parallel_size=vision_pp,
             data_parallel_size=dp,
         ),
     )
@@ -185,7 +196,12 @@ def pretrain(
     dataset = FakeVLMDataset(
         language_model.hf_config.vocab_size, seq_len, num_image_tokens, image_size
     )
-    dataloader = ctx.prepare_dataloader(dataset, batch_size=batch_size, shuffle=True)
+    dataloader = ctx.prepare_dataloader(
+        dataset,
+        batch_size=batch_size,
+        collate_fn=microbatch_collate(num_microbatches),
+        shuffle=True,
+    )
 
     params = list(language_model.parameters()) + list(modality_encoder.parameters())
     optimizer = torch.optim.Adam(params, lr=lr)
@@ -201,12 +217,12 @@ def pretrain(
     dataloader_iter = iter(dataloader)
     with tqdm(range(steps), disable=rank != 0) as pbar:
         for _ in pbar:
-            batch = next(dataloader_iter)
+            microbatches = next(dataloader_iter)
             outputs = _training_step(
                 language_model,
                 modality_encoder,
                 ctx,
-                batch,
+                microbatches,
                 causal_lm_criterion,
                 optimizer,
             )

--- a/tasks/done/T007-MICROBATCH-COLLATE.md
+++ b/tasks/done/T007-MICROBATCH-COLLATE.md
@@ -80,3 +80,6 @@ parallelism; without PP it is plain gradient accumulation.
 ## HUMAN COMMENTS
 - PR targets `feat/T002-parallelism`; auto-merge into it after green (the user
   authorized auto-merging the prerequisites so T008 builds cleanly).
+
+## PR
+https://github.com/cornstarch-org/Cornstarch/pull/74 (base: feat/T002-parallelism)

--- a/tasks/done/T007-MICROBATCH-COLLATE.md
+++ b/tasks/done/T007-MICROBATCH-COLLATE.md
@@ -1,0 +1,82 @@
+## Task ID: T007-MICROBATCH-COLLATE
+## Type: IMPLEMENTATION (`pytest tests` must stay green)
+## Depends on: T006 (PP-driven rank co-location), merged into
+## `feat/T002-parallelism` first; branch T007 from the post-T006 base.
+## Goal: make microbatching a **user responsibility expressed through
+`collate_fn`**, so Cornstarch never has to infer how to split modality tensors
+(the old `ndim` heuristic could not handle e.g. a varying number of images per
+sample). The user's `collate_fn` returns a **`list[dict]`** — the microbatches
+for one optimizer step. Microbatching works **with or without** pipeline
+parallelism; without PP it is plain gradient accumulation.
+
+## Motivation
+- A schedule (and a non-PP training loop) must split a batch into microbatches
+  along the **sample** axis, **consistently across modalities** — a microbatch's
+  `pixel_values` must correspond to the same samples as its `input_ids`/`labels`,
+  or `merge_*`'s per-modality token/feature count check fails. Naive dim-0
+  slicing breaks when images-per-sample varies; only the user knows the mapping.
+- This mirrors the T006 principle "Cornstarch must not infer": the per-modality
+  split is the user's, supplied where they already own batch assembly —
+  `collate_fn` (already accepted by `ctx.prepare_dataloader`).
+
+## What you must read
+- `cornstarch/distributed/parallelization.py`
+  (`ParallelContext.prepare_dataloader` / `wrapped_collate` — DP sampler + CP
+  split; `sync_gradients`; the `_default_collate` helper).
+- `cornstarch/distributed/context_parallel/splitters.py`
+  (`ContextParallelSplitter.compute_offsets`/`split` — applied per microbatch).
+- `examples/distributed/pretrain_llm.py` / `pretrain_vlm.py`
+  (`_training_step`, the dataloader/`collate_fn` wiring) and
+  `examples/distributed/common.py` (`FakeTextDataset`, `causal_lm_criterion`).
+- `cornstarch/models/multimodal/execution.py`
+  (`ExecutionFuture.execute(inputs=...)` — how a per-microbatch dict is fed).
+
+## Commits
+### Commit 1 — `collate_fn` returns a microbatch list; `prepare_dataloader` honors it
+- Define the contract: `collate_fn(samples) -> list[dict]`, the list of
+  microbatches for one optimizer step. The user owns cross-modality consistency.
+- `prepare_dataloader` / `wrapped_collate`:
+  - Normalize the collate result to a list: a bare `dict` becomes `[dict]` (the
+    single-microbatch case; keeps the default `_default_collate` working).
+  - Apply the existing DP-sampler / CP-split transforms **per microbatch** in the
+    list (loop the current CP logic over each element).
+  - The `DataLoader` then yields a `list[dict]` per iteration.
+- Do not split modality tensors anywhere in Cornstarch.
+
+### Commit 2 — non-PP microbatch consumption = gradient accumulation
+- Provide the non-PP step path (used when `ctx.uses_pipeline_parallel` is False,
+  per T006): iterate the microbatch list, run
+  `output_future.execute(inputs=mb)`, `loss = criterion(out, mb) / len(list)`,
+  `loss.backward()`; after the loop, `ctx.sync_gradients()` + optimizer step.
+- Put this in the distributed examples' `_training_step` (a small local helper).
+  Keep the `CornstarchExecutionPlan` build parallelism-agnostic.
+- Add an example `collate_fn` that slices a batch into a microbatch list
+  (LLM: slice along the sample axis; VLM: keep each sample's pixels with its
+  text). Examples stop passing `num_microbatches`/`microbatch_size`.
+
+## Tests
+- `prepare_dataloader` with a `collate_fn` returning N microbatches yields a
+  `list[dict]` of length N each iteration; CP split (when configured) is applied
+  per microbatch. (Can be a small non-distributed/`world_size=1` unit test, plus
+  a CP-on gloo check if cheap.)
+- Non-PP gradient accumulation: a co-located (T006) run that processes a batch as
+  N microbatches accumulates gradients equal (within tolerance) to processing the
+  same batch whole. (gloo CPU, `world_size<=2`.)
+- `pytest tests` green.
+
+## What you must NOT do
+- Do NOT split modality tensors inside Cornstarch (no `ndim`/dim-0 heuristic).
+- Do NOT couple `num_microbatches` to anything but the `collate_fn` list length.
+- Do NOT change CP/DP numerical behavior.
+
+## Done Condition
+- `collate_fn` returning a `list[dict]` is the microbatch interface;
+  `prepare_dataloader` yields a list and applies DP/CP per microbatch.
+- Non-PP microbatched training does gradient accumulation and matches the
+  whole-batch reference.
+- `pytest tests` green; branch pushed; PR opened against `feat/T002-parallelism`;
+  this file moved to `tasks/done/T007-MICROBATCH-COLLATE.md` with the PR URL.
+
+## HUMAN COMMENTS
+- PR targets `feat/T002-parallelism`; auto-merge into it after green (the user
+  authorized auto-merging the prerequisites so T008 builds cleanly).

--- a/tests/distributed/test_microbatch.py
+++ b/tests/distributed/test_microbatch.py
@@ -1,0 +1,172 @@
+"""Microbatching through ``collate_fn`` returning a ``list[dict]``.
+
+Microbatching is the user's responsibility: ``collate_fn`` returns the list of
+microbatches for one optimizer step (Cornstarch never splits modality tensors
+itself). ``prepare_dataloader`` yields that list, applying the DP/CP transforms
+per microbatch. Without pipeline parallelism, consuming the list is plain
+gradient accumulation — which must match processing the batch whole.
+"""
+from __future__ import annotations
+
+import unittest
+
+import torch
+from torch.utils.data import Dataset
+
+from tests.distributed.distributed_base import GlooDistributedTestBase
+from tests.model.model_configs import llama_config
+
+from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import (
+    CornstarchExecutionPlan,
+    ExecutionFuture,
+    from_hf_config,
+)
+
+VOCAB = 128
+
+
+class _TextDataset(Dataset):
+    def __init__(self, length: int = 8, seq_len: int = 16) -> None:
+        self.length = length
+        self.seq_len = seq_len
+
+    def __len__(self) -> int:
+        return self.length
+
+    def __getitem__(self, index: int) -> dict:
+        g = torch.Generator().manual_seed(index)
+        ids = torch.randint(0, VOCAB, (self.seq_len,), generator=g)
+        return {"input_ids": ids, "labels": ids.clone()}
+
+
+def _split_collate(num_microbatches: int):
+    """A user ``collate_fn`` returning a list of ``num_microbatches`` dicts."""
+
+    def collate(samples: list) -> list[dict]:
+        input_ids = torch.stack([s["input_ids"] for s in samples], dim=0)
+        labels = torch.stack([s["labels"] for s in samples], dim=0)
+        chunks_i = input_ids.chunk(num_microbatches, dim=0)
+        chunks_l = labels.chunk(num_microbatches, dim=0)
+        return [
+            {"input_ids": ids, "labels": lbl}
+            for ids, lbl in zip(chunks_i, chunks_l)
+        ]
+
+    return collate
+
+
+def _build_model():
+    config = llama_config()
+    config.vocab_size = VOCAB
+    config.tie_word_embeddings = False
+    model = from_hf_config(config, model_kind="language", attn_implementation="eager")
+    model.set_random_init()
+    return model
+
+
+def _lm_plan(model):
+    plan = CornstarchExecutionPlan()
+    merged = plan.merge_modality_encoder_outputs(
+        language_model=model,
+        input_ids=ExecutionFuture("input_ids"),
+        labels=ExecutionFuture("labels"),
+        modality_token_ids={},
+        encoder_outputs={},
+    )
+    return plan.run_language_model(module=model, inputs=merged)
+
+
+class TestMicrobatchDataloader(GlooDistributedTestBase):
+    """``prepare_dataloader`` yields the user's microbatch list each iteration."""
+
+    @property
+    def world_size(self) -> int:
+        return 1
+
+    def test_yields_microbatch_list(self) -> None:
+        model = _build_model()
+        plan = ParallelizationPlan(global_ranks=[0])
+        plan.parallelize(model, ParallelConfig(data_parallel_size=1))
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+
+        loader = ctx.prepare_dataloader(
+            _TextDataset(length=8, seq_len=16),
+            batch_size=4,
+            collate_fn=_split_collate(2),
+        )
+        microbatches = next(iter(loader))
+
+        self.assertIsInstance(microbatches, list)
+        self.assertEqual(len(microbatches), 2)
+        for mb in microbatches:
+            self.assertEqual(mb["input_ids"].shape, (2, 16))
+
+    def test_bare_dict_collate_is_wrapped_as_single_microbatch(self) -> None:
+        model = _build_model()
+        plan = ParallelizationPlan(global_ranks=[0])
+        plan.parallelize(model, ParallelConfig(data_parallel_size=1))
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+
+        def dict_collate(samples: list) -> dict:
+            return {
+                "input_ids": torch.stack([s["input_ids"] for s in samples], dim=0),
+                "labels": torch.stack([s["labels"] for s in samples], dim=0),
+            }
+
+        loader = ctx.prepare_dataloader(
+            _TextDataset(length=8, seq_len=16), batch_size=4, collate_fn=dict_collate
+        )
+        microbatches = next(iter(loader))
+        self.assertIsInstance(microbatches, list)
+        self.assertEqual(len(microbatches), 1)
+
+
+class TestGradientAccumulation(GlooDistributedTestBase):
+    """Non-PP microbatch consumption == gradient accumulation == whole batch."""
+
+    @property
+    def world_size(self) -> int:
+        return 1
+
+    def test_accumulation_matches_whole_batch(self) -> None:
+        model = _build_model()
+        plan = ParallelizationPlan(global_ranks=[0])
+        plan.parallelize(model, ParallelConfig(data_parallel_size=1))
+        ctx = plan.materialize("cpu", dtype=torch.float32)
+        self.assertFalse(ctx.uses_pipeline_parallel)
+        model.train()
+
+        torch.manual_seed(0)
+        batch = {
+            "input_ids": torch.randint(0, VOCAB, (4, 16)),
+            "labels": torch.randint(0, VOCAB, (4, 16)),
+        }
+
+        # Whole batch.
+        output_future = _lm_plan(model)
+        output_future.execute(inputs=batch).loss.backward()
+        whole = {n: p.grad.detach().clone() for n, p in model.named_parameters() if p.grad is not None}
+
+        for p in model.parameters():
+            p.grad = None
+
+        # Two microbatches with scaled loss (gradient accumulation).
+        num_microbatches = 2
+        mbs = [
+            {k: v.chunk(num_microbatches, dim=0)[i] for k, v in batch.items()}
+            for i in range(num_microbatches)
+        ]
+        for mb in mbs:
+            output_future = _lm_plan(model)
+            loss = output_future.execute(inputs=mb).loss / num_microbatches
+            loss.backward()
+        accum = {n: p.grad.detach().clone() for n, p in model.named_parameters() if p.grad is not None}
+
+        self.assertEqual(set(whole), set(accum))
+        for name in whole:
+            torch.testing.assert_close(whole[name], accum[name], rtol=1e-4, atol=1e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Second of three tasks (T006 → **T007** → T008). Makes microbatching a **user responsibility expressed through `collate_fn`**, so Cornstarch never infers how to split modality tensors.

- `collate_fn` may return a **`list[dict]`** — the microbatches for one optimizer step. `prepare_dataloader` yields that list and applies the DP-sampler / CP-split transforms to each microbatch independently (a bare `dict` is wrapped as a single-element list).
- **Without pipeline parallelism** (modules co-located, from T006): the training step iterates the list, runs the plan locally per microbatch, and accumulates gradients — no schedule.
- The pipeline-parallel branch hands the same list to the schedule (wired in T008).
- Examples gain a `microbatch_collate` helper; `pipeline_parallel_size` defaults to `None` (co-located) in the example CLIs.

## Why
Naive dim-0 slicing breaks when e.g. the number of images per sample varies; only the user knows the mapping. This mirrors T006's "Cornstarch must not infer" principle.

## Testing
- `tests/distributed` — 63 passed (added 3 microbatch tests: loader yields the list / wraps a bare dict; non-PP gradient accumulation matches the whole-batch reference).
- `tests` (non-distributed) — 106 passed.
- `ruff check` clean on changed files.
- Smoke-checked the LM example on 2-rank gloo (DP=2, co-located, gradient accumulation).

## Scope notes
- Schedule classes are still **not** reworked here (T008). The pipeline-parallel example branch passes the microbatch list to the schedule, which begins consuming it in T008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ4nazu3FyUMBzEbmxgVL