### PR TITLE
B6: rename zigzag context parallelism to head-tail

### DIFF
--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -39,6 +39,7 @@ that folds DP/CP into ``prepare_dataloader``, builds the schedule, and exposes
 from cornstarch.distributed.context_parallel import apply_context_parallel
 from cornstarch.distributed.context_parallel.splitters import (
     ContextParallelSplitter,
+    HeadTailContextParallelSplitter,
     MakespanMinContextParallelSplitter,
     UniformContextParallelSplitter,
     ZigzagContextParallelSplitter,
@@ -76,6 +77,7 @@ __all__ = [
     "apply_context_parallel",
     "ContextParallelSplitter",
     "UniformContextParallelSplitter",
+    "HeadTailContextParallelSplitter",
     "ZigzagContextParallelSplitter",
     "MakespanMinContextParallelSplitter",
     # pipeline parallel

--- a/cornstarch/distributed/context_parallel/attention.py
+++ b/cornstarch/distributed/context_parallel/attention.py
@@ -20,7 +20,7 @@ the kernel reproduces a causal language model under CP without a custom kernel.
 The gathered K/V buffer lays the global key columns out in **rank order**
 (rank 0's positions, then rank 1's, ...), so it is a permutation of global
 order (identity for the uniform splitter).  For each contiguous run ``[a, b)``
-of global positions a rank owns (uniform -> one run/rank; zigzag -> two), the
+of global positions a rank owns (uniform -> one run/rank; head-tail -> two), the
 run's queries must attend exactly the global positions ``[0, query_pos]``,
 i.e. every key with global position ``< a`` (the *prefix*) plus the run's own
 keys ``[a, query_pos]`` (the *diagonal*).  We build the per-run key/value as
@@ -116,7 +116,7 @@ def _contiguous_runs(local_offsets: torch.Tensor) -> list[tuple[int, int, int, i
     q_start+q_len)`` is the run's range in the rank's *local* Q order and
     ``[a, b)`` is the run's *global* position range (``b - a == q_len``).
 
-    Uniform splitting yields one run/rank; zigzag yields two (an early run and a
+    Uniform splitting yields one run/rank; head-tail yields two (an early run and a
     late run).
     """
     offs = local_offsets.tolist()

--- a/cornstarch/distributed/context_parallel/splitters.py
+++ b/cornstarch/distributed/context_parallel/splitters.py
@@ -14,6 +14,7 @@ Usage in a dataloader ``collate_fn`` or training loop::
 from __future__ import annotations
 
 import heapq
+import warnings
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -93,8 +94,8 @@ class UniformContextParallelSplitter(ContextParallelSplitter):
         return self._offsets_per_rank
 
 
-class ZigzagContextParallelSplitter(ContextParallelSplitter):
-    """Interleaved (zigzag) assignment for causal-attention load balance.
+class HeadTailContextParallelSplitter(ContextParallelSplitter):
+    """Head-tail assignment for causal-attention load balance.
 
     Divides positions into ``2 × cp_size`` chunks and pairs the first chunk
     with the last, the second with the second-to-last, and so on.  This gives
@@ -118,6 +119,28 @@ class ZigzagContextParallelSplitter(ContextParallelSplitter):
             torch.tensor(p, dtype=torch.long) for p in paired
         ]
         return self._offsets_per_rank
+
+
+class ZigzagContextParallelSplitter(HeadTailContextParallelSplitter):
+    """Deprecated alias for :class:`HeadTailContextParallelSplitter`.
+
+    The former ``zigzag`` name described this same head-and-mirrored-tail token
+    ownership.  It is retained for one compatibility cycle; new code should use
+    the canonical class name.
+    """
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "ZigzagContextParallelSplitter is deprecated; use "
+            "HeadTailContextParallelSplitter instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__()
+
+    def __repr__(self) -> str:
+        """Use the canonical terminology in user-visible representations."""
+        return "HeadTailContextParallelSplitter()"
 
 
 class MakespanMinContextParallelSplitter(ContextParallelSplitter):

--- a/docs/parallelization/cornstarch_parallel.md
+++ b/docs/parallelization/cornstarch_parallel.md
@@ -108,12 +108,12 @@ Context parallelism split sequeneces into subsets of tokens and distribute them 
 There are multiple ways of partitioning sequences and distributing tokens into ranks that Corntarch supports:
 
 - `uniform`: The simplest way of such partitioning. Chunk every sequence into `cp_world_size` chunks, and each rank takes one portion.
-- `zigzag`: For causal attention, the amount of computation becomes imbalanced if tokens are uniformly distributed. `zigzag` partitions the sequence into `2 * cp_world_size` and each rank gets one portion from the upper half and another from the lower half, the workload sum of which is always balanced in causal attention.
-- `makespan_min`: In multimodal LLM, attention should no longer be simple causal; vision tokens should attend each other regardless of their location (previous vision tokens can attend to the future vision tokens). In this form of attention, zigzag is no longer be balanced, `makespan_min` computes the amount of workloads per token block (128 tokens per block) and distributes them to minimize overall makespan (execution time). The number of tokens per rank may be different depending on the amount of workloads.
+- `headtail`: For causal attention, the amount of computation becomes imbalanced if tokens are uniformly distributed. `headtail` partitions the sequence into `2 * cp_world_size` chunks and gives each rank one head chunk and its mirrored tail chunk, balancing causal-attention work.
+- `makespan_min`: In multimodal LLM, attention should no longer be simple causal; vision tokens should attend each other regardless of their location (previous vision tokens can attend to the future vision tokens). In this form of attention, head-tail ownership is no longer necessarily balanced; `makespan_min` computes the amount of work per token block (128 tokens per block) and distributes blocks to minimize overall makespan (execution time). The number of tokens per rank may differ.
 
 ![](/assets/images/context_parallel_distribution_mode_illustration.png)
 
-The token distribution scheme can be configured by passing `cornstarch.shardformer.shard.shard_config.ContextParallelDistributionMode.[UNIFORM | ZIGZAG | MAKESPAN_MIN]` to LLM's `shard_config.context_parallel_distribution_mode`. Default is `MAKESPAN_MIN`.
+The current distributed API selects these layouts with `UniformContextParallelSplitter`, `HeadTailContextParallelSplitter`, or `MakespanMinContextParallelSplitter`. The former `ZigzagContextParallelSplitter` name remains a deprecated compatibility alias for head-tail ownership.
 
 ### Pipeline Parallelism
 

--- a/examples/distributed/pretrain_llm.py
+++ b/examples/distributed/pretrain_llm.py
@@ -38,7 +38,7 @@ from cornstarch.distributed import (
     ParallelConfig,
     ParallelContext,
     ParallelizationPlan,
-    ZigzagContextParallelSplitter,
+    HeadTailContextParallelSplitter,
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
@@ -132,7 +132,7 @@ def pretrain(
             pipeline_parallel_size=pp,
             context_parallel_size=cp,
             context_parallel_splitter=(
-                ZigzagContextParallelSplitter() if cp > 1 else None
+                HeadTailContextParallelSplitter() if cp > 1 else None
             ),
             expert_parallel_size=ep,
             data_parallel_size=dp,

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -42,7 +42,7 @@ from cornstarch.distributed import (
     ParallelConfig,
     ParallelContext,
     ParallelizationPlan,
-    ZigzagContextParallelSplitter,
+    HeadTailContextParallelSplitter,
 )
 from cornstarch.models import (
     CornstarchExecutionPlan,
@@ -207,7 +207,7 @@ def pretrain(
             pipeline_parallel_size=llm_pp,
             context_parallel_size=llm_cp,
             context_parallel_splitter=(
-                ZigzagContextParallelSplitter() if llm_cp > 1 else None
+                HeadTailContextParallelSplitter() if llm_cp > 1 else None
             ),
             data_parallel_size=dp,
         ),

--- a/tests/distributed/test_context_parallel.py
+++ b/tests/distributed/test_context_parallel.py
@@ -13,6 +13,7 @@ from tests.distributed.distributed_base import GlooDistributedTestBase
 from cornstarch.distributed.context_parallel.splitters import (
     MakespanMinContextParallelSplitter,
     UniformContextParallelSplitter,
+    HeadTailContextParallelSplitter,
     ZigzagContextParallelSplitter,
 )
 from cornstarch.distributed import ParallelConfig, ParallelizationPlan
@@ -152,7 +153,7 @@ class TestUniformSplitter(GlooDistributedTestBase):
         )
 
 
-class TestZigzagSplitter(GlooDistributedTestBase):
+class TestHeadTailSplitter(GlooDistributedTestBase):
     @property
     def world_size(self) -> int:
         return 2
@@ -161,10 +162,10 @@ class TestZigzagSplitter(GlooDistributedTestBase):
         return dist.group.WORLD
 
     def test_coverage_and_no_overlap(self):
-        """Zigzag assignment should also cover the full sequence exactly once."""
+        """Head-tail assignment should cover the full sequence exactly once."""
         mask = _make_mask(1, 64)
         cp_group = self._get_cp_group()
-        splitter = ZigzagContextParallelSplitter()
+        splitter = HeadTailContextParallelSplitter()
         offsets_per_rank = splitter.compute_offsets(mask, cp_group)
 
         rank = dist.get_rank(cp_group)
@@ -182,10 +183,10 @@ class TestZigzagSplitter(GlooDistributedTestBase):
             self.assertEqual(combined.unique().numel(), 64)
 
     def test_rank0_gets_first_and_last_chunk(self):
-        """For 2 ranks, rank 0 should own the first and last quarter (zigzag pairing)."""
+        """For 2 ranks, rank 0 should own the first and last quarter."""
         mask = _make_mask(1, 64)
         cp_group = self._get_cp_group()
-        splitter = ZigzagContextParallelSplitter()
+        splitter = HeadTailContextParallelSplitter()
         offsets_per_rank = splitter.compute_offsets(mask, cp_group)
 
         rank = dist.get_rank(cp_group)
@@ -194,6 +195,19 @@ class TestZigzagSplitter(GlooDistributedTestBase):
             # Rank 0 pairs halves[0] + halves[3] = [0..15] ∪ [48..63]
             expected = torch.cat([torch.arange(0, 16), torch.arange(48, 64)])
             self.assertTrue(torch.equal(offsets_per_rank[0], expected))
+
+    def test_deprecated_alias_warns_and_preserves_offsets(self):
+        """The compatibility name warns and retains identical ownership."""
+        mask = _make_mask(1, 64)
+        cp_group = self._get_cp_group()
+        canonical = HeadTailContextParallelSplitter()
+        with self.assertWarnsRegex(DeprecationWarning, "HeadTail"):
+            compatibility = ZigzagContextParallelSplitter()
+
+        expected = canonical.compute_offsets(mask, cp_group)
+        actual = compatibility.compute_offsets(mask, cp_group)
+        self.assertTrue(all(torch.equal(a, b) for a, b in zip(actual, expected)))
+        self.assertEqual(repr(compatibility), "HeadTailContextParallelSplitter()")
 
 
 class TestMakespanMinSplitter(GlooDistributedTestBase):

--- a/tests/distributed/test_numerical_equivalence.py
+++ b/tests/distributed/test_numerical_equivalence.py
@@ -21,7 +21,7 @@ single ``cuda:0``, so the CP test runs on a one-GPU box (it only needs CUDA to
 be available, not >=2 devices).  CP equivalence is asserted at the
 attention-function level against a full-sequence SDPA reference, both
 *non-causal* (default kernel path) and *causal* (the per-run prefix+diagonal
-decomposition, exercised for the uniform and zigzag splitters).
+decomposition, exercised for the uniform and head-tail splitters).
 """
 from __future__ import annotations
 
@@ -461,7 +461,7 @@ class TestContextParallelEquivalence(GlooDistributedTestBase):
         )
 
     @parametrize(
-        "splitter_name", ["uniform", "zigzag"], name_fn=lambda x: f"split={x}"
+        "splitter_name", ["uniform", "headtail"], name_fn=lambda x: f"split={x}"
     )
     @parametrize("batch_size", [1, 2], name_fn=lambda x: f"bs={x}")
     @parametrize("seq_len", [128, 256], name_fn=lambda x: f"seq={x}")
@@ -472,7 +472,7 @@ class TestContextParallelEquivalence(GlooDistributedTestBase):
 
         The splitter under test produces each rank's global positions; the CP
         kernel masks against exactly those offsets (uniform = 1 contiguous run
-        per rank, zigzag = 2). The rank's local out and dq/dk/dv must match the
+        per rank, head-tail = 2). The rank's local out and dq/dk/dv must match the
         reference rows gathered back by the same offsets — forward and backward.
         """
         from flash_attn import flash_attn_func
@@ -482,17 +482,17 @@ class TestContextParallelEquivalence(GlooDistributedTestBase):
         )
         from cornstarch.distributed.context_parallel.splitters import (
             UniformContextParallelSplitter,
-            ZigzagContextParallelSplitter,
+            HeadTailContextParallelSplitter,
         )
 
         nheads, dim = 8, 64  # dim=64 / heads=8 are flash-attn-supported shapes
-        # seq must divide world_size (uniform) and 2*cp_size (zigzag chunking).
+        # seq must divide world_size (uniform) and 2*cp_size (head-tail chunking).
         assert seq_len % (2 * self.world_size) == 0
 
         splitter = (
             UniformContextParallelSplitter()
             if splitter_name == "uniform"
-            else ZigzagContextParallelSplitter()
+            else HeadTailContextParallelSplitter()
         )
         offsets_per_rank = splitter.compute_offsets(
             torch.ones(batch_size, seq_len), dist.GroupMember.WORLD
@@ -562,7 +562,7 @@ class TestContextParallelEquivalence(GlooDistributedTestBase):
         )
 
     @parametrize(
-        "splitter_name", ["uniform", "zigzag"], name_fn=lambda x: f"split={x}"
+        "splitter_name", ["uniform", "headtail"], name_fn=lambda x: f"split={x}"
     )
     def test_cp_causal_attention_from_position_ids(self, splitter_name: str):
         """Causal CP parity when offsets are recovered from ``position_ids``.
@@ -580,14 +580,14 @@ class TestContextParallelEquivalence(GlooDistributedTestBase):
         )
         from cornstarch.distributed.context_parallel.splitters import (
             UniformContextParallelSplitter,
-            ZigzagContextParallelSplitter,
+            HeadTailContextParallelSplitter,
         )
 
         q_heads, kv_heads, dim, batch_size, seq_len = 8, 2, 64, 2, 128
         splitter = (
             UniformContextParallelSplitter()
             if splitter_name == "uniform"
-            else ZigzagContextParallelSplitter()
+            else HeadTailContextParallelSplitter()
         )
         offsets_per_rank = splitter.compute_offsets(
             torch.ones(batch_size, seq_len), dist.GroupMember.WORLD


### PR DESCRIPTION
Introduces HeadTailContextParallelSplitter as the canonical public API while preserving identical token offsets. Retains ZigzagContextParallelSplitter as a one-release deprecated compatibility class that emits DeprecationWarning and uses the canonical representation. Updates active examples, documentation, attention terminology, parametrization names, and splitter tests. Validation: ruff passes; focused distributed splitter suite passes 8/8; full repository suite passes 186/186.