### PR TITLE
T008: consolidate schedules — encoder as a leading pipeline stage

### DIFF
--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -54,9 +54,8 @@ from cornstarch.distributed.parallelization import (
 )
 from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
 from cornstarch.distributed.pipeline_parallel.schedule import (
-    CompiledSchedule,
+    BasePipelineSchedule,
     MeshLayout,
-    NonPipelineParallelSchedule,
     OneForwardOneBackwardSchedule,
     TrainingSchedule,
 )
@@ -81,9 +80,8 @@ __all__ = [
     # pipeline parallel
     "apply_pipeline_parallel",
     "TrainingSchedule",
-    "NonPipelineParallelSchedule",
+    "BasePipelineSchedule",
     "OneForwardOneBackwardSchedule",
-    "CompiledSchedule",
     "MeshLayout",
     # expert parallel
     "apply_expert_parallel",

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -31,9 +31,7 @@ from cornstarch.distributed.expert_parallel import apply_expert_parallel
 from cornstarch.distributed.parallel_config import ParallelConfig
 from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
 from cornstarch.distributed.pipeline_parallel.schedule import (
-    CompiledSchedule,
     MeshLayout,
-    NonPipelineParallelSchedule,
     OneForwardOneBackwardSchedule,
     TrainingSchedule,
 )
@@ -215,47 +213,33 @@ class ParallelContext:
         self,
         plan: "CornstarchExecutionPlan",
         output_future: "ExecutionFuture",
-        num_microbatches: int = 1,
-        microbatch_size: int = 1,
     ) -> TrainingSchedule:
-        """Return a training schedule for the given execution plan.
+        """Return the pipeline-parallel training schedule for the plan.
 
-        Schedule construction is cheap (DAG inspection + a rank-local program, no
-        collectives), so the caller is free to rebuild it per step — recovering
-        the per-batch flexibility the non-distributed plan already has.
+        Only call this when pipeline parallelism is used (``uses_pipeline_parallel``);
+        without it there are no stages and the training loop runs the plan directly
+        (``output_future.execute()`` + ``backward()`` per microbatch). The returned
+        :class:`OneForwardOneBackwardSchedule` drives the global pipeline — the
+        modality encoder(s) as leading stage(s) feeding the language-model stages,
+        with the encoder→language-model boundary crossed by the cross-mesh seam.
 
-        Selection:
-
-        - **Multiple modalities on disjoint ranks** -> :class:`CompiledSchedule`,
-          which runs each node only on its owning mesh and compiles the cross-mesh
-          transfers that move a node's output to the ranks that consume it.  This
-          is what lets a VLM train with the vision encoder and the language model
-          on separate ranks (and lets a modality idle on a batch that omits it).
-        - **A single modality with pipeline parallelism** ->
-          :class:`OneForwardOneBackwardSchedule` (1F1B) driven by that mesh.
-        - **A single modality without pipeline parallelism** ->
-          :class:`NonPipelineParallelSchedule`, which runs the whole DAG locally.
+        Construction is cheap (DAG/stage analysis + a rank-local program, no
+        collectives), so the caller may rebuild it per step. The number of
+        microbatches comes from the list passed to ``schedule.step``.
         """
-        ranksets = {
-            self._layouts[id(module)].rankset
-            for module in self._modules
-            if id(module) in self._layouts
-        }
-        if len(ranksets) > 1:
-            return CompiledSchedule(
-                plan,
-                output_future,
-                {id(module): self._layouts[id(module)] for module in self._modules},
-                self._dp_size,
+        if not self._uses_pipeline_parallel:
+            raise ValueError(
+                "create_schedule() requires pipeline parallelism. With no pipeline "
+                "parallelism the modules are co-located; run the plan directly "
+                "(output_future.execute() + backward()) per microbatch instead."
             )
-
-        for module in self._modules:
-            mesh = self._meshes.get(id(module))
-            if mesh is not None and mesh.num_stages > 1:
-                return OneForwardOneBackwardSchedule(
-                    plan, output_future, mesh, num_microbatches, microbatch_size
-                )
-        return NonPipelineParallelSchedule(plan, output_future)
+        return OneForwardOneBackwardSchedule(
+            plan,
+            output_future,
+            {id(module): self._layouts[id(module)] for module in self._modules},
+            self._meshes,
+            self._dp_size,
+        )
 
     # ------------------------------------------------------------------
     # Gradient sync

--- a/cornstarch/distributed/pipeline_parallel/schedule.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule.py
@@ -1,23 +1,36 @@
-"""Training schedules for distributed execution.
+"""Training schedules for pipeline-parallel distributed execution.
 
-Provides a unified ``step()`` interface for both pipeline-parallel (PP)
-and non-pipeline-parallel training.  Both schedules accept a
-``CornstarchExecutionPlan`` and an ``ExecutionFuture`` that describe
-the multimodal computation DAG; the schedule determines *how* to
-execute it (single-shot vs. microbatch-pipelined 1F1B).
+A schedule exists **only when pipeline parallelism is used**. Without pipeline
+parallelism the modules are co-located on every rank and the training loop runs
+the execution plan directly (``output_future.execute()`` + ``backward()``),
+accumulating gradients over the user's ``collate_fn`` microbatch list — no
+schedule is involved.
+
+When pipeline parallelism is used the modules are disaggregated onto disjoint
+rank ranges and form a pipeline:
+
+- each **modality encoder is a leading pipeline stage** (one stage; intra-encoder
+  pipelining is out of scope), feeding
+- the **language-model stages** (``merge`` runs on the first language-model
+  stage; the language model is pipelined across the rest).
+
+The boundary between the encoder mesh and the language-model mesh is a
+pipeline-stage boundary — a *seam* — crossed with the same point-to-point
+transport as an ordinary stage hop, but with the cross-mesh rank pairing
+(producer representative broadcasts to the consumer's first-stage TP/EP group;
+mirrored on the backward).
 
 ``TrainingSchedule``
-    Abstract base: execute one forward-backward training step.
+    Abstract base: ``step(microbatches, criterion, optimizer)`` runs one
+    forward-backward training step over a list of microbatches.
 
-``NonPipelineParallelSchedule``
-    Executes the full DAG on every rank in a single forward pass,
-    then runs backward.  Used when PP is disabled.
+``BasePipelineSchedule``
+    Builds, for this rank, its place in the global pipeline (which stage it owns,
+    how it forwards, and how it communicates with its neighbors), and the shared
+    forward/backward microbatch machinery. Subclasses implement the ordering.
 
 ``OneForwardOneBackwardSchedule``
-    Splits the batch into microbatches and pipelines them across PP
-    stages using the 1F1B schedule.  Pre-pipeline nodes (modality
-    encoders, merge) run on the first stage; the language model is
-    pipelined across stages.
+    The 1F1B ordering (warmup / steady / cooldown).
 """
 from __future__ import annotations
 
@@ -27,7 +40,6 @@ from typing import Any, Callable
 
 import torch
 import torch.distributed as dist
