### PR TITLE
Fix variable Gloo all-to-all ring peers

### DIFF
--- a/tests/distributed/gloo_utils.py
+++ b/tests/distributed/gloo_utils.py
@@ -123,9 +123,10 @@ def all_to_all_single_gloo(
         # isend/irecv take *global* ranks; translate the group-local peer ids so
         # this emulation also works for sub-groups (e.g. an EP group nested in a
         # larger DP/PP/TP mesh), not just the whole world.
-        global_peer = dist.get_global_rank(group, recv_from)
-        send_req = dist.isend(send_tensor, dst=global_peer, group=group)
-        recv_req = dist.irecv(recv_tensor, src=global_peer, group=group)
+        global_send_peer = dist.get_global_rank(group, send_to)
+        global_recv_peer = dist.get_global_rank(group, recv_from)
+        send_req = dist.isend(send_tensor, dst=global_send_peer, group=group)
+        recv_req = dist.irecv(recv_tensor, src=global_recv_peer, group=group)
         recv_req.wait()
         send_req.wait()
 

--- a/tests/distributed/test_gloo_collectives.py
+++ b/tests/distributed/test_gloo_collectives.py
@@ -1,0 +1,51 @@
+"""Regression tests for the CPU/Gloo collective shims used by distributed tests."""
+
+import torch
+import torch.distributed as dist
+
+from tests.distributed.distributed_base import GlooDistributedTestBase
+
+
+class TestVariableAllToAllSingleGloo(GlooDistributedTestBase):
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def test_routes_to_clockwise_peer_and_receives_from_counterclockwise_peer(self):
+        """A ring step must not use the receive peer as its send destination."""
+        rank = dist.get_rank()
+        send_counts = (
+            (1, 2, 0, 1),
+            (0, 1, 2, 0),
+            (1, 0, 1, 2),
+            (2, 1, 0, 1),
+        )
+        input_chunks = [
+            torch.tensor(
+                [100 * rank + 10 * destination + index for index in range(count)],
+                dtype=torch.long,
+            )
+            for destination, count in enumerate(send_counts[rank])
+        ]
+        input_tensor = torch.cat(input_chunks)
+        output_counts = [send_counts[source][rank] for source in range(self.world_size)]
+        output = torch.empty(sum(output_counts), dtype=torch.long)
+
+        dist.all_to_all_single(
+            output,
+            input_tensor,
+            output_split_sizes=output_counts,
+            input_split_sizes=list(send_counts[rank]),
+            group=dist.group.WORLD,
+        )
+
+        expected = torch.cat(
+            [
+                torch.tensor(
+                    [100 * source + 10 * rank + index for index in range(count)],
+                    dtype=torch.long,
+                )
+                for source, count in enumerate(output_counts)
+            ]
+        )
+        torch.testing.assert_close(output, expected)


### PR DESCRIPTION
## Summary
- send each variable all-to-all ring chunk to the clockwise peer while receiving from the counterclockwise peer
- retain process-group local-to-global rank translation
- add a four-rank asymmetric split regression that fails when send and receive peers are conflated

## Validation
- `pytest -q tests/distributed/test_gloo_collectives.py` (1 passed)
- `ruff check tests/distributed/gloo_utils.py tests/distributed/test_gloo_collectives.py`
- `git diff --check`