### PR TITLE
fix: build every modality mesh on every rank (multi-mesh PG-creation deadlock)

### DIFF
--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -344,7 +344,6 @@ class ParallelizationPlan:
             else list(range(dist.get_world_size()))
         )
         world_size = len(global_ranks)
-        my_rank = dist.get_rank()
 
         if not self._configs:
             raise ValueError("No modules registered with parallelize().")
@@ -380,9 +379,11 @@ class ParallelizationPlan:
                 ep_size=config.expert_parallel_size,
             )
 
-            if my_rank not in modality_ranks:
-                continue
-
+            # Build the mesh on EVERY rank, not just members: a ``DeviceMesh``
+            # calls ``new_group`` (a world collective), so all ranks must
+            # construct every modality's mesh in the same order or process-group
+            # creation deadlocks. Non-members build it as a no-op and discard it;
+            # only members keep and use it.
             mesh = ModalProcessGroupMesh(
                 device_type=device.type,
                 global_ranks=modality_ranks,
@@ -392,6 +393,8 @@ class ParallelizationPlan:
                 num_pp_stages=config.num_pp_stages,
                 ep_size=config.expert_parallel_size,
             )
+            if not mesh.is_member:
+                continue
             meshes[id(module)] = mesh
 
             # The model-side parallelisms (TP/CP/PP/EP) walk a Cornstarch model's

--- a/cornstarch/distributed/process_group_mesh.py
+++ b/cornstarch/distributed/process_group_mesh.py
@@ -60,8 +60,15 @@ class ModalProcessGroupMesh:
 
         ``global_ranks`` must contain exactly ``dp_size × num_pp_stages ×
         cp_size × tp_size × ep_size`` entries in replica-major / EP-minor order.
-        All ranks that belong to this modality must call this constructor with
-        the same arguments.
+
+        **Building a ``DeviceMesh`` calls ``new_group``, which is a collective
+        over the whole world** — every rank must construct every modality's mesh
+        in the same order, even ranks that do not belong to it, or process-group
+        creation deadlocks. So this constructor must be called on *all* ranks for
+        each modality. A rank that is not in ``global_ranks`` still builds the
+        ``DeviceMesh`` (participating in the collective as a non-member) but is
+        marked ``is_member == False`` and has no pipeline stage; callers keep and
+        use only the meshes they are members of.
         """
         expected = dp_size * num_pp_stages * cp_size * tp_size * ep_size
         if len(global_ranks) != expected:
@@ -78,6 +85,7 @@ class ModalProcessGroupMesh:
         self._num_stages = num_pp_stages
         self._global_ranks = global_ranks
         self._my_rank = dist.get_rank()
+        self._is_member = self._my_rank in global_ranks
 
         mesh_tensor = torch.tensor(global_ranks, dtype=torch.int).reshape(
             dp_size, num_pp_stages, cp_size, tp_size, ep_size
@@ -89,9 +97,13 @@ class ModalProcessGroupMesh:
         )
 
         # Derive this rank's PP stage from its position in the flat layout.
-        flat_pos = global_ranks.index(self._my_rank)
-        inner = cp_size * tp_size * ep_size
-        self._stage = (flat_pos % (num_pp_stages * inner)) // inner
+        # Non-members have no stage (they only participated in group creation).
+        if self._is_member:
+            flat_pos = global_ranks.index(self._my_rank)
+            inner = cp_size * tp_size * ep_size
+            self._stage = (flat_pos % (num_pp_stages * inner)) // inner
+        else:
+            self._stage = -1
 
     # ------------------------------------------------------------------
     # Per-dimension accessors
@@ -175,6 +187,12 @@ class ModalProcessGroupMesh:
     # ------------------------------------------------------------------
     # Pipeline stage semantics
     # ------------------------------------------------------------------
+
+    @property
+    def is_member(self) -> bool:
+        """Whether the current rank belongs to this mesh (vs a non-member that
+        only participated in the collective process-group creation)."""
+        return self._is_member
 
     @property
     def stage(self) -> int:


### PR DESCRIPTION
## Summary
Fixes an **intermittent process-group-creation deadlock** found by running the full suite on `feat/T002-parallelism` after T008 merged: `tests/distributed/test_multimodal_distributed.py::TestCrossMeshVLMPipeline` hung ~1 in 4 runs.

## Root cause
Constructing a `ModalProcessGroupMesh` builds a `DeviceMesh`, which calls `new_group` — a **collective over the whole world**: every rank must call it in the same order, even ranks that aren't members of the new group. `ParallelizationPlan.materialize()` built each modality's mesh **only on its member ranks** (`if my_rank not in modality_ranks: continue` before mesh construction). For disaggregated, disjoint-rank modalities (e.g. vision on rank 0, language model on ranks 1–2), the non-member ranks never made the matching `new_group` calls, so process-group creation deadlocked — timing-dependent, hence intermittent.

Captured via `faulthandler`: all ranks stuck in `DeviceMesh.__init__ → new_group → _new_process_group_helper` inside `materialize`, **not** in the schedule.

## Fix
Build every modality's mesh on **every** rank so `new_group` is called consistently. A non-member constructs the `DeviceMesh` as a no-op participant (`ModalProcessGroupMesh.is_member` is `False`, no pipeline stage) and the mesh is discarded; members keep and use theirs exactly as before. Co-located and single-mesh runs are unaffected (every rank is already a member). The schedule is untouched.

## Testing
- `TestCrossMeshVLMPipeline` (the flaky one): **8/8** passes after the fix (was ~25% hang).
- Full `tests/distributed`: **64 passed**, run twice back-to-back (~6 min each, no hang).
- `tests` (non-distributed): **106 passed**.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ERJ4nazu3FyUMBzEbmxgVL