-import torch.nn as nn
 from torch.optim import Optimizer
 
 from cornstarch.distributed.pipeline_parallel.p2p import (
@@ -38,7 +50,6 @@ from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.models.multimodal.execution import (
     CornstarchExecutionPlan,
     ExecutionFuture,
-    ExecutionNode,
     _first_output_tensor,
 )
 
@@ -89,17 +100,6 @@ def _retain_grad(obj: Any) -> None:
     _tree_map(_rg, obj)
 
 
-def _get_micro_batch(batch: Any, offset: int, size: int) -> Any:
-    """Slice a micro-batch from ``batch`` along dimension 0."""
-    if isinstance(batch, torch.Tensor):
-        return batch[offset : offset + size]
-    if isinstance(batch, dict):
-        return {k: _get_micro_batch(v, offset, size) for k, v in batch.items()}
-    if isinstance(batch, (list, tuple)):
-        return type(batch)(_get_micro_batch(v, offset, size) for v in batch)
-    return batch
-
-
 def _merge_batch(batches: list[Any], dim: int = 0) -> Any:
     """Concatenate a list of batches along ``dim``."""
     if not batches:
@@ -111,21 +111,12 @@ def _merge_batch(batches: list[Any], dim: int = 0) -> Any:
     return batches
 
 
-def _model_forward(
-    model: nn.Module,
-    micro_batch: dict,
-    input_obj: Any | None,
-) -> Any:
-    """Merge ``input_obj`` into ``micro_batch`` and call the model."""
-    kwargs = dict(micro_batch) if isinstance(micro_batch, dict) else {"input": micro_batch}
-    if input_obj is not None:
-        if isinstance(input_obj, dict):
-            for k in input_obj:
-                kwargs.pop(k, None)
-            kwargs.update(input_obj)
-        else:
-            kwargs["hidden_states"] = input_obj
-    return model(**kwargs)
+def _default_device() -> torch.device:
+    return (
+        torch.device(f"cuda:{torch.cuda.current_device()}")
+        if torch.cuda.is_available() and torch.cuda.device_count() > 0
+        else torch.device("cpu")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -135,362 +126,23 @@ def _model_forward(
 class TrainingSchedule(ABC):
     """Execute one forward-backward training step and return results.
 
-    Subclasses implement ``step()`` which runs forward, computes loss,
-    runs backward, and returns a dict with ``"loss"`` and ``"outputs"``.
-    The caller is responsible for gradient synchronization, optimizer
-    step, and zeroing gradients after ``step()`` returns.
+    ``step`` takes the list of microbatches for one optimizer step (the value the
+    user's ``collate_fn`` returns), runs forward + loss + backward across the
+    pipeline, and returns a dict with ``"loss"`` (accumulated on the last stage,
+    ``None`` elsewhere) and ``"outputs"``. The caller owns gradient
+    synchronization and the optimizer step.
     """
 
     @abstractmethod
     def step(
         self,
-        batch: dict[str, torch.Tensor],
+        microbatches: list[dict[str, torch.Tensor]],
         criterion: Callable[..., Any],
         optimizer: Optimizer | None = None,
         return_loss: bool = True,
         return_outputs: bool = False,
     ) -> dict:
-        """Execute one training step.
-
-        Returns a dict with:
-        - ``"loss"``: accumulated loss tensor or ``None``
-        - ``"outputs"``: per-microbatch outputs or ``None``
-        """
-
-
-# ---------------------------------------------------------------------------
-# Non-PP schedule
-# ---------------------------------------------------------------------------
-
-class NonPipelineParallelSchedule(TrainingSchedule):
-    """Executes the full execution plan DAG on every rank, then backward.
-
-    Used when pipeline parallelism is disabled.  The entire multimodal
-    computation (encoder → merge → language model) runs in a single
-    forward pass on each rank, followed by a single backward pass.
-    """
-
-    def __init__(
-        self,
-        plan: CornstarchExecutionPlan,
-        output_future: ExecutionFuture,
-    ) -> None:
-        self._plan = plan
-        self._output_future = output_future
-
-    def step(
-        self,
-        batch: dict[str, torch.Tensor],
-        criterion: Callable[..., Any],
-        optimizer: Optimizer | None = None,
-        return_loss: bool = True,
-        return_outputs: bool = False,
-    ) -> dict:
-        output = self._output_future.execute(inputs=batch)
-        loss = criterion(output, batch)
-        loss.backward()
-        return {
-            "loss": loss.detach() if return_loss else None,
-            "outputs": output if return_outputs else None,
-        }
-
-
-# ---------------------------------------------------------------------------
-# PP stage model auto-built from the DAG
-# ---------------------------------------------------------------------------
-
-class _StageModel(nn.Module):
-    """Stage-aware model auto-built from execution plan nodes.
-
-    On the first PP stage, executes all pre-pipeline nodes (modality
-    encoders, merge) using the execution plan's node-execution logic,
-    then runs the language model.  On later stages, passes received
-    hidden states directly to the language model.
-    """
-
-    def __init__(
-        self,
-        plan: CornstarchExecutionPlan,
-        pre_pipeline_nodes: list[ExecutionNode],
-        language_model_node: ExecutionNode,
-        is_first_stage: bool,
-    ) -> None:
-        super().__init__()
-        self._plan = plan
-        self._pre_pipeline_nodes = pre_pipeline_nodes
-        self._lm_node = language_model_node
-        self._is_first_stage = is_first_stage
-
-    def forward(self, **kwargs) -> Any:
-        if "hidden_states" in kwargs:
-            # Non-first PP stage: received hidden_states from P2P.
-            # Pass through to the LM which has a PipelineParallelForwardSpec
-            # that extracts hidden_states in embed_inputs().
-            lm = self._lm_node.params["module"]
-            return lm(**kwargs)
-
-        # First PP stage (or single-stage): execute pre-pipeline nodes
-        # (encoders, merge) then the LM node.
-        values: dict[str, Any] = dict(kwargs)
-        for node in self._pre_pipeline_nodes:
-            values[node.name] = CornstarchExecutionPlan._execute_node(node, values)
-        return CornstarchExecutionPlan._execute_node(self._lm_node, values)
-
-
-# ---------------------------------------------------------------------------
-# 1F1B PP schedule
-# ---------------------------------------------------------------------------
-
-class OneForwardOneBackwardSchedule(TrainingSchedule):
-    """Pipeline-parallel 1F1B schedule driven by a CornstarchExecutionPlan.
-
-    Inspects the execution plan's DAG to identify pre-pipeline nodes
-    (modality encoders, merge) and the pipeline node (language model),
-    then auto-builds a stage-aware model wrapper.  The schedule splits
-    the batch into microbatches and pipelines them across PP stages
-    using the standard 1F1B pattern: warmup, steady state, cooldown.
-    """
-
-    def __init__(
-        self,
-        plan: CornstarchExecutionPlan,
-        output_future: ExecutionFuture,
-        mesh: ModalProcessGroupMesh,
-        num_microbatches: int,
-        microbatch_size: int,
-    ) -> None:
-        self._mesh = mesh
-        self._comm = PipelineP2PCommunication(mesh)
-        self._num_microbatches = num_microbatches
-        self._microbatch_size = microbatch_size
-
-        # Split DAG into pre-pipeline and pipeline nodes.
-        nodes = plan._topological_nodes(output_future.name)
-        lm_node = next(n for n in nodes if n.kind == "run_language_model")
-        pre_nodes = [n for n in nodes if n.kind != "run_language_model"]
-
-        self._stage_model = _StageModel(
-            plan, pre_nodes, lm_node, mesh.is_first_stage()
-        )
-
-    def step(
-        self,
-        batch: dict[str, torch.Tensor],
-        criterion: Callable[..., Any],
-        optimizer: Optimizer | None = None,
-        return_loss: bool = True,
-        return_outputs: bool = False,
-    ) -> dict:
-        """Execute one 1F1B training step (forward + backward)."""
-        self._batch = batch
-        self._microbatch_offset = 0
-        return self._run_1f1b(criterion, optimizer, return_loss, return_outputs)
-
-    # ------------------------------------------------------------------
-    # Microbatch management
-    # ------------------------------------------------------------------
-
-    def _load_micro_batch(self) -> Any:
-        mb = _get_micro_batch(
-            self._batch, self._microbatch_offset, self._microbatch_size
-        )
-        self._microbatch_offset += self._microbatch_size
-        return mb
-
-    # ------------------------------------------------------------------
-    # Forward / backward steps
-    # ------------------------------------------------------------------
-
-    def _forward_step(
-        self,
-        input_obj: Any | None,
-        criterion: Callable,
-        accum_loss: torch.Tensor | None = None,
-        outputs: list[Any] | None = None,
-    ) -> Any:
-        """Run one micro-batch forward and compute loss on the last stage."""
-        micro_batch = self._load_micro_batch()
-
-        if input_obj is not None and isinstance(micro_batch, dict):
-            if isinstance(input_obj, dict):
-                for k in input_obj:
-                    micro_batch.pop(k, None)
-
-        output_obj = _model_forward(self._stage_model, micro_batch, input_obj)
-
-        if self._mesh.is_last_stage():
-            loss = criterion(output_obj, micro_batch) / self._num_microbatches
-            if accum_loss is not None:
-                accum_loss.add_(loss.detach())
-            if outputs is not None:
-                outputs.append(_detach(output_obj))
-            return loss
-
-        return output_obj
-
-    def _backward_step(
-        self,
-        optimizer: Optimizer | None,
-        input_obj: Any | None,
-        output_obj: Any,
-        output_obj_grad: Any | None,
-    ) -> Any | None:
-        """Run one micro-batch backward and return input gradients."""
-        _retain_grad(input_obj)
-
-        if output_obj_grad is None:
-            output_obj.backward()
-        else:
-            keys = None
-            if isinstance(output_obj, dict):
-                keys = output_obj.get("backward_tensor_keys") or list(
-                    output_obj_grad.keys()
-                )
-            if keys is not None:
-                tensors = [output_obj[k] for k in keys if isinstance(output_obj[k], torch.Tensor)]
-                grads = [output_obj_grad[k] for k in keys if isinstance(output_obj[k], torch.Tensor)]
-                if len(tensors) == 1:
-                    torch.autograd.backward(tensors[0], grads[0])
-                else:
-                    torch.autograd.backward(tensors, grads)
-            else:
-                torch.autograd.backward(output_obj, output_obj_grad)
-
-        input_obj_grad: dict | None = None
-        if input_obj is not None:
-            input_obj_grad = {}
-            if isinstance(input_obj, dict):
-                for k, v in input_obj.items():
-                    if isinstance(v, torch.Tensor) and v.grad is not None:
-                        input_obj_grad[k] = v.grad
-            elif isinstance(input_obj, torch.Tensor) and input_obj.grad is not None:
-                input_obj_grad = input_obj.grad
-
-        return input_obj_grad
-
-    # ------------------------------------------------------------------
-    # P2P wrappers
-    # ------------------------------------------------------------------
-
-    def _recv_forward(self) -> Any | None:
-        if self._mesh.is_first_stage():
-            return None
-        return self._comm.recv_forward()
-
-    def _recv_backward(self) -> Any | None:
-        if self._mesh.is_last_stage():
-            return None
-        return self._comm.recv_backward()
-
-    def _send_forward(self, output: Any) -> None:
-        if self._mesh.is_last_stage():
-            return
-        self._comm.send_forward(output)
-
-    def _send_backward(self, grad: Any) -> None:
-        if self._mesh.is_first_stage():
-            return
-        self._comm.send_backward(grad)
-
-    def _send_forward_recv_backward(
-        self, output: Any, send_first: bool = True
-    ) -> Any | None:
-        if self._mesh.is_last_stage():
-            return None
-        return self._comm.send_forward_recv_backward(output, send_first)
-
-    def _send_backward_recv_forward(
-        self, grad: Any, send_first: bool = True
-    ) -> Any | None:
-        if self._mesh.is_first_stage():
-            return None
-        return self._comm.send_backward_recv_forward(grad, send_first)
-
-    # ------------------------------------------------------------------
-    # Main 1F1B loop
-    # ------------------------------------------------------------------
-
-    def _run_1f1b(
-        self,
-        criterion: Callable[..., Any],
-        optimizer: Optimizer | None,
-        return_loss: bool,
-        return_outputs: bool,
-    ) -> dict:
-        num_warmup = min(
-            self._mesh.num_stages - self._mesh.stage - 1,
-            self._num_microbatches,
-        )
-        num_steady = self._num_microbatches - num_warmup
-
-        input_objs: list[Any] = []
-        output_objs: list[Any] = []
-
-        # Accumulate the loss on the same device the batch (and hence the
-        # model output) lives on, rather than assuming CUDA whenever a GPU is
-        # visible — the gloo CPU tests run the model on CPU even with a GPU
-        # present.
-        device = _first_tensor_device(self._batch)
-        if device is None:
-            device = (
-                torch.device(f"cuda:{torch.cuda.current_device()}")
-                if torch.cuda.is_available() and torch.cuda.device_count() > 0
-                else torch.device("cpu")
-            )
-
-        accum_loss: torch.Tensor | None = None
-        if return_loss and self._mesh.is_last_stage():
-            accum_loss = torch.zeros(1, device=device)
-
-        outputs: list[Any] | None = (
-            [] if return_outputs and self._mesh.is_last_stage() else None
-        )
-
-        # Warmup: later stages fill their activation buffers.
-        for _ in range(num_warmup):
-            input_obj = self._recv_forward()
-            output_obj = self._forward_step(input_obj, criterion, accum_loss, outputs)
-            self._send_forward(output_obj)
-            input_objs.append(input_obj)
-            output_objs.append(output_obj)
-
-        # Steady state: alternate one forward, one backward.
-        if num_steady > 0:
-            input_obj = self._recv_forward()
-
-        for i in range(num_steady):
-            last = i == num_steady - 1
-            output_obj = self._forward_step(input_obj, criterion, accum_loss, outputs)
-            output_obj_grad = self._send_forward_recv_backward(
-                output_obj, send_first=(self._mesh.stage % 2 == 0)
-            )
-            input_objs.append(input_obj)
-            output_objs.append(output_obj)
-
-            input_obj = input_objs.pop(0)
-            output_obj = output_objs.pop(0)
-            input_obj_grad = self._backward_step(optimizer, input_obj, output_obj, output_obj_grad)
-
-            if last:
-                self._send_backward(input_obj_grad)
-            else:
-                input_obj = self._send_backward_recv_forward(
-                    input_obj_grad,
-                    send_first=(self._mesh.stage % 2 == 0),
-                )
-
-        # Cooldown: earlier stages drain remaining backwards.
-        for _ in range(num_warmup):
-            input_obj = input_objs.pop(0)
-            output_obj = output_objs.pop(0)
-            output_obj_grad = self._recv_backward()
-            input_obj_grad = self._backward_step(optimizer, input_obj, output_obj, output_obj_grad)
-            self._send_backward(input_obj_grad)
-
-        return {
-            "loss": accum_loss,
-            "outputs": _merge_batch(outputs) if outputs is not None else None,
-        }
+        ...
 
 
 # ---------------------------------------------------------------------------
@@ -503,13 +155,11 @@ class MeshLayout:
 
     A ``ModalProcessGroupMesh`` is only *constructed* on the ranks that belong to
     its modality, so a rank cannot ask another modality's mesh which global ranks
-    it owns.  The cross-mesh schedule needs exactly that — to compile a transfer
-    it must know, on *every* rank, where a producing modality's output lives and
-    which consuming-modality ranks need it.  ``MeshLayout`` is that purely
-    arithmetic description (no process groups, no collectives): it is computed for
-    *every* registered module on *every* rank from the same ``(dp, pp, cp, tp,
-    ep)`` reshape the mesh itself uses, so producer and consumer independently
-    derive the same rank pairing.
+    it owns. The seam between an encoder mesh and the language-model mesh needs
+    exactly that — to pair producer and consumer ranks it must know, on *every*
+    rank, where each modality lives. ``MeshLayout`` is that purely arithmetic
+    description (no process groups, no collectives), computed for every module on
+    every rank from the same ``(dp, pp, cp, tp, ep)`` reshape the mesh uses.
     """
 
     global_ranks: tuple[int, ...]
@@ -520,8 +170,6 @@ class MeshLayout:
     ep_size: int
 
     def _flat_index(self, dp: int, pp: int, cp: int, tp: int, ep: int) -> int:
-        # Mirror ModalProcessGroupMesh's (dp, pp, cp, tp, ep) replica-major /
-        # EP-minor reshape so the same coordinate resolves to the same rank.
         return (
             (((dp * self.num_pp_stages + pp) * self.cp_size + cp) * self.tp_size + tp)
             * self.ep_size
@@ -551,52 +199,24 @@ class MeshLayout:
 
 
 # ---------------------------------------------------------------------------
-# Compiled cross-mesh schedule
+# Base pipeline schedule
 # ---------------------------------------------------------------------------
 
-class CompiledSchedule(TrainingSchedule):
-    """Runs a multi-mesh execution DAG, compiling cross-mesh transfers per batch.
+class BasePipelineSchedule(TrainingSchedule):
+    """Drive an execution plan across a pipeline that may span several meshes.
 
-    This is the schedule used when an execution plan spans modalities that live
-    on **disjoint** rank ranges (Option C gives each modality its own slice of
-    the world).  ``NonPipelineParallelSchedule`` runs the *whole* DAG on every
-    rank, which breaks here: a modality's module is materialized only on its own
-    ranks and stays ``meta`` elsewhere, so running e.g. the vision encoder on the
-    language-model ranks raises a device error.
+    The global pipeline is ``[encoder stages..., language-model stages...]``. This
+    rank owns exactly one global stage (the meshes are disjoint): an encoder rank
+    owns its encoder's leading stage; a language-model rank owns its language-model
+    pipeline stage. The base class resolves that placement, runs this rank's stage
+    forward/backward per microbatch, and moves activations to its neighbors —
+    using ordinary pipeline P2P for an intra-mesh hop and the cross-mesh *seam*
+    transport for the encoder→language-model boundary. Subclasses choose the
+    microbatch ordering (1F1B, etc.).
 
-    The plan stays a purely logical data-flow DAG (it knows nothing about ranks).
-    The schedule compiles, from that DAG plus the per-module :class:`MeshLayout`
-    map, a rank-local program:
-
-    - **Node activation.** A rank executes a node iff it belongs to that node's
-      owning mesh; otherwise the node is a no-op on that rank.  A modality whose
-      node is absent from this batch's plan (e.g. a text-only step) simply idles
-      on its ranks — that is how per-batch flexibility falls out for free.
-    - **Cross-mesh edges.** When a node ``A`` on mesh ``M_A`` produces a value
-      consumed by node ``B`` on a different mesh ``M_B``, a transfer is inserted.
-      The rank pairing is the cross-mesh analogue of a pipeline-stage boundary:
-
-        * Forward: the producer **representative** of ``M_A`` for data-parallel
-          replica ``d`` — its last-pipeline-stage ``(cp=tp=ep=0)`` rank — sends
-          the feature tensor to *every* first-pipeline-stage rank of ``M_B`` in
-          replica ``d`` (a broadcast, since the consuming layer needs the value
-          replicated across the consumer's TP/EP group).
-        * Backward: mirrored.  The consumer representative of ``M_B`` sends the
-          gradient back to every last-stage rank of ``M_A`` in replica ``d``;
-          each runs its local ``backward`` into the producing subgraph.
-
-      Replica ``d`` of the producer always pairs with replica ``d`` of the
-      consumer (DP size is identical across modalities by construction), so each
-      replica's batch shard stays on its own ranks.
-
-    Cross-mesh transfer is a graph break by design (like a PP boundary): the
-    received tensor is a fresh leaf, and the gradient is shipped back explicitly.
-    It is mathematically transparent — no parallelism math changes.
-
-    Scope: every mesh in a multi-mesh plan must be non-pipelined
-    (``num_pp_stages == 1``).  Single-mesh pipelining keeps using
-    :class:`OneForwardOneBackwardSchedule`; combining intra-mesh 1F1B with
-    cross-mesh microbatch coordination is intentionally left out.
+    The plan stays parallelism-agnostic; all rank/stage/transport knowledge lives
+    here. The transfer is mathematically transparent — it is a graph break (like
+    any pipeline boundary), with the gradient shipped back explicitly.
     """
 
     def __init__(
@@ -604,6 +224,7 @@ class CompiledSchedule(TrainingSchedule):
         plan: CornstarchExecutionPlan,
         output_future: ExecutionFuture,
         layouts: dict[int, MeshLayout],
+        meshes: dict[int, ModalProcessGroupMesh],
         dp_size: int,
     ) -> None:
         self._plan = plan
@@ -611,176 +232,423 @@ class CompiledSchedule(TrainingSchedule):
         self._layouts = layouts
         self._dp_size = dp_size
         self._my_rank = dist.get_rank()
+        self._device: torch.device | None = None
 
-        for layout in layouts.values():
-            if layout.num_pp_stages > 1:
-                raise NotImplementedError(
-                    "CompiledSchedule (multi-mesh execution across disjoint "
-                    "modality ranks) does not support pipeline parallelism inside "
-                    "a modality yet; got a mesh with "
-                    f"num_pp_stages={layout.num_pp_stages}. Use pipeline "
-                    "parallelism only for a single-mesh (language-model-only) plan."
-                )
+        nodes = plan._topological_nodes(output_future.name)
+        self._encoder_nodes = [n for n in nodes if n.kind == "run_modality_encoder"]
+        self._merge_node = next(
+            (n for n in nodes if n.kind == "merge_modality_encoder_outputs"), None
+        )
+        self._lm_node = next(n for n in nodes if n.kind == "run_language_model")
+
+        self._lm_layout = layouts[id(self._lm_node.params["module"])]
+        self._num_encoders = len(self._encoder_nodes)
+        self._num_stages = self._num_encoders + self._lm_layout.num_pp_stages
+
+        # Resolve this rank's role and global stage index.
+        self._role: str | None = None
+        self._encoder_index = -1
+        for index, node in enumerate(self._encoder_nodes):
+            if self._my_rank in layouts[id(node.params["module"])].rankset:
+                self._role = "encoder"
+                self._encoder_index = index
+                self._encoder_node = node
+                self._encoder_layout = layouts[id(node.params["module"])]
+                self._stage = index
+                break
+        if self._role is None and self._my_rank in self._lm_layout.rankset:
+            self._role = "llm"
+            self._lm_mesh = meshes[id(self._lm_node.params["module"])]
+            self._lm_comm = PipelineP2PCommunication(self._lm_mesh)
+            self._lm_stage = self._lm_mesh.stage
+            self._stage = self._num_encoders + self._lm_stage
+
+        # A rank with no stage in *this* batch's plan idles (e.g. the encoder
+        # ranks on a text-only step, whose plan has no run_modality_encoder node).
+        # Every rank derives the same plan from the same batch, so the active
+        # ranks never wait on a transfer from an idle one.
+        self._idle = self._role is None
+
+        # Cross-mesh seam between the (single) leading encoder and LM stage 0.
+        # The seam pairs the producing encoder with the language model; multiple
+        # encoders feeding one merge as parallel leading stages is out of scope.
+        self._has_encoder = self._num_encoders > 0
+        if self._has_encoder:
+            self._seam_producer = layouts[
+                id(self._encoder_nodes[0].params["module"])
+            ]
+            # The merge consumes the encoder output under this future name.
+            self._encoder_output_name = self._encoder_nodes[0].name
+
+        self._modality_token_ids: dict[str, int] = (
+            dict(self._merge_node.params.get("modality_token_ids", {}))
+            if self._merge_node is not None
+            else {}
+        )
 
     # ------------------------------------------------------------------
-    # Node -> owning mesh resolution
+    # Stage semantics
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _node_module(node: ExecutionNode) -> Any:
-        """Return the module whose mesh owns ``node``.
+    @property
+    def num_stages(self) -> int:
+        return self._num_stages
 
-        The merge node embeds text with the language model, so it belongs to the
-        language model's mesh; encoder/LM nodes carry their module directly.
+    @property
+    def stage(self) -> int:
+        return self._stage
+
+    def is_first_stage(self) -> bool:
+        return self._stage == 0
+
+    def is_last_stage(self) -> bool:
+        return self._stage == self._num_stages - 1
+
+    def _at_llm_first_stage(self) -> bool:
+        return self._role == "llm" and self._lm_stage == 0
+
+    def _seam_on_recv(self) -> bool:
+        """This rank receives its forward input across the seam (LM stage 0)."""
+        return self._at_llm_first_stage() and self._has_encoder
+
+    def _seam_on_send(self) -> bool:
+        """This rank sends its forward output across the seam (the encoder)."""
+        return self._role == "encoder"
+
+    # ------------------------------------------------------------------
+    # Forward computation for this rank's stage
+    # ------------------------------------------------------------------
+
+    def _mask_modality_labels(self, microbatch: dict) -> dict:
+        """Return ``microbatch`` with modality-token label positions set to -100.
+
+        Under pipeline parallelism the last language-model stage computes the loss
+        from the microbatch labels rather than from ``merge``'s output, so it
+        recomputes the same mask locally (every rank has the microbatch and the
+        plan). A no-op when there are no modality tokens (text-only / LM-only).
         """
-        if node.kind == "merge_modality_encoder_outputs":
-            return node.params["language_model"]
-        return node.params["module"]
+        if not self._modality_token_ids or "input_ids" not in microbatch:
+            return microbatch
+        input_ids = microbatch["input_ids"]
+        labels = microbatch.get("labels")
+        if labels is None:
+            return microbatch
+        token_mask = torch.zeros_like(input_ids, dtype=torch.bool)
+        for token_id in self._modality_token_ids.values():
+            token_mask |= input_ids == int(token_id)
+        masked = dict(microbatch)
+        masked["labels"] = labels.masked_fill(token_mask, -100)
+        return masked
 
-    def _node_layout(self, node: ExecutionNode) -> MeshLayout:
-        return self._layouts[id(self._node_module(node))]
+    def _forward_compute(self, microbatch: dict, input_obj: Any | None) -> Any:
+        """Run this rank's stage forward and return its output activation/result."""
+        if self._role == "encoder":
+            output = CornstarchExecutionPlan._execute_node(
+                self._encoder_node, dict(microbatch)
+            )
+            return _first_output_tensor(output)
+
+        # Language-model role.
+        if self._lm_stage == 0:
+            values = self._mask_modality_labels(microbatch)
+            values = dict(values)
+            if self._has_encoder:
+                # ``input_obj`` is the feature tensor received across the seam.
+                values[self._encoder_output_name] = input_obj
+            merged = CornstarchExecutionPlan._execute_node(self._merge_node, values)
+            values[self._merge_node.name] = merged
+            return CornstarchExecutionPlan._execute_node(self._lm_node, values)
+
+        # Later language-model stage: merge the received activation (a dict of
+        # pipelined tensors, or a bare hidden_states tensor) into the kwargs and
+        # run this stage. The forward spec consumes hidden_states and ignores
+        # input_ids off the first stage; labels are used only on the last stage.
+        kwargs = dict(self._mask_modality_labels(microbatch))
+        if isinstance(input_obj, dict):
+            for key in input_obj:
+                kwargs.pop(key, None)
+            kwargs.update(input_obj)
+        elif input_obj is not None:
+            kwargs["hidden_states"] = input_obj
+        return self._lm_node.params["module"](**kwargs)
 
     # ------------------------------------------------------------------
-    # Cross-mesh transfers
+    # Forward / backward micro-steps
     # ------------------------------------------------------------------
 
-    def _forward_transfer(
+    def _forward_step(
         self,
-        prod: MeshLayout,
-        cons: MeshLayout,
-        value: Any,
-        device: torch.device,
-    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
-        """Move a producer node's output to the consumer mesh's ranks.
+        microbatch: dict,
+        input_obj: Any | None,
+        criterion: Callable,
+        num_microbatches: int,
+        accum_loss: torch.Tensor | None,
+        outputs: list[Any] | None,
+    ) -> Any:
+        output_obj = self._forward_compute(microbatch, input_obj)
+        if self.is_last_stage():
+            loss = criterion(output_obj, microbatch) / num_microbatches
+            if accum_loss is not None:
+                accum_loss.add_(loss.detach())
+            if outputs is not None:
+                outputs.append(_detach(output_obj))
+            return loss
+        return output_obj
 
-        Returns ``(received, sent_feat)``: the consumer ranks get ``received``
-        (a fresh tensor); the producer representative gets ``sent_feat`` (the
-        graph tensor it sent, kept for the backward transfer).  At most one is
-        non-``None`` on any rank, since the meshes are disjoint.
-        """
-        received: torch.Tensor | None = None
-        sent_feat: torch.Tensor | None = None
+    def _backward_step(
+        self,
+        input_obj: Any | None,
+        output_obj: Any,
+        output_obj_grad: Any | None,
+    ) -> Any | None:
+        _retain_grad(input_obj)
+
+        if output_obj_grad is None:
+            # Last stage: ``output_obj`` is the scalar loss.
+            output_obj.backward()
+        else:
+            keys = None
+            if isinstance(output_obj, dict):
+                keys = output_obj.get("backward_tensor_keys") or list(
+                    output_obj_grad.keys()
+                )
+            if keys is not None:
+                tensors = [
+                    output_obj[k] for k in keys if isinstance(output_obj[k], torch.Tensor)
+                ]
+                grads = [
+                    output_obj_grad[k] for k in keys if isinstance(output_obj[k], torch.Tensor)
+                ]
+                if len(tensors) == 1:
+                    torch.autograd.backward(tensors[0], grads[0])
+                else:
+                    torch.autograd.backward(tensors, grads)
+            else:
+                torch.autograd.backward(output_obj, output_obj_grad)
+
+        if input_obj is None:
+            return None
+        if isinstance(input_obj, torch.Tensor):
+            return input_obj.grad
+        if isinstance(input_obj, dict):
+            return {
+                k: v.grad
+                for k, v in input_obj.items()
+                if isinstance(v, torch.Tensor) and v.grad is not None
+            }
+        return None
+
+    # ------------------------------------------------------------------
+    # Seam transport (encoder <-> language-model boundary)
+    # ------------------------------------------------------------------
+
+    def _seam_send_forward(self, obj: Any) -> None:
+        prod, cons = self._seam_producer, self._lm_layout
         for d in range(self._dp_size):
             producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
-            consumer_ranks = cons.stage_ranks(d, 0)
             if self._my_rank == producer_rep:
-                feat = _first_output_tensor(value)
-                exchange_objects(feat.detach(), consumer_ranks, [], device)
-                sent_feat = feat
-            elif self._my_rank in consumer_ranks:
-                received = exchange_objects(None, [], [producer_rep], device)[0]
-        return received, sent_feat
+                exchange_objects(obj, cons.stage_ranks(d, 0), [], self._device)
 
-    def _backward_transfer(
-        self,
-        prod: MeshLayout,
-        cons: MeshLayout,
-        grad: Any,
-        device: torch.device,
-    ) -> Any | None:
-        """Ship a cross-mesh gradient from the consumer back to the producer.
+    def _seam_recv_forward(self) -> Any | None:
+        prod, cons = self._seam_producer, self._lm_layout
+        for d in range(self._dp_size):
+            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
+            if self._my_rank in cons.stage_ranks(d, 0):
+                received = exchange_objects(None, [], [producer_rep], self._device)[0]
+                if isinstance(received, torch.Tensor):
+                    received.requires_grad_(True)
+                return received
+        return None
 
-        Mirror of :meth:`_forward_transfer`: the consumer representative sends
-        the gradient to every last-stage producer rank (so each replicated
-        producer rank can run its own backward).  Returns the received gradient
-        on producer ranks, ``None`` elsewhere.
-        """
-        received_grad: Any | None = None
+    def _seam_send_backward(self, grad: Any) -> None:
+        prod, cons = self._seam_producer, self._lm_layout
         for d in range(self._dp_size):
             consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
-            producer_ranks = prod.stage_ranks(d, prod.last_stage)
             if self._my_rank == consumer_rep:
-                exchange_objects(grad, producer_ranks, [], device)
-            elif self._my_rank in producer_ranks:
-                received_grad = exchange_objects(None, [], [consumer_rep], device)[0]
-        return received_grad
+                exchange_objects(grad, prod.stage_ranks(d, prod.last_stage), [], self._device)
+
+    def _seam_recv_backward(self) -> Any | None:
+        prod, cons = self._seam_producer, self._lm_layout
+        for d in range(self._dp_size):
+            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
+            if self._my_rank in prod.stage_ranks(d, prod.last_stage):
+                return exchange_objects(None, [], [consumer_rep], self._device)[0]
+        return None
+
+    def _seam_send_forward_recv_backward(self, obj: Any) -> Any | None:
+        """Encoder side: send features forward and receive the gradient back.
+
+        Issued as a single ``batch_isend_irecv`` (send + recv together) so the
+        encoder and language-model meshes do not both block on a send.
+        """
+        prod, cons = self._seam_producer, self._lm_layout
+        grad = None
+        for d in range(self._dp_size):
+            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
+            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
+            if self._my_rank == producer_rep:
+                grad = exchange_objects(
+                    obj, cons.stage_ranks(d, 0), [consumer_rep], self._device
+                )[0]
+            elif self._my_rank in prod.stage_ranks(d, prod.last_stage):
+                grad = exchange_objects(None, [], [consumer_rep], self._device)[0]
+        return grad
+
+    def _seam_send_backward_recv_forward(self, grad: Any) -> Any | None:
+        """Language-model side: send the gradient back and receive features.
+
+        Mirror of :meth:`_seam_send_forward_recv_backward`; the consumer
+        representative ships the gradient to every producer rank and all consumer
+        ranks receive the next microbatch's features in the same exchange.
+        """
+        prod, cons = self._seam_producer, self._lm_layout
+        feat = None
+        for d in range(self._dp_size):
+            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
+            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
+            if self._my_rank == consumer_rep:
+                feat = exchange_objects(
+                    grad, prod.stage_ranks(d, prod.last_stage), [producer_rep], self._device
+                )[0]
+            elif self._my_rank in cons.stage_ranks(d, 0):
+                feat = exchange_objects(None, [], [producer_rep], self._device)[0]
+        if isinstance(feat, torch.Tensor):
+            feat.requires_grad_(True)
+        return feat
 
     # ------------------------------------------------------------------
-    # Step
+    # Neighbor communication (dispatch seam vs intra-mesh)
     # ------------------------------------------------------------------
+
+    def _recv_forward(self) -> Any | None:
+        if self.is_first_stage():
+            return None
+        if self._seam_on_recv():
+            return self._seam_recv_forward()
+        return self._lm_comm.recv_forward()
+
+    def _send_forward(self, obj: Any) -> None:
+        if self.is_last_stage():
+            return
+        if self._seam_on_send():
+            self._seam_send_forward(obj)
+            return
+        self._lm_comm.send_forward(obj)
+
+    def _recv_backward(self) -> Any | None:
+        if self.is_last_stage():
+            return None
+        if self._seam_on_send():
+            return self._seam_recv_backward()
+        return self._lm_comm.recv_backward()
+
+    def _send_backward(self, grad: Any) -> None:
+        if self.is_first_stage():
+            return
+        if self._seam_on_recv():
+            self._seam_send_backward(grad)
+            return
+        self._lm_comm.send_backward(grad)
+
+    def _send_forward_recv_backward(self, obj: Any) -> Any | None:
+        if self.is_last_stage():
+            return None
+        if self._seam_on_send():
+            return self._seam_send_forward_recv_backward(obj)
+        return self._lm_comm.send_forward_recv_backward(obj)
+
+    def _send_backward_recv_forward(self, grad: Any) -> Any | None:
+        if self.is_first_stage():
+            return None
+        if self._seam_on_recv():
+            return self._seam_send_backward_recv_forward(grad)
+        return self._lm_comm.send_backward_recv_forward(grad)
+
+
+# ---------------------------------------------------------------------------
+# 1F1B schedule
+# ---------------------------------------------------------------------------
+
+class OneForwardOneBackwardSchedule(BasePipelineSchedule):
+    """One-forward-one-backward pipeline schedule over the global pipeline."""
 
     def step(
         self,
-        batch: dict[str, torch.Tensor],
+        microbatches: list[dict[str, torch.Tensor]],
         criterion: Callable[..., Any],
         optimizer: Optimizer | None = None,
         return_loss: bool = True,
         return_outputs: bool = False,
     ) -> dict:
-        device = _first_tensor_device(batch)
-        if device is None:
-            device = (
-                torch.device(f"cuda:{torch.cuda.current_device()}")
-                if torch.cuda.is_available() and torch.cuda.device_count() > 0
-                else torch.device("cpu")
+        if self._idle:
+            # No stage in this batch's plan (e.g. encoder ranks on a text-only
+            # step): nothing to run, no transfers to anyone.
+            return {"loss": None, "outputs": None}
+
+        if not isinstance(microbatches, list):
+            microbatches = [microbatches]
+        num_microbatches = len(microbatches)
+        self._device = _first_tensor_device(microbatches) or _default_device()
+
+        num_warmup = min(self._num_stages - self._stage - 1, num_microbatches)
+        num_steady = num_microbatches - num_warmup
+
+        accum_loss: torch.Tensor | None = None
+        if return_loss and self.is_last_stage():
+            accum_loss = torch.zeros(1, device=self._device)
+        outputs: list[Any] | None = (
+            [] if return_outputs and self.is_last_stage() else None
+        )
+
+        input_objs: list[Any] = []
+        output_objs: list[Any] = []
+        mb_index = 0
+
+        # Warmup.
+        for _ in range(num_warmup):
+            input_obj = self._recv_forward()
+            output_obj = self._forward_step(
+                microbatches[mb_index], input_obj, criterion,
+                num_microbatches, accum_loss, outputs,
             )
+            mb_index += 1
+            self._send_forward(output_obj)
+            input_objs.append(input_obj)
+            output_objs.append(output_obj)
 
-        ordered = self._plan._topological_nodes(self._output_future.name)
-        producer_of = {node.name: node for node in ordered}
-        values: dict[str, Any] = dict(batch) if isinstance(batch, dict) else {}
+        if num_steady > 0:
+            input_obj = self._recv_forward()
 
-        # Forward: run owned nodes, transferring cross-mesh inputs as we reach
-        # the consumer node.  ``edges`` records this rank's role per cross-mesh
-        # edge so the backward pass can mirror the transfers in reverse.
-        edges: list[dict[str, Any]] = []
-        for node in ordered:
-            node_layout = self._node_layout(node)
-            for dep in sorted(node.dependencies):
-                producer = producer_of.get(dep)
-                if producer is None:
-                    continue  # a raw batch input, present on every rank
-                prod_layout = self._node_layout(producer)
-                if prod_layout.rankset == node_layout.rankset:
-                    continue  # intra-mesh edge — no transfer
-                received, sent_feat = self._forward_transfer(
-                    prod_layout, node_layout, values.get(dep), device
-                )
-                if received is not None:
-                    received.requires_grad_(True)
-                    values[dep] = received
-                    edges.append(
-                        {
-                            "role": "consumer",
-                            "prod": prod_layout,
-                            "cons": node_layout,
-                            "leaf": received,
-                        }
-                    )
-                if sent_feat is not None:
-                    edges.append(
-                        {
-                            "role": "producer",
-                            "prod": prod_layout,
-                            "cons": node_layout,
-                            "feat": sent_feat,
-                        }
-                    )
-            if self._my_rank in node_layout.rankset:
-                values[node.name] = CornstarchExecutionPlan._execute_node(node, values)
+        # Steady state.
+        for i in range(num_steady):
+            last = i == num_steady - 1
+            output_obj = self._forward_step(
+                microbatches[mb_index], input_obj, criterion,
+                num_microbatches, accum_loss, outputs,
+            )
+            mb_index += 1
+            output_obj_grad = self._send_forward_recv_backward(output_obj)
+            input_objs.append(input_obj)
+            output_objs.append(output_obj)
 
-        # Loss + backward on the ranks that own the output node.
-        loss: torch.Tensor | None = None
-        output: Any | None = None
-        output_layout = self._node_layout(producer_of[self._output_future.name])
-        if self._my_rank in output_layout.rankset:
-            output = values[self._output_future.name]
-            loss = criterion(output, batch)
-            loss.backward()
+            input_obj = input_objs.pop(0)
+            output_obj = output_objs.pop(0)
+            input_obj_grad = self._backward_step(input_obj, output_obj, output_obj_grad)
 
-        # Backward: mirror the cross-mesh transfers in reverse.
-        for edge in reversed(edges):
-            if edge["role"] == "consumer":
-                self._backward_transfer(
-                    edge["prod"], edge["cons"], edge["leaf"].grad, device
-                )
+            if last:
+                self._send_backward(input_obj_grad)
             else:
-                received_grad = self._backward_transfer(
-                    edge["prod"], edge["cons"], None, device
-                )
-                if received_grad is not None and edge["feat"].requires_grad:
-                    torch.autograd.backward(edge["feat"], received_grad)
+                input_obj = self._send_backward_recv_forward(input_obj_grad)
+
+        # Cooldown.
+        for _ in range(num_warmup):
+            input_obj = input_objs.pop(0)
+            output_obj = output_objs.pop(0)
+            output_obj_grad = self._recv_backward()
+            input_obj_grad = self._backward_step(input_obj, output_obj, output_obj_grad)
+            self._send_backward(input_obj_grad)
 
         return {
-            "loss": loss.detach() if (return_loss and loss is not None) else None,
-            "outputs": output if return_outputs else None,
+            "loss": accum_loss if return_loss else None,
+            "outputs": _merge_batch(outputs) if outputs is not None else None,
         }

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -39,6 +39,7 @@ from cornstarch.distributed import (
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
+    ExecutionFuture,
     build_modality_encoder,
     from_hf_config,
 )
@@ -75,22 +76,22 @@ class FakeVLMDataset(Dataset):
         return {"input_ids": ids, "labels": ids.clone(), "pixel_values": pixel_values}
 
 
-def _build_plan(language_model: Any, modality_encoder: Any, mb: dict):
-    """Build the (parallelism-agnostic) plan for one VLM microbatch.
+def _build_plan(language_model: Any, modality_encoder: Any):
+    """Build the (parallelism-agnostic) VLM plan.
 
     The three plan-construction lines match the non-distributed
-    ``examples/pretrain_vlm.py``; ``mb`` is one microbatch from the user's
-    ``collate_fn`` list.
+    ``examples/pretrain_vlm.py``; inputs are futures so the same plan serves both
+    the local per-microbatch run and the schedule (which feeds each microbatch).
     """
     plan = CornstarchExecutionPlan()
     vision_outputs = plan.run_modality_encoder(
         module=modality_encoder,
-        pixel_values=mb["pixel_values"],
+        pixel_values=ExecutionFuture("pixel_values"),
     )
     merged = plan.merge_modality_encoder_outputs(
         language_model=language_model,
-        input_ids=mb["input_ids"],
-        labels=mb["labels"],
+        input_ids=ExecutionFuture("input_ids"),
+        labels=ExecutionFuture("labels"),
         modality_token_ids={"vision": IMAGE_TOKEN_ID},
         encoder_outputs={"vision": vision_outputs},
     )
@@ -111,22 +112,23 @@ def _training_step(
     Without pipeline parallelism the encoder and language model are co-located on
     every rank, so the whole ``encoder -> merge -> language model`` plan runs
     locally per microbatch and gradients accumulate (no schedule). With pipeline
-    parallelism the encoder and language model are disaggregated onto separate
-    ranks and the microbatch list is driven by the schedule (wired in T008).
-    ``ctx.sync_gradients`` all-reduces the DP gradients before the optimizer step.
+    parallelism the encoder is the leading pipeline stage feeding the
+    language-model stages, and the schedule drives the microbatch list across the
+    cross-mesh seam. ``ctx.sync_gradients`` all-reduces the DP gradients before
+    the optimizer step.
     """
+    plan, output_future = _build_plan(language_model, modality_encoder)
+
     if not ctx.uses_pipeline_parallel:
         loss_total = None
         for mb in microbatches:
-            _, output_future = _build_plan(language_model, modality_encoder, mb)
-            output = output_future.execute()
+            output = output_future.execute(inputs=mb)
             loss = criterion(output, mb) / len(microbatches)
             loss.backward()
             loss_total = loss.detach() if loss_total is None else loss_total + loss.detach()
         ctx.sync_gradients()
         return {"loss": loss_total}
 
-    plan, output_future = _build_plan(language_model, modality_encoder, microbatches[0])
     schedule = ctx.create_schedule(plan, output_future)
     result = schedule.step(microbatches, criterion, optimizer, return_loss=True)
     ctx.sync_gradients()

--- a/tasks/done/T008-SCHEDULE-CONSOLIDATION.md
+++ b/tasks/done/T008-SCHEDULE-CONSOLIDATION.md
@@ -271,3 +271,6 @@ Remaining (write a BLOCK per CLAUDE.md if it turns out ambiguous during impl):
 ## HUMAN COMMENTS
 - (PR base branch? T005 merged into `feat/T002-parallelism`; confirm whether
   T006 should also target `feat/T002-parallelism`.)
+
+## PR
+https://github.com/cornstarch-org/Cornstarch/pull/75 (base: feat/T002-parallelism; left open for human review)

--- a/tasks/done/T008-SCHEDULE-CONSOLIDATION.md
+++ b/tasks/done/T008-SCHEDULE-CONSOLIDATION.md
@@ -1,0 +1,273 @@
+## Task ID: T008-SCHEDULE-CONSOLIDATION
+## Type: DESIGN + IMPLEMENTATION (`pytest tests` must stay green)
+## Depends on: T006 (PP-driven rank co-location) and T007 (microbatch via
+## `collate_fn`), both merged into `feat/T002-parallelism` first; branch T008 from
+## the post-T007 `feat/T002-parallelism`.
+## Goal: collapse the schedule hierarchy to **two** classes under
+`cornstarch/distributed/pipeline_parallel/`: an extensible **base pipeline
+schedule** and a **1F1B** subclass. A schedule exists **only when pipeline
+parallelism is in play**; when PP is not used there are no stages and no
+schedule at all — training runs `output_future.execute()` + `loss.backward()`,
+exactly like the non-distributed `examples/pretrain_vlm.py`. **When PP is used**,
+each modality encoder becomes a **leading pipeline stage** feeding the
+language-model stages, and the schedule **microbatches all inputs and overlaps
+execution following 1F1B**. The stage set for a step is assembled **per step
+from that step's plan** (image steps run encoder+LLM stages; text-only steps run
+LLM-only stages with the encoder ranks idle); the microbatch count is whatever the user's `collate_fn`
+returns (Prerequisite 2), while warmup/steady/cooldown follow the stages present.
+
+## Prerequisites (already implemented + merged into `feat/T002-parallelism`)
+- **T006** — `ParallelConfig.pipeline_parallel_size: int | None = None`; all-`None`
+  ⇒ co-located (no PP), all-positive ⇒ disaggregated (PP), mix ⇒ error;
+  `ctx.uses_pipeline_parallel` exposed.
+- **T007** — `collate_fn` returns `list[dict]` microbatches; `prepare_dataloader`
+  applies DP/CP per microbatch and yields the list; the non-PP training path does
+  gradient accumulation over the list (no schedule).
+This task consumes both: `create_schedule` is only called when
+`ctx.uses_pipeline_parallel`, and `schedule.step` takes the microbatch list.
+
+## Motivation
+- `TrainingSchedule` lives under `pipeline_parallel`, but today a schedule is
+  produced even when no pipeline parallelism is used:
+  `NonPipelineParallelSchedule` just wraps `output_future.execute()` +
+  `criterion` + `backward`. That is not a "schedule"; it is the plain
+  non-distributed step. It should not exist — the non-PP path should call
+  `execute()`/`backward()` directly.
+- T005 added `CompiledSchedule` for the multi-mesh (encoder on disjoint ranks)
+  case, but it runs a **single full-batch** forward/backward with no
+  microbatching and explicitly bails on PP (`NotImplementedError` for
+  `num_pp_stages > 1`). So a VLM cannot pipeline, and there are now **three**
+  schedule classes with overlapping responsibilities
+  (`NonPipelineParallelSchedule`, `OneForwardOneBackwardSchedule`,
+  `CompiledSchedule`).
+- The unifying insight: a modality encoder on its own ranks feeding the language
+  model **is** a pipeline-stage boundary. Treating the encoder as the first
+  pipeline stage makes the cross-mesh transfer just another stage boundary, lets
+  the VLM pipeline its microbatches, and removes the need for a separate
+  multi-mesh schedule.
+
+## Design decision (CONFIRMED with the user — record, do not re-litigate)
+**A schedule exists only when pipeline parallelism is used. When PP is used, the
+encoder is a genuine leading pipeline stage.**
+
+"Pipeline parallelism is used" = the encoder is split from the language model
+into separate pipeline stages, and/or the language model itself is split across
+stages (`num_pp_stages > 1`).
+
+- **When PP is NOT used:** there are **no pipeline stages at all**. All
+  modalities are **co-located on every rank** — a single rank runs encoder →
+  merge → language model directly (DP/TP optional). The step is a plain
+  `output_future.execute()` + `loss.backward()` + `ctx.sync_gradients()`,
+  exactly like the non-distributed `examples/pretrain_vlm.py`. **No schedule
+  object is created and no activation is transferred across ranks.**
+  *(This requires modalities to be co-located rather than on disjoint ranks —
+  see "OPEN: rank co-location" below; it is the one real ripple of this rule.)*
+
+- **When PP is used:** the modalities form a pipeline whose **depth = (encoder
+  stages) + (language-model stages)**. The encoder is the leading stage(s) (one
+  stage per encoder; intra-encoder PP is out of scope), the language model the
+  following stages, on disjoint ranks; the encoder→LLM boundary is a
+  pipeline-stage boundary. 1F1B microbatches and overlaps — e.g. with one
+  encoder stage and `llm_pp == 1` there are 2 stages, so the encoder of
+  microbatch `k+1` overlaps the LLM of microbatch `k`.
+
+**Text-only batch flexibility (T005) — revised per the user (supersedes the
+earlier "w/s/c invariant to encoder inputs" wording):** the pipeline structure
+for a step is **assembled per step from that step's plan** (which modalities are
+present) using the per-modality **stage shapes from config**. A text-only step's
+plan has no `run_modality_encoder` node, so **the encoder stage is simply absent
+for that step**: the encoder ranks do nothing, and the first language-model stage
+begins its 1F1B computation immediately without waiting for or receiving any
+encoder activation. **No empty/placeholder activation is sent.**
+
+This does NOT sacrifice consistency: each `step()` runs one self-contained 1F1B
+forward+backward, and every rank derives the same stage set from the same
+per-step plan (all ranks see the same batch), so there is no rank disagreement
+or deadlock. The microbatch count is `len(microbatches)` (the user-provided list
+from `collate_fn`, per Prerequisite 2) and is the same for every rank;
+warmup/steady/cooldown reflect the stages actually present that step (encoder+LLM
+on image steps, LLM-only on text steps). That per-step variation is fine because
+steps share no pipeline state. Schedule construction must stay cheap (DAG/stage
+analysis from the per-step plan + config, no collectives).
+
+  *(Co-location is handled by **Prerequisite 1** above: when PP is not used all
+  modules share one rank range, so `output_future.execute()` runs the full
+  encoder→merge→LLM locally with no transfer and no schedule.)*
+
+## What you must read
+- `cornstarch/distributed/pipeline_parallel/schedule.py`
+  (`TrainingSchedule`, `NonPipelineParallelSchedule`,
+  `OneForwardOneBackwardSchedule` — `_StageModel`, `_run_1f1b`,
+  `_forward_step`/`_backward_step`, warmup/steady/cooldown math —, `MeshLayout`,
+  `CompiledSchedule` — `_forward_transfer`/`_backward_transfer` seam pairing).
+- `cornstarch/distributed/pipeline_parallel/p2p.py`
+  (`PipelineP2PCommunication` for intra-mesh stage hops; `exchange_objects` for
+  explicit-global-rank seam transfers — reuse both).
+- `cornstarch/distributed/process_group_mesh.py`
+  (`ModalProcessGroupMesh`: `stage`, `num_stages`, `is_first_stage`,
+  `is_last_stage`, `get_prev_ranks`/`get_next_ranks`, `distribute_layers`).
+- `cornstarch/distributed/parallelization.py`
+  (`ParallelContext.create_schedule` selection logic, `_meshes`, `_layouts`,
+  `materialize` building `MeshLayout` per module).
+- `cornstarch/models/multimodal/execution.py`
+  (`CornstarchExecutionPlan` nodes/kinds, `_execute_node`, `_topological_nodes`,
+  `_first_output_tensor`, `merge_modality_encoder_outputs` — note it masks labels
+  at modality-token positions to -100).
+- `examples/distributed/pretrain_llm.py` and `pretrain_vlm.py`
+  (`_training_step` builds the plan per step and calls `ctx.create_schedule` +
+  `schedule.step`; these are the call sites to converge).
+- `examples/pretrain_vlm.py` (the non-distributed step to mirror: `execute()` +
+  `backward()` with no schedule).
+- `tests/distributed/test_parallelism_integration.py` (calls
+  `create_schedule`/`step` for non-PP and PP LM combos — must keep passing),
+  `tests/distributed/test_numerical_equivalence.py` (TP/PP/EP/DP parity — no math
+  change), `tests/distributed/test_multimodal_distributed.py` (T005 cross-mesh +
+  flexibility tests — must keep passing, adapted to the new surface).
+
+## Proposed approach (refine during implementation; write a BLOCK per CLAUDE.md
+## if an interface decision below is unclear)
+
+### Commit 1 — base pipeline schedule + 1F1B subclass (no behavior change yet)
+Refactor `OneForwardOneBackwardSchedule` into:
+- `BasePipelineSchedule(TrainingSchedule)` — owns everything schedule-shape-
+  independent: the stage model, **consuming the user-provided microbatch list**
+  (`step(microbatches: list[dict], ...)`, `num_microbatches = len(microbatches)`;
+  drop the internal `_get_micro_batch`/`microbatch_size` slicer per Prereq 2),
+  per-stage forward/backward steps, the P2P send/recv wrappers, loss
+  accumulation, and the abstract iteration order. Document it as the extension
+  point for other pipeline schedules (e.g. a future GPipe — **do not implement
+  GPipe**).
+- `OneForwardOneBackwardSchedule(BasePipelineSchedule)` — implements only the
+  1F1B warmup/steady/cooldown ordering.
+- `ctx.create_schedule` drops the `num_microbatches`/`microbatch_size` params
+  (the count comes from the microbatch list passed to `step`).
+- Keep the single-mesh LM PP path behaviorally identical (same loss/grads); the
+  integration + numerical-equivalence PP tests must stay green (adapted to pass a
+  microbatch list instead of `num_microbatches`).
+
+### Commit 2 — encoder as a leading pipeline stage; remove `CompiledSchedule`
+Generalize the pipeline so its stage list spans the encoder mesh(es) and the LLM
+mesh, with the encoder(s) as the leading stage(s):
+- Build the global stage list from the **config** (the `ParallelContext` meshes/
+  layouts), ordered encoder(s) → LLM stages. Map plan nodes to stages:
+  `run_modality_encoder` → the encoder stage; `merge_modality_encoder_outputs` →
+  the first LLM stage (it needs the LLM embedding); `run_language_model` →
+  pipelined across the LLM stages (as today).
+- Two boundary kinds: **intra-mesh** stage hops use `PipelineP2PCommunication`
+  (1:1, same cp/tp/ep position, as today); the **encoder→LLM seam** uses the
+  `MeshLayout` producer-rep-broadcast / consumer-rep-collapse pairing (lift it
+  out of `CompiledSchedule` — `_forward_transfer`/`_backward_transfer` — into a
+  reusable seam transfer). The encoder stage's "send_forward" is the seam send;
+  the LLM first stage's "recv_forward" is the seam recv; backward mirrors.
+- **Per-microbatch flow** (microbatches come from the user's `collate_fn` list,
+  Prereq 2 — the schedule does not slice): for each microbatch `m`, the encoder
+  stage runs `encoder(m["pixel_values"])` → seam → the first LLM stage merges
+  those features with `m["input_ids"]`/`m["labels"]`. The user guarantees the
+  per-microbatch image-token / feature counts match (that is why splitting is
+  theirs).
+- **Text-only step** (per the revised flexibility decision): the per-step plan
+  has no `run_modality_encoder` node, so **the encoder stage is absent** — the
+  encoder ranks do nothing and the first LLM stage is the leading stage (it does
+  not `recv_forward` from any encoder). No placeholder activation. All ranks agree
+  because they share the per-step plan. (Define the seam rank-pairing under
+  combined DP/TP/PP for the image case; if ambiguous, STOP and write a BLOCK.)
+- **Masked-label correctness through PP for VLM (resolved):** `merge_*` masks
+  labels at modality-token positions to -100, but under PP the loss is computed on
+  the last stage from the microbatch's labels, not the merge output. Since every
+  rank has the same per-microbatch inputs and builds the same plan, **the last
+  stage recomputes the mask locally** — from `input_ids` + `modality_token_ids`
+  (both available in the microbatch / plan) — and masks `labels` to -100 before
+  the loss. No need to ship masked labels down the pipeline.
+- Delete `CompiledSchedule`. The multi-mesh case is now the leading-stage
+  pipeline.
+
+### Commit 3 — no schedule when PP is not used; converge call sites
+- **`create_schedule` always returns a real (pipeline) schedule and is only ever
+  called when PP is used; it never returns `None`.** Whether PP is used is a
+  property of the `ParallelContext` (decided in Prereq 1: all-`None`
+  `pipeline_parallel_size` ⇒ co-located, no PP; all-positive ⇒ disaggregated, PP).
+  Expose that as e.g. `ctx.uses_pipeline_parallel` (or `ctx.is_pipelined`) so the
+  caller can branch.
+- **The training step diverges by PP**, and `CornstarchExecutionPlan` stays
+  parallelism-agnostic (the plan-build lines are identical):
+  - **No PP** (co-located): no schedule object at all — iterate the `collate_fn`
+    microbatch list running `output_future.execute(inputs=mb)` + scaled
+    `loss.backward()` (gradient accumulation), then `ctx.sync_gradients()`.
+  - **PP**: `schedule = ctx.create_schedule(plan, output_future)`;
+    `schedule.step(microbatches, criterion, optimizer)`; then
+    `ctx.sync_gradients()`.
+  Structure the examples as two small functions (a non-PP step and a PP step)
+  selected on `ctx.uses_pipeline_parallel`, with the shared `CornstarchExecutionPlan`
+  build in common.
+- Delete `NonPipelineParallelSchedule`.
+- Update `examples/distributed/pretrain_llm.py` / `pretrain_vlm.py` and
+  `tests/distributed/test_parallelism_integration.py` /
+  `test_multimodal_distributed.py` to this surface.
+- Update `cornstarch/distributed/__init__.py` exports (drop the removed classes,
+  add `BasePipelineSchedule`; keep `MeshLayout`).
+
+### Tests (same commit or immediately after the relevant impl)
+- VLM 1F1B with `llm_pp=1` **and** `llm_pp>1`, with a multi-microbatch
+  `collate_fn` (list length > 1): one forward+backward yields finite loss on the
+  LLM last stage and gradients on both the encoder and LLM meshes (gloo CPU,
+  `world_size<=4`). Mirror the existing
+  `tests/distributed/test_multimodal_distributed.py` structure.
+- Per-step flexibility: alternating image / text-only batches on the same VLM
+  pipeline both run without deadlock. The image step runs encoder+LLM stages
+  (vision does real work, gets grads); the text-only step runs LLM stages only
+  with the encoder ranks idle (no vision grads, no seam transfer). The microbatch
+  count (list length) is the same for both; the stage count / warmup-cooldown
+  differ as expected (encoder stage present vs absent).
+- Non-PP microbatch gradient accumulation (Prereq 2): a co-located run with a
+  multi-microbatch `collate_fn` and no schedule accumulates gradients matching the
+  single-batch reference.
+- LM-only non-PP (dp/tp/dp+tp): no schedule is created; training still steps and
+  produces grads.
+- LM-only PP and TP/PP/EP/DP numerical equivalence: unchanged.
+- Keep `pytest tests` green.
+
+## What you must NOT do
+- Do NOT make `cornstarch/models/multimodal/execution.py` import from
+  `cornstarch/distributed/` — the plan stays distributed-agnostic.
+- Do NOT change CP/TP/PP/EP/DP numerical behavior; seam + microbatching must be
+  mathematically transparent.
+- Do NOT implement GPipe — only leave the base class extensible for it.
+- Do NOT make the non-distributed `examples/pretrain_vlm.py` depend on the
+  distributed package.
+- Do NOT introduce a separate checkpoint format.
+
+## Resolved decisions / remaining ambiguity
+Resolved (do not re-litigate):
+- **Rank co-location** → Prerequisite 1.
+- **Masked labels through PP for VLM** → last stage recomputes the mask locally
+  (Commit 2).
+- **`create_schedule` return** → always a real pipeline schedule, only used under
+  PP; the non-PP path uses no schedule; the example step diverges by PP
+  (Commit 3).
+
+Remaining (write a BLOCK per CLAUDE.md if it turns out ambiguous during impl):
+- The encoder→LLM **seam rank-pairing under combined DP/TP/PP** for the image
+  case (Commit 2). Reuse the `MeshLayout` producer-rep-broadcast /
+  consumer-rep-collapse rule lifted from `CompiledSchedule`; if a combination is
+  unclear, STOP and write a BLOCK.
+
+## Done Condition
+- Exactly two schedule classes remain under `pipeline_parallel`:
+  `BasePipelineSchedule` and `OneForwardOneBackwardSchedule`.
+  `NonPipelineParallelSchedule` and `CompiledSchedule` are gone.
+- No schedule is created for non-PP single-mesh training; those paths run
+  `output_future.execute()` + `backward()` directly.
+- When PP is used, a VLM trains with the encoder as a leading pipeline stage,
+  microbatched and overlapped under 1F1B, at `llm_pp=1` and `llm_pp>1`; the stage
+  set for a step is assembled from that step's plan (text-only steps run
+  LLM-only stages, encoder ranks idle).
+- When PP is not used, no schedule is created and the VLM step is a plain
+  `execute()`/`backward()` (subject to the rank-co-location decision).
+- New VLM 1F1B + per-step-flexibility tests are green; LM-only non-PP/PP and
+  TP/PP/EP/DP equivalence unchanged; `pytest tests` green.
+- Branch pushed; PR opened against the appropriate base; this file moved to
+  `tasks/done/T006-SCHEDULE-CONSOLIDATION.md` with the PR URL.
+
+## HUMAN COMMENTS
+- (PR base branch? T005 merged into `feat/T002-parallelism`; confirm whether
+  T006 should also target `feat/T002-parallelism`.)

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -1,15 +1,13 @@
-"""Cross-mesh (disjoint-rank) multimodal training through the Option C surface.
+"""Disaggregated (pipeline-parallel) multimodal training: encoder as a leading stage.
 
-These tests cover the regression the language-only integration suite cannot: a
-VLM whose vision encoder and language model are parallelized onto **disjoint**
-rank ranges.  ``NonPipelineParallelSchedule`` runs the whole DAG on every rank,
-which fails here because the vision encoder is materialized only on the vision
-ranks (and stays ``meta`` on the language-model ranks).  ``CompiledSchedule``
-runs each node only on its owning mesh and compiles the cross-mesh transfer that
-moves the projected vision features to the ranks that consume them.
+When pipeline parallelism is used, a VLM's vision encoder and language model are
+disaggregated onto disjoint ranks and form one pipeline: the encoder is the
+**leading stage**, feeding the language-model stages across the cross-mesh seam.
+``OneForwardOneBackwardSchedule`` drives it, microbatched from the user's list.
 
-Everything runs on CPU under gloo (``world_size <= 4``) so the suite stays cheap
-and offline.
+These run on CPU under gloo (``world_size <= 4``). The co-located (no-PP) VLM
+path is covered by ``test_colocation``; the LM-only pipeline by
+``test_parallelism_integration``.
 """
 from __future__ import annotations
 
@@ -24,6 +22,7 @@ from tests.model.model_configs import clip_vision_config, llama_config
 from cornstarch.distributed import ParallelConfig, ParallelizationPlan
 from cornstarch.models import (
     CornstarchExecutionPlan,
+    ExecutionFuture,
     build_modality_encoder,
     from_hf_config,
 )
@@ -59,53 +58,41 @@ def _num_vision_tokens(vision_config) -> int:
     return (vision_config.image_size // vision_config.patch_size) ** 2 + 1
 
 
-def _make_batch(vision_config, vocab_size: int, batch_size: int = 2):
+def _make_microbatches(vision_config, vocab_size, batch_size, num_microbatches):
+    """Build a batch and split it into ``num_microbatches`` (one image per sample)."""
     num_image_tokens = _num_vision_tokens(vision_config)
     seq_len = num_image_tokens + 3
     g = torch.Generator().manual_seed(0)
     input_ids = torch.randint(1, vocab_size, (batch_size, seq_len), generator=g)
     input_ids[:, :num_image_tokens] = IMAGE_TOKEN_ID
-    image_size = vision_config.image_size
-    pixel_values = torch.randn(
-        batch_size, 3, image_size, image_size, generator=g
-    )
-    return {
+    image = vision_config.image_size
+    pixel_values = torch.randn(batch_size, 3, image, image, generator=g)
+    batch = {
         "input_ids": input_ids,
         "labels": input_ids.clone(),
         "pixel_values": pixel_values,
     }
+    return [
+        {k: v.chunk(num_microbatches, dim=0)[i] for k, v in batch.items()}
+        for i in range(num_microbatches)
+    ]
 
 
-def _build_vlm_plan(modality_encoder, language_model, batch):
-    """Build the per-step plan exactly like ``examples/pretrain_vlm.py``."""
+def _vlm_plan(language_model, modality_encoder):
+    """A futures-based plan so the schedule can feed each microbatch in turn."""
     plan = CornstarchExecutionPlan()
     vision_outputs = plan.run_modality_encoder(
-        module=modality_encoder,
-        pixel_values=batch["pixel_values"],
+        module=modality_encoder, pixel_values=ExecutionFuture("pixel_values")
     )
     merged = plan.merge_modality_encoder_outputs(
         language_model=language_model,
-        input_ids=batch["input_ids"],
-        labels=batch["labels"],
+        input_ids=ExecutionFuture("input_ids"),
+        labels=ExecutionFuture("labels"),
         modality_token_ids={"vision": IMAGE_TOKEN_ID},
         encoder_outputs={"vision": vision_outputs},
     )
-    language_outputs = plan.run_language_model(module=language_model, inputs=merged)
-    return plan, language_outputs
-
-
-def _build_text_only_plan(language_model, batch):
-    """A plan with no vision node — the per-batch flexibility case."""
-    plan = CornstarchExecutionPlan()
-    merged = plan.merge_modality_encoder_outputs(
-        language_model=language_model,
-        input_ids=batch["input_ids"],
-        labels=batch["labels"],
-        modality_token_ids={},
-        encoder_outputs={},
-    )
-    language_outputs = plan.run_language_model(module=language_model, inputs=merged)
-    return plan, language_outputs
+    output_future = plan.run_language_model(module=language_model, inputs=merged)
+    return plan, output_future
 
 
 def _criterion(output, batch):
@@ -118,8 +105,29 @@ def _has_grad(module) -> bool:
     return any(p.grad is not None for p in module.parameters())
 
 
+def _parallelize(modality_encoder, language_model, world_size, *, vision_tp, llm_tp, llm_pp):
+    plan = ParallelizationPlan(global_ranks=list(range(world_size)))
+    plan.parallelize(
+        modality_encoder,
+        ParallelConfig(
+            tensor_parallel_size=vision_tp,
+            pipeline_parallel_size=1,
+            data_parallel_size=1,
+        ),
+    )
+    plan.parallelize(
+        language_model,
+        ParallelConfig(
+            tensor_parallel_size=llm_tp,
+            pipeline_parallel_size=llm_pp,
+            data_parallel_size=1,
+        ),
+    )
+    return plan.materialize("cpu", dtype=torch.float32)
+
+
 class TestCrossMeshVLMStep(GlooDistributedTestBase):
-    """A single forward+backward of a disjoint-rank VLM yields finite loss/grads."""
+    """Encoder (rank 0) feeds a single-stage language model (rank 1)."""
 
     @property
     def world_size(self) -> int:
@@ -127,54 +135,34 @@ class TestCrossMeshVLMStep(GlooDistributedTestBase):
 
     def test_step(self) -> None:
         language_model, modality_encoder, vision_config = _build_models()
-
-        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
-        plan.parallelize(
-            modality_encoder,
-            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
+        ctx = _parallelize(
+            modality_encoder, language_model, self.world_size,
+            vision_tp=1, llm_tp=1, llm_pp=1,
         )
-        plan.parallelize(
-            language_model,
-            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
-        )
-        ctx = plan.materialize("cpu", dtype=torch.float32)
+        self.assertTrue(ctx.uses_pipeline_parallel)
         language_model.train()
         modality_encoder.train()
 
-        batch = _make_batch(vision_config, language_model.hf_config.vocab_size)
-
-        exec_plan, output_future = _build_vlm_plan(
-            modality_encoder, language_model, batch
+        microbatches = _make_microbatches(
+            vision_config, language_model.hf_config.vocab_size,
+            batch_size=2, num_microbatches=2,
         )
-        schedule = ctx.create_schedule(exec_plan, output_future)
-
-        optimizer = torch.optim.SGD(
-            list(language_model.parameters()) + list(modality_encoder.parameters()),
-            lr=0.01,
-        )
-        result = schedule.step(batch, _criterion, optimizer, return_loss=True)
+        plan, output_future = _vlm_plan(language_model, modality_encoder)
+        schedule = ctx.create_schedule(plan, output_future)
+        result = schedule.step(microbatches, _criterion, return_loss=True)
         ctx.sync_gradients()
 
-        rank = dist.get_rank()
-        if rank == 0:
-            # Vision mesh: produces features, no loss, but receives grad back.
+        if dist.get_rank() == 0:
             self.assertIsNone(result["loss"])
             self.assertTrue(_has_grad(modality_encoder), "vision got no grad")
         else:
-            # Language-model mesh: owns the output, computes a finite loss.
             self.assertIsNotNone(result["loss"])
             self.assertTrue(result["loss"].isfinite().all())
             self.assertTrue(_has_grad(language_model), "language model got no grad")
 
 
-class TestCrossMeshVLMTensorParallel(GlooDistributedTestBase):
-    """Cross-mesh transfer broadcasts across the consumer's TP group and back.
-
-    The vision encoder stays single-rank (CLIP has no registered TP plan) while
-    the language model is tensor-parallel over two ranks, so the forward transfer
-    must fan the features out to *both* LM ranks and the backward must collapse
-    back to one producer.  Vision is rank 0; the LM is ranks 1 and 2.
-    """
+class TestCrossMeshVLMPipeline(GlooDistributedTestBase):
+    """Encoder (rank 0) + a 2-stage pipelined language model (ranks 1, 2)."""
 
     @property
     def world_size(self) -> int:
@@ -182,30 +170,60 @@ class TestCrossMeshVLMTensorParallel(GlooDistributedTestBase):
 
     def test_step(self) -> None:
         language_model, modality_encoder, vision_config = _build_models()
-
-        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
-        plan.parallelize(
-            modality_encoder,
-            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
+        ctx = _parallelize(
+            modality_encoder, language_model, self.world_size,
+            vision_tp=1, llm_tp=1, llm_pp=2,
         )
-        plan.parallelize(
-            language_model,
-            ParallelConfig(tensor_parallel_size=2, pipeline_parallel_size=1, data_parallel_size=1),
-        )
-        ctx = plan.materialize("cpu", dtype=torch.float32)
         language_model.train()
         modality_encoder.train()
 
-        batch = _make_batch(vision_config, language_model.hf_config.vocab_size)
-        exec_plan, output_future = _build_vlm_plan(
-            modality_encoder, language_model, batch
+        microbatches = _make_microbatches(
+            vision_config, language_model.hf_config.vocab_size,
+            batch_size=4, num_microbatches=2,
         )
-        schedule = ctx.create_schedule(exec_plan, output_future)
-
-        result = schedule.step(batch, _criterion, return_loss=True)
+        plan, output_future = _vlm_plan(language_model, modality_encoder)
+        schedule = ctx.create_schedule(plan, output_future)
+        result = schedule.step(microbatches, _criterion, return_loss=True)
+        ctx.sync_gradients()
 
         rank = dist.get_rank()
+        if rank == 2:  # last LM stage
+            self.assertIsNotNone(result["loss"])
+            self.assertTrue(result["loss"].isfinite().all())
+        else:  # encoder (0) and first LM stage (1) hold no loss
+            self.assertIsNone(result["loss"])
+
         if rank == 0:
+            self.assertTrue(_has_grad(modality_encoder), "vision got no grad")
+        else:
+            self.assertTrue(_has_grad(language_model), "language model got no grad")
+
+
+class TestCrossMeshVLMTensorParallel(GlooDistributedTestBase):
+    """Seam broadcasts to the consumer's TP group: encoder (0) -> LM tp=2 (1, 2)."""
+
+    @property
+    def world_size(self) -> int:
+        return 3
+
+    def test_step(self) -> None:
+        language_model, modality_encoder, vision_config = _build_models()
+        ctx = _parallelize(
+            modality_encoder, language_model, self.world_size,
+            vision_tp=1, llm_tp=2, llm_pp=1,
+        )
+        language_model.train()
+        modality_encoder.train()
+
+        microbatches = _make_microbatches(
+            vision_config, language_model.hf_config.vocab_size,
+            batch_size=2, num_microbatches=1,
+        )
+        plan, output_future = _vlm_plan(language_model, modality_encoder)
+        schedule = ctx.create_schedule(plan, output_future)
+        result = schedule.step(microbatches, _criterion, return_loss=True)
+
+        if dist.get_rank() == 0:
             self.assertIsNone(result["loss"])
             self.assertTrue(_has_grad(modality_encoder), "vision got no grad")
         else:
@@ -215,7 +233,7 @@ class TestCrossMeshVLMTensorParallel(GlooDistributedTestBase):
 
 
 class TestCrossMeshFlexibility(GlooDistributedTestBase):
-    """Alternating image / text-only batches both train; vision idles on text."""
+    """Image steps run encoder+LM; text-only steps run LM only with vision idle."""
 
     @property
     def world_size(self) -> int:
@@ -223,20 +241,12 @@ class TestCrossMeshFlexibility(GlooDistributedTestBase):
 
     def test_alternating_modalities(self) -> None:
         language_model, modality_encoder, vision_config = _build_models()
-
-        plan = ParallelizationPlan(global_ranks=list(range(self.world_size)))
-        plan.parallelize(
-            modality_encoder,
-            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
+        ctx = _parallelize(
+            modality_encoder, language_model, self.world_size,
+            vision_tp=1, llm_tp=1, llm_pp=1,
         )
-        plan.parallelize(
-            language_model,
-            ParallelConfig(tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1),
-        )
-        ctx = plan.materialize("cpu", dtype=torch.float32)
         language_model.train()
         modality_encoder.train()
-
         optimizer = torch.optim.SGD(
             list(language_model.parameters()) + list(modality_encoder.parameters()),
             lr=0.01,
@@ -244,32 +254,32 @@ class TestCrossMeshFlexibility(GlooDistributedTestBase):
         rank = dist.get_rank()
         vocab = language_model.hf_config.vocab_size
 
-        # --- Step 1: a batch WITH the vision modality. ---
+        # Image step: encoder is the leading stage.
         optimizer.zero_grad()
-        batch = _make_batch(vision_config, vocab)
-        exec_plan, output_future = _build_vlm_plan(
-            modality_encoder, language_model, batch
+        microbatches = _make_microbatches(vision_config, vocab, 2, 2)
+        plan, output_future = _vlm_plan(language_model, modality_encoder)
+        ctx.create_schedule(plan, output_future).step(microbatches, _criterion, optimizer)
+        if rank == 0:
+            self.assertTrue(_has_grad(modality_encoder), "vision should train on images")
+
+        # Text-only step: the plan has no encoder node, so the vision ranks idle
+        # and the language-model stage runs alone.
+        optimizer.zero_grad()
+        text_mbs = [{k: v for k, v in mb.items() if k != "pixel_values"} for mb in microbatches]
+        plan = CornstarchExecutionPlan()
+        merged = plan.merge_modality_encoder_outputs(
+            language_model=language_model,
+            input_ids=ExecutionFuture("input_ids"),
+            labels=ExecutionFuture("labels"),
+            modality_token_ids={},
+            encoder_outputs={},
         )
-        schedule = ctx.create_schedule(exec_plan, output_future)
-        schedule.step(batch, _criterion, optimizer)
-        if rank == 0:
-            self.assertTrue(_has_grad(modality_encoder), "vision should train on image step")
-
-        # --- Step 2: a batch WITHOUT the vision modality. ---
-        optimizer.zero_grad()
-        text_batch = {
-            k: v for k, v in batch.items() if k != "pixel_values"
-        }
-        exec_plan, output_future = _build_text_only_plan(language_model, text_batch)
-        schedule = ctx.create_schedule(exec_plan, output_future)
-        result = schedule.step(text_batch, _criterion, optimizer)
+        output_future = plan.run_language_model(module=language_model, inputs=merged)
+        result = ctx.create_schedule(plan, output_future).step(text_mbs, _criterion, optimizer)
 
         if rank == 0:
-            # The vision mesh has no node this batch: it idles, no grad, no loss.
             self.assertIsNone(result["loss"])
-            self.assertFalse(
-                _has_grad(modality_encoder), "vision should idle on a text-only step"
-            )
+            self.assertFalse(_has_grad(modality_encoder), "vision should idle on text")
         else:
             self.assertIsNotNone(result["loss"])
             self.assertTrue(result["loss"].isfinite().all())

--- a/tests/distributed/test_numerical_equivalence.py
+++ b/tests/distributed/test_numerical_equivalence.py
@@ -46,6 +46,7 @@ from cornstarch.distributed.pipeline_parallel.forward_spec_wrapper import (
     PipelineParallelForwardSpec,
 )
 from cornstarch.distributed.pipeline_parallel.schedule import (
+    MeshLayout,
     OneForwardOneBackwardSchedule,
 )
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
@@ -235,16 +236,25 @@ class TestPipelineParallelEquivalence(GlooDistributedTestBase):
             encoder_outputs={},
         )
         output_future = plan.run_language_model(module=model, inputs=merged)
-        schedule = OneForwardOneBackwardSchedule(
-            plan, output_future, mesh, num_microbatches=2, microbatch_size=2,
+        layout = MeshLayout(
+            global_ranks=tuple(mesh._global_ranks),
+            dp_size=mesh.dp_size,
+            num_pp_stages=mesh.num_stages,
+            cp_size=mesh.cp_size,
+            tp_size=mesh.tp_size,
+            ep_size=mesh.ep_size,
         )
+        schedule = OneForwardOneBackwardSchedule(
+            plan, output_future, {id(model): layout}, {id(model): mesh}, mesh.dp_size,
+        )
+        microbatches = [{k: v[i * 2 : i * 2 + 2] for k, v in batch.items()} for i in range(2)]
 
         def criterion(output, micro_batch):
             if isinstance(output, torch.Tensor):
                 return output
             return output.loss if hasattr(output, "loss") else output["loss"]
 
-        result = schedule.step(batch, criterion, optimizer=None, return_loss=True)
+        result = schedule.step(microbatches, criterion, optimizer=None, return_loss=True)
         if mesh.is_last_stage():
             torch.testing.assert_close(
                 result["loss"].reshape(()), ref_loss, atol=ATOL, rtol=RTOL

--- a/tests/distributed/test_parallelism_integration.py
+++ b/tests/distributed/test_parallelism_integration.py
@@ -133,15 +133,15 @@ def _run_combo(test: GlooDistributedTestBase, combo, moe: bool) -> None:
     )
     output_future = exec_plan.run_language_model(module=model, inputs=merged)
 
-    if pp > 1:
-        num_microbatches = 2
-        schedule = ctx.create_schedule(
-            exec_plan, output_future,
-            num_microbatches=num_microbatches,
-            microbatch_size=batch_size // num_microbatches,
-        )
-    else:
-        schedule = ctx.create_schedule(exec_plan, output_future)
+    schedule = ctx.create_schedule(exec_plan, output_future)
+
+    # The microbatch list is the user's responsibility (collate_fn); here split
+    # the batch into 2 microbatches under PP, otherwise a single microbatch.
+    num_microbatches = 2 if pp > 1 else 1
+    microbatches = [
+        {k: v.chunk(num_microbatches, dim=0)[i] for k, v in batch.items()}
+        for i in range(num_microbatches)
+    ]
 
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
@@ -150,7 +150,7 @@ def _run_combo(test: GlooDistributedTestBase, combo, moe: bool) -> None:
             return output
         return output.loss if hasattr(output, "loss") else output["loss"]
 
-    result = schedule.step(batch, criterion, optimizer, return_loss=True)
+    result = schedule.step(microbatches, criterion, optimizer, return_loss=True)
     if result["loss"] is not None:
         test.assertTrue(result["loss"].isfinite().all())
 

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -6,7 +6,6 @@ Uses 2 ranks (1 PP stage per rank) with the gloo backend.  Verifies that:
 - The full 1F1B loop accumulates a non-None loss on rank 1 only.
 """
 import unittest
-from typing import Any, Optional
 
 import torch
 import torch.nn as nn
@@ -98,6 +97,7 @@ class TestPipelineP2P(GlooDistributedTestBase):
         """1F1B forward pass on CornstarchLanguageModel via the schedule API."""
         from cornstarch.distributed.pipeline_parallel.forward_spec_wrapper import PipelineParallelForwardSpec
         from cornstarch.distributed.pipeline_parallel.schedule import (
+            MeshLayout,
             OneForwardOneBackwardSchedule,
         )
         from cornstarch.models import CornstarchExecutionPlan, ExecutionFuture, from_hf_config
@@ -135,8 +135,16 @@ class TestPipelineP2P(GlooDistributedTestBase):
         )
         output_future = plan.run_language_model(module=model, inputs=merged)
 
+        layout = MeshLayout(
+            global_ranks=tuple(mesh._global_ranks),
+            dp_size=mesh.dp_size,
+            num_pp_stages=mesh.num_stages,
+            cp_size=mesh.cp_size,
+            tp_size=mesh.tp_size,
+            ep_size=mesh.ep_size,
+        )
         schedule = OneForwardOneBackwardSchedule(
-            plan, output_future, mesh, num_microbatches=2, microbatch_size=1,
+            plan, output_future, {id(model): layout}, {id(model): mesh}, mesh.dp_size,
         )
         optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
 
@@ -144,13 +152,14 @@ class TestPipelineP2P(GlooDistributedTestBase):
             "input_ids": torch.randint(0, 128, (2, 8)),
             "labels": torch.randint(0, 128, (2, 8)),
         }
+        microbatches = [{k: v[i : i + 1] for k, v in batch.items()} for i in range(2)]
 
         def criterion(output, batch):
             if isinstance(output, torch.Tensor):
                 return output
             return output.loss if hasattr(output, "loss") else output["loss"]
 
-        result = schedule.step(batch, criterion, optimizer, return_loss=True)
+        result = schedule.step(microbatches, criterion, optimizer, return_loss=True)
 
         if mesh.is_last_stage():
             self.assertIsNotNone(result["loss"])


### PR DESCRIPTION
## Summary
Final task of three (T006 → T007 → **T008**). Collapses the schedule layer to **two** classes and makes a modality encoder a genuine **leading pipeline stage**.

- `BasePipelineSchedule` + `OneForwardOneBackwardSchedule` replace `NonPipelineParallelSchedule` **and** `CompiledSchedule`.
- A schedule exists **only when pipeline parallelism is used**. `create_schedule` always returns a real schedule and raises if called without PP; without PP the modules are co-located (T006) and the loop runs the plan directly per microbatch (T007 gradient accumulation).
- Under PP the global pipeline is `[encoder stage, language-model stages...]`. The encoder→LM boundary is a **cross-mesh seam**: the producer representative broadcasts features to the consumer's first-stage TP/EP group; the backward mirrors it. Seam combined ops are issued as a single `batch_isend_irecv` (avoids a send/send deadlock).
- `step` consumes the user's microbatch list (`num_microbatches = len(list)`). The last stage **recomputes the modality-masked labels locally** for the loss. A rank with no node in this batch's plan (e.g. the encoder on a text-only step) **idles**.
- Intra-mesh stage hops reuse `PipelineP2PCommunication` unchanged → LM-only PP and TP/PP/EP/DP numerical equivalence are preserved.

## Depends on
T006 (PP-driven co-location) and T007 (microbatch via `collate_fn`), both already merged into `feat/T002-parallelism`.

## Testing
- `tests/distributed` — 64 passed: rewritten cross-mesh VLM tests (single-stage LM, 2-stage pipelined LM, TP-broadcast seam, image/text flexibility), LM-only PP integration, and TP/PP/EP/DP numerical equivalence (unchanged).
- `tests` (non-distributed) — 106 passed.
- `ruff check` clean.
- Smoke-checked the VLM example end-to-end on 2-rank gloo (`--llm-pp 1`): encoder leading stage → LM via the seam, no deadlock/meta errors.

## Scope notes
- One encoder per pipeline (single leading stage); multiple encoders as parallel leading stages and intra-encoder PP are out of scope.
- Co-located mixed-degree (unequal `ranks_per_replica`) remains a T006 limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ4nazu3FyUMBzEbmxgVL