### PR TITLE
Route CP-sharded modality features across meshes

### DIFF
--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -23,7 +23,9 @@ tests call these directly; everything else is built on them.
   all-gather flash attention plus data-side sequence splitters.
 - **Pipeline parallelism** (``apply_pipeline_parallel`` + the
   ``TrainingSchedule`` hierarchy + P2P): explicit Megatron/ColossalAI-style
-  1F1B scheduling, not DTensor-based.
+  1F1B scheduling, not DTensor-based. Multimodal encoder-to-LLM seams use a
+  differentiable variable-split all-to-all so each projected row moves directly
+  between its source and destination CP owners.
 - **Expert parallelism** (``apply_expert_parallel``): shards a MoE layer's
   batched experts across the EP mesh axis and routes tokens via all-to-all.
 - **Data parallelism** (``GradientSynchronizer``): bucketed gradient all-reduce

--- a/cornstarch/distributed/context_parallel/splitters.py
+++ b/cornstarch/distributed/context_parallel/splitters.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import heapq
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import numpy as np
 import torch
@@ -25,16 +25,17 @@ import torch.distributed as dist
 class ContextParallelSplitter(ABC):
     """Abstract base for context-parallel sequence splitters.
 
-    Subclasses implement ``compute_offsets`` which determines, for each CP
-    rank, which sequence positions it owns.  After ``compute_offsets`` is
-    called once per batch the ``split`` method slices any ``(batch, seq, ...)``
-    tensor for the current rank.
+    Existing subclasses may implement ``compute_offsets`` which determines, for
+    each CP rank, which sequence positions it owns. Built-in splitters also
+    implement ``offsets_for_size`` so ranks outside a modality process group can
+    plan a cross-mesh route. Third-party subclasses remain constructible and
+    retain their original ``compute_offsets`` contract; multimodal cross-mesh
+    routing asks them to opt into the pure helper explicitly.
     """
 
     def __init__(self) -> None:
         self._offsets_per_rank: list[torch.Tensor] | None = None
 
-    @abstractmethod
     def compute_offsets(
         self,
         attention_mask: torch.Tensor,
@@ -47,6 +48,33 @@ class ContextParallelSplitter(ABC):
         one per CP rank, each containing the sequence indices assigned to
         that rank.
         """
+        self._offsets_per_rank = self.offsets_for_size(
+            attention_mask, dist.get_world_size(cp_group)
+        )
+        return self._offsets_per_rank
+
+    def offsets_for_size(
+        self,
+        attention_mask: torch.Tensor,
+        cp_size: int,
+    ) -> list[torch.Tensor]:
+        """Compute offsets without requiring membership in a CP process group.
+
+        Cross-mesh routing is planned identically on encoder and language-model
+        ranks.  A rank generally belongs to only one of those meshes, so it must
+        be able to derive the other mesh's ownership from the splitter and its
+        declared size without touching that mesh's process group.
+
+        Unlike :meth:`compute_offsets`, this pure helper does not replace the
+        offsets used by :meth:`split`.
+        """
+        if cp_size < 1:
+            raise ValueError("cp_size must be >= 1.")
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support cross-mesh routing. "
+            "Implement offsets_for_size(attention_mask, cp_size) without process-"
+            "group membership."
+        )
 
     def split(
         self,
@@ -80,18 +108,16 @@ class UniformContextParallelSplitter(ContextParallelSplitter):
     are distributed to the first ranks (numpy ``array_split`` behaviour).
     """
 
-    def compute_offsets(
+    def offsets_for_size(
         self,
         attention_mask: torch.Tensor,
-        cp_group: dist.ProcessGroup,
+        cp_size: int,
     ) -> list[torch.Tensor]:
-        cp_size = dist.get_world_size(cp_group)
+        if cp_size < 1:
+            raise ValueError("cp_size must be >= 1.")
         seq_len = attention_mask.shape[1]
         chunks = np.array_split(np.arange(seq_len), cp_size)
-        self._offsets_per_rank = [
-            torch.tensor(c, dtype=torch.long) for c in chunks
-        ]
-        return self._offsets_per_rank
+        return [torch.tensor(c, dtype=torch.long) for c in chunks]
 
 
 class HeadTailContextParallelSplitter(ContextParallelSplitter):
@@ -103,22 +129,20 @@ class HeadTailContextParallelSplitter(ContextParallelSplitter):
     late (cheaper) positions, roughly balancing FLOPs across ranks.
     """
 
-    def compute_offsets(
+    def offsets_for_size(
         self,
         attention_mask: torch.Tensor,
-        cp_group: dist.ProcessGroup,
+        cp_size: int,
     ) -> list[torch.Tensor]:
-        cp_size = dist.get_world_size(cp_group)
+        if cp_size < 1:
+            raise ValueError("cp_size must be >= 1.")
         seq_len = attention_mask.shape[1]
         halves = np.array_split(np.arange(seq_len), cp_size * 2)
         paired = [
             np.concatenate([halves[i], halves[2 * cp_size - 1 - i]])
             for i in range(cp_size)
         ]
-        self._offsets_per_rank = [
-            torch.tensor(p, dtype=torch.long) for p in paired
-        ]
-        return self._offsets_per_rank
+        return [torch.tensor(p, dtype=torch.long) for p in paired]
 
 
 class ZigzagContextParallelSplitter(HeadTailContextParallelSplitter):
@@ -160,18 +184,20 @@ class MakespanMinContextParallelSplitter(ContextParallelSplitter):
         super().__init__()
         self._block_size = block_size
 
-    def compute_offsets(
+    def offsets_for_size(
         self,
         attention_mask: torch.Tensor,
-        cp_group: dist.ProcessGroup,
+        cp_size: int,
     ) -> list[torch.Tensor]:
+        if cp_size < 1:
+            raise ValueError("cp_size must be >= 1.")
         assert attention_mask.ndim in (2, 3), (
             "attention_mask must be 2-D (batch, seq) or 3-D (batch, seq_q, seq_kv)"
         )
 
         if attention_mask.ndim == 2:
-            return self._compute_from_2d(attention_mask, cp_group)
-        return self._compute_from_3d(attention_mask, cp_group)
+            return self._compute_from_2d(attention_mask, cp_size)
+        return self._compute_from_3d(attention_mask, cp_size)
 
     def _assign_blocks_greedy(
         self,
@@ -204,10 +230,9 @@ class MakespanMinContextParallelSplitter(ContextParallelSplitter):
     def _compute_from_2d(
         self,
         mask: torch.Tensor,
-        cp_group: dist.ProcessGroup,
+        cp_size: int,
     ) -> list[torch.Tensor]:
         """Assign blocks by per-block attended-token count (2-D mask)."""
-        cp_size = dist.get_world_size(cp_group)
         seq_len = mask.shape[1]
         B = self._block_size
 
@@ -223,18 +248,14 @@ class MakespanMinContextParallelSplitter(ContextParallelSplitter):
             .sum(dim=(0, 2))
             .numpy()
         )
-        self._offsets_per_rank = self._assign_blocks_greedy(
-            block_workloads, cp_size, seq_len
-        )
-        return self._offsets_per_rank
+        return self._assign_blocks_greedy(block_workloads, cp_size, seq_len)
 
     def _compute_from_3d(
         self,
         mask: torch.Tensor,
-        cp_group: dist.ProcessGroup,
+        cp_size: int,
     ) -> list[torch.Tensor]:
         """Assign blocks by per-block attended-KV-cell count (3-D mask)."""
-        cp_size = dist.get_world_size(cp_group)
         seq_len = mask.shape[1]
         B = self._block_size
 
@@ -251,7 +272,4 @@ class MakespanMinContextParallelSplitter(ContextParallelSplitter):
             .sum(dim=(0, 2, 3))
             .numpy()
         )
-        self._offsets_per_rank = self._assign_blocks_greedy(
-            block_workloads, cp_size, seq_len
-        )
-        return self._offsets_per_rank
+        return self._assign_blocks_greedy(block_workloads, cp_size, seq_len)

--- a/cornstarch/distributed/cross_mesh_routing.py
+++ b/cornstarch/distributed/cross_mesh_routing.py
@@ -1,0 +1,554 @@
+"""Differentiable N-to-M routing across multimodal context-parallel meshes.
+
+Projected modality rows are identified by their ordinal within each sample and
+matched to that sample's ordered global placeholder positions. The source
+splitter owns modality-row ordinals while the destination splitter owns merged
+text positions; no uniform-chunk or physical-rank arithmetic is used. A route
+packs rows by destination, performs one variable-split ``all_to_all_single``,
+then restores the destination splitter's local placeholder order.
+
+Pipeline schedules have an explicit autograd graph break, so they call
+``exchange_forward`` / ``exchange_backward`` and ship the exact transposed
+exchange themselves.  Co-located/direct callers can use ``route_autograd``;
+its backward is the same transposed all-to-all and never gathers full features.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+import torch
+import torch.distributed as dist
+
+
+CP_ROUTING_OFFSETS_KEY = "_cornstarch_cp_routing_offsets"
+CP_MODALITY_MASKS_KEY = "cp_modality_attention_masks"
+
+
+@dataclass(frozen=True)
+class CrossMeshGroup:
+    """One DP-replica and compatible TP/EP-lane seam process group."""
+
+    ranks: tuple[int, ...]
+    producer_ranks: tuple[int, ...]
+    consumer_ranks: tuple[int, ...]
+    process_group: dist.ProcessGroup
+    dp_rank: int
+    producer_tp_rank: int
+    producer_ep_rank: int
+    consumer_tp_rank: int
+    consumer_ep_rank: int
+
+    @property
+    def rank_to_index(self) -> dict[int, int]:
+        return {rank: index for index, rank in enumerate(self.ranks)}
+
+
+@dataclass(frozen=True)
+class RoutePlan:
+    """Rank-local packing/restoration plan for one :class:`CrossMeshGroup`."""
+
+    source_select_indices: tuple[int, ...]
+    send_indices: tuple[int, ...]
+    restore_indices: tuple[int, ...]
+    send_counts: tuple[int, ...]
+    recv_counts: tuple[int, ...]
+    source_rows: int
+    source_storage_rows: int
+    destination_rows: int
+
+
+@dataclass
+class GroupExchangeState:
+    """Saved forward layout needed for the exact reverse exchange."""
+
+    seam_group: CrossMeshGroup
+    plan: RoutePlan
+
+
+@dataclass
+class SeamExchangeState:
+    """All lane exchanges performed by one physical rank for one microbatch."""
+
+    groups: list[GroupExchangeState]
+    source_shape: torch.Size | None
+    source_fanout: int
+
+
+class _VariableSplitAllToAll(torch.autograd.Function):
+    """Autograd-aware variable row exchange, including zero-sized splits."""
+
+    @staticmethod
+    def forward(ctx, input_, output_split_sizes, input_split_sizes, group):
+        ctx.output_split_sizes = tuple(output_split_sizes)
+        ctx.input_split_sizes = tuple(input_split_sizes)
+        ctx.group = group
+        output = input_.new_empty((sum(output_split_sizes), *input_.shape[1:]))
+        dist.all_to_all_single(
+            output,
+            input_.contiguous(),
+            output_split_sizes=list(output_split_sizes),
+            input_split_sizes=list(input_split_sizes),
+            group=group,
+        )
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        grad_input = grad_output.new_empty(
+            (sum(ctx.input_split_sizes), *grad_output.shape[1:])
+        )
+        dist.all_to_all_single(
+            grad_input,
+            grad_output.contiguous(),
+            output_split_sizes=list(ctx.input_split_sizes),
+            input_split_sizes=list(ctx.output_split_sizes),
+            group=ctx.group,
+        )
+        return grad_input, None, None, None
+
+
+def _offset_lists(offsets: Sequence[torch.Tensor]) -> list[list[int]]:
+    return [offset.to(device="cpu", dtype=torch.long).tolist() for offset in offsets]
+
+
+def _placeholder_keys(
+    global_input_ids: torch.Tensor,
+    token_id: int,
+    offsets: Sequence[int],
+) -> list[tuple[int, int]]:
+    keys: list[tuple[int, int]] = []
+    ids = global_input_ids.detach().to(device="cpu")
+    for batch_index in range(ids.shape[0]):
+        for position in offsets:
+            if int(ids[batch_index, position]) == token_id:
+                keys.append((batch_index, position))
+    return keys
+
+
+def _placeholder_keys_by_source_ordinal(
+    global_input_ids: torch.Tensor,
+    token_id: int,
+    source_attention_mask: torch.Tensor,
+    source_ordinals: Sequence[int],
+) -> list[tuple[int, int]]:
+    """Map locally owned modality-row ordinals to global placeholder keys."""
+    ids = global_input_ids.detach().to(device="cpu")
+    keys: list[tuple[int, int]] = []
+    for batch_index in range(ids.shape[0]):
+        placeholders = (ids[batch_index] == token_id).nonzero(as_tuple=True)[0].tolist()
+        valid_ordinals = source_attention_mask[batch_index].nonzero(
+            as_tuple=True
+        )[0].tolist()
+        ordinal_to_placeholder = dict(zip(valid_ordinals, placeholders))
+        keys.extend(
+            (batch_index, ordinal_to_placeholder[ordinal])
+            for ordinal in source_ordinals
+            if ordinal in ordinal_to_placeholder
+        )
+    return keys
+
+
+def build_route_plan(
+    *,
+    global_input_ids: torch.Tensor,
+    token_id: int,
+    source_attention_mask: torch.Tensor | None,
+    source_offsets: Sequence[torch.Tensor],
+    destination_offsets: Sequence[torch.Tensor],
+    seam_group: CrossMeshGroup,
+    global_rank: int,
+) -> RoutePlan:
+    """Derive a deterministic one-row-per-placeholder route from real offsets."""
+    if global_input_ids.ndim != 2:
+        raise ValueError("cp_global_input_ids must have shape (batch, sequence).")
+
+    source = _offset_lists(source_offsets)
+    destination = _offset_lists(destination_offsets)
+    seq_len = global_input_ids.shape[1]
+    source_flat = [ordinal for rank_offsets in source for ordinal in rank_offsets]
+    source_length = max(source_flat, default=-1) + 1
+    if sorted(source_flat) != list(range(source_length)):
+        raise ValueError(
+            "Source CP offsets must own every modality row ordinal exactly once."
+        )
+    placeholder_counts = (global_input_ids == token_id).sum(dim=1).to(device="cpu")
+    if source_attention_mask is None:
+        source_attention_mask = (
+            torch.arange(source_length).unsqueeze(0)
+            < placeholder_counts.unsqueeze(1)
+        )
+    source_attention_mask = source_attention_mask.detach().to(
+        device="cpu", dtype=torch.bool
+    )
+    if source_attention_mask.shape != (global_input_ids.shape[0], source_length):
+        raise ValueError(
+            "The modality attention mask must have shape (batch, projected_sequence)."
+        )
+    if not torch.equal(source_attention_mask.sum(dim=1), placeholder_counts):
+        raise ValueError(
+            "Each sample's valid projected modality rows must equal its placeholder count."
+        )
+    destination_flat = [
+        position for rank_offsets in destination for position in rank_offsets
+    ]
+    if sorted(destination_flat) != list(range(seq_len)):
+        raise ValueError(
+            "Destination CP offsets must own every merged-text position exactly once."
+        )
+
+    destination_owner = {
+        position: cp_rank
+        for cp_rank, rank_offsets in enumerate(destination)
+        for position in rank_offsets
+    }
+    rank_to_index = seam_group.rank_to_index
+
+    source_cp = (
+        seam_group.producer_ranks.index(global_rank)
+        if global_rank in seam_group.producer_ranks
+        else None
+    )
+    destination_cp = (
+        seam_group.consumer_ranks.index(global_rank)
+        if global_rank in seam_group.consumer_ranks
+        else None
+    )
+
+    local_source_keys = (
+        _placeholder_keys_by_source_ordinal(
+            global_input_ids,
+            token_id,
+            source_attention_mask,
+            source[source_cp],
+        )
+        if source_cp is not None
+        else []
+    )
+    send_by_peer: list[list[int]] = [[] for _ in seam_group.ranks]
+    for row, key in enumerate(local_source_keys):
+        peer = seam_group.consumer_ranks[destination_owner[key[1]]]
+        send_by_peer[rank_to_index[peer]].append(row)
+    send_indices = tuple(row for rows in send_by_peer for row in rows)
+    send_counts = tuple(len(rows) for rows in send_by_peer)
+    local_source_width = len(source[source_cp]) if source_cp is not None else 0
+    source_select_indices = tuple(
+        batch_index * local_source_width + local_index
+        for batch_index in range(global_input_ids.shape[0])
+        for local_index, ordinal in enumerate(source[source_cp] if source_cp is not None else [])
+        if bool(source_attention_mask[batch_index, ordinal])
+    )
+
+    desired_keys = (
+        _placeholder_keys(global_input_ids, token_id, destination[destination_cp])
+        if destination_cp is not None
+        else []
+    )
+    incoming_by_peer: list[list[tuple[int, int]]] = [[] for _ in seam_group.ranks]
+    if destination_cp is not None:
+        # Reconstruct each source's exact packing order, then retain only rows
+        # addressed to this destination. This keeps restoration correct even if
+        # a certified splitter stores non-monotonic offsets.
+        for source_cp_rank, source_rank in enumerate(seam_group.producer_ranks):
+            source_keys = _placeholder_keys_by_source_ordinal(
+                global_input_ids,
+                token_id,
+                source_attention_mask,
+                source[source_cp_rank],
+            )
+            incoming_by_peer[rank_to_index[source_rank]].extend(
+                key for key in source_keys
+                if destination_owner[key[1]] == destination_cp
+            )
+    recv_counts = tuple(len(keys) for keys in incoming_by_peer)
+    arrival_keys = [key for keys in incoming_by_peer for key in keys]
+    arrival_index = {key: index for index, key in enumerate(arrival_keys)}
+    restore_indices = tuple(arrival_index[key] for key in desired_keys)
+
+    return RoutePlan(
+        source_select_indices=source_select_indices,
+        send_indices=send_indices,
+        restore_indices=restore_indices,
+        send_counts=send_counts,
+        recv_counts=recv_counts,
+        source_rows=len(local_source_keys),
+        source_storage_rows=global_input_ids.shape[0] * local_source_width,
+        destination_rows=len(desired_keys),
+    )
+
+
+def _pack(features: torch.Tensor, plan: RoutePlan) -> torch.Tensor:
+    flat = features.reshape(-1, features.shape[-1])
+    if flat.shape[0] == plan.source_storage_rows:
+        source_index = torch.tensor(
+            plan.source_select_indices, dtype=torch.long, device=flat.device
+        )
+        flat = flat.index_select(0, source_index)
+    elif flat.shape[0] != plan.source_rows:
+        raise ValueError(
+            "The modality projector must produce exactly one feature row per "
+            f"locally owned placeholder; got {flat.shape[0]} rows for "
+            f"{plan.source_rows} placeholders. Projectors with a different output "
+            "length require an explicit placeholder span map."
+        )
+    index = torch.tensor(plan.send_indices, dtype=torch.long, device=flat.device)
+    return flat.index_select(0, index)
+
+
+def _restore(received: torch.Tensor, plan: RoutePlan) -> torch.Tensor:
+    index = torch.tensor(plan.restore_indices, dtype=torch.long, device=received.device)
+    return received.index_select(0, index)
+
+
+def route_autograd(
+    features: torch.Tensor,
+    plan: RoutePlan,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Route local rows differentiably through one cross-mesh seam group."""
+    packed = _pack(features, plan)
+    received = _VariableSplitAllToAll.apply(
+        packed, plan.recv_counts, plan.send_counts, group
+    )
+    return _restore(received, plan)
+
+
+def exchange_forward(
+    features: torch.Tensor,
+    plan: RoutePlan,
+    group: dist.ProcessGroup,
+) -> torch.Tensor:
+    """Non-autograd forward used at an explicit pipeline graph break."""
+    packed = _pack(features, plan)
+    received = features.new_empty((sum(plan.recv_counts), features.shape[-1]))
+    dist.all_to_all_single(
+        received,
+        packed.contiguous(),
+        output_split_sizes=list(plan.recv_counts),
+        input_split_sizes=list(plan.send_counts),
+        group=group,
+    )
+    return _restore(received, plan)
+
+
+def exchange_backward(
+    destination_grad: torch.Tensor,
+    state: GroupExchangeState,
+    *,
+    hidden_size: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> torch.Tensor:
+    """Transpose a pipeline seam exchange without a full gradient collective."""
+    plan = state.plan
+    if destination_grad.reshape(-1, hidden_size).shape[0] != plan.destination_rows:
+        raise ValueError(
+            "Destination feature gradient row count changed across the pipeline seam."
+        )
+    grad = destination_grad.reshape(-1, hidden_size).to(device=device, dtype=dtype)
+    arrival_grad = grad.new_empty((sum(plan.recv_counts), hidden_size))
+    if plan.restore_indices:
+        restore = torch.tensor(plan.restore_indices, dtype=torch.long, device=device)
+        arrival_grad.index_copy_(0, restore, grad)
+    packed_grad = grad.new_empty((sum(plan.send_counts), hidden_size))
+    dist.all_to_all_single(
+        packed_grad,
+        arrival_grad.contiguous(),
+        output_split_sizes=list(plan.send_counts),
+        input_split_sizes=list(plan.recv_counts),
+        group=state.seam_group.process_group,
+    )
+    source_grad = grad.new_zeros((plan.source_rows, hidden_size))
+    if plan.send_indices:
+        send_index = torch.tensor(plan.send_indices, dtype=torch.long, device=device)
+        source_grad.index_add_(0, send_index, packed_grad)
+    return source_grad
+
+
+class CrossMeshRouter:
+    """Groups and rank-local routing for one encoder-to-language-model seam."""
+
+    def __init__(self, groups: Sequence[CrossMeshGroup]) -> None:
+        rank = dist.get_rank()
+        self._groups = [group for group in groups if rank in group.ranks]
+        self._rank = rank
+
+    @property
+    def groups(self) -> tuple[CrossMeshGroup, ...]:
+        return tuple(self._groups)
+
+    def forward(
+        self,
+        features: torch.Tensor | None,
+        *,
+        global_input_ids: torch.Tensor,
+        token_id: int,
+        source_attention_mask: torch.Tensor | None,
+        source_offsets: Sequence[torch.Tensor],
+        destination_offsets: Sequence[torch.Tensor],
+        hidden_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor | None, SeamExchangeState]:
+        received: torch.Tensor | None = None
+        states: list[GroupExchangeState] = []
+        source_shape = features.shape if features is not None else None
+        source_groups = 0
+
+        for seam_group in self._groups:
+            plan = build_route_plan(
+                global_input_ids=global_input_ids,
+                token_id=token_id,
+                source_attention_mask=source_attention_mask,
+                source_offsets=source_offsets,
+                destination_offsets=destination_offsets,
+                seam_group=seam_group,
+                global_rank=self._rank,
+            )
+            is_source = self._rank in seam_group.producer_ranks
+            is_destination = self._rank in seam_group.consumer_ranks
+            if is_source:
+                source_groups += 1
+                if features is None:
+                    raise ValueError("A producer seam rank did not supply modality features.")
+                local = features.to(device=device, dtype=dtype)
+            else:
+                local = torch.empty((0, hidden_size), device=device, dtype=dtype)
+            routed = exchange_forward(local, plan, seam_group.process_group)
+            if is_destination:
+                if received is not None:
+                    raise RuntimeError("A destination rank belongs to multiple seam lanes.")
+                received = routed
+            states.append(GroupExchangeState(seam_group, plan))
+
+        return received, SeamExchangeState(states, source_shape, source_groups)
+
+    def backward(
+        self,
+        destination_grad: torch.Tensor | None,
+        state: SeamExchangeState,
+        *,
+        hidden_size: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> torch.Tensor | None:
+        source_grad: torch.Tensor | None = None
+        for group_state in state.groups:
+            group = group_state.seam_group
+            if self._rank in group.consumer_ranks:
+                if destination_grad is None:
+                    raise ValueError("A consumer seam rank did not supply a feature gradient.")
+                local_grad = destination_grad
+            else:
+                local_grad = torch.empty((0, hidden_size), device=device, dtype=dtype)
+            returned = exchange_backward(
+                local_grad,
+                group_state,
+                hidden_size=hidden_size,
+                dtype=dtype,
+                device=device,
+            )
+            if self._rank in group.producer_ranks:
+                source_grad = returned if source_grad is None else source_grad + returned
+
+        if source_grad is not None and state.source_fanout > 1:
+            source_grad.div_(state.source_fanout)
+        if source_grad is not None and state.source_shape is not None:
+            plan = state.groups[0].plan
+            storage_rows = state.source_shape.numel() // hidden_size
+            if storage_rows == plan.source_storage_rows:
+                storage_grad = source_grad.new_zeros((storage_rows, hidden_size))
+                if plan.source_select_indices:
+                    source_index = torch.tensor(
+                        plan.source_select_indices,
+                        dtype=torch.long,
+                        device=device,
+                    )
+                    storage_grad.index_copy_(0, source_index, source_grad)
+                source_grad = storage_grad
+            elif storage_rows != plan.source_rows:
+                raise ValueError(
+                    "The producer feature shape changed across the pipeline seam."
+                )
+            source_grad = source_grad.reshape(state.source_shape)
+        return source_grad
+
+
+def build_cross_mesh_groups(
+    *,
+    producer_layout: Any,
+    consumer_layout: Any,
+) -> list[CrossMeshGroup]:
+    """Collectively construct deterministic DP-local seam groups on all ranks.
+
+    The projected hidden dimension is replicated today. Equal TP/EP degrees pair
+    like lanes; a producer degree of one may fan out to replicated consumer
+    lanes. A producer-sharded layout cannot be collapsed implicitly and is
+    rejected rather than mixing incompatible hidden-dimension shards.
+    """
+    if producer_layout.dp_size != consumer_layout.dp_size:
+        raise ValueError("Encoder and language-model seam layouts must have equal DP size.")
+    for axis in ("tp_size", "ep_size"):
+        producer_degree = getattr(producer_layout, axis)
+        consumer_degree = getattr(consumer_layout, axis)
+        if producer_degree not in (1, consumer_degree):
+            label = axis.removesuffix("_size").upper()
+            raise ValueError(
+                f"Incompatible {label} layout at modality seam: producer degree "
+                f"{producer_degree}, consumer degree {consumer_degree}. The "
+                "projected hidden dimension must be replicated on the producer "
+                "or paired across equal lanes."
+            )
+
+    groups: list[CrossMeshGroup] = []
+    for dp_rank in range(producer_layout.dp_size):
+        for consumer_tp in range(consumer_layout.tp_size):
+            producer_tp = 0 if producer_layout.tp_size == 1 else consumer_tp
+            for consumer_ep in range(consumer_layout.ep_size):
+                producer_ep = 0 if producer_layout.ep_size == 1 else consumer_ep
+                producer_ranks = tuple(
+                    producer_layout.rank_at(
+                        dp_rank,
+                        producer_layout.last_stage,
+                        cp_rank,
+                        producer_tp,
+                        producer_ep,
+                    )
+                    for cp_rank in range(producer_layout.cp_size)
+                )
+                consumer_ranks = tuple(
+                    consumer_layout.rank_at(
+                        dp_rank, 0, cp_rank, consumer_tp, consumer_ep
+                    )
+                    for cp_rank in range(consumer_layout.cp_size)
+                )
+                ranks = tuple(dict.fromkeys((*producer_ranks, *consumer_ranks)))
+                process_group = dist.new_group(ranks=list(ranks))
+                groups.append(
+                    CrossMeshGroup(
+                        ranks=ranks,
+                        producer_ranks=producer_ranks,
+                        consumer_ranks=consumer_ranks,
+                        process_group=process_group,
+                        dp_rank=dp_rank,
+                        producer_tp_rank=producer_tp,
+                        producer_ep_rank=producer_ep,
+                        consumer_tp_rank=consumer_tp,
+                        consumer_ep_rank=consumer_ep,
+                    )
+                )
+    return groups
+
+
+def routing_offsets_from_batch(
+    batch: Mapping[str, Any], module_id: int
+) -> Sequence[torch.Tensor]:
+    """Read module-specific offsets preserved by ``ParallelContext``."""
+    metadata = batch.get(CP_ROUTING_OFFSETS_KEY)
+    if not isinstance(metadata, Mapping) or module_id not in metadata:
+        raise ValueError(
+            "Cross-mesh CP routing metadata is missing. Use "
+            "ParallelContext.prepare_dataloader() so both meshes' actual offsets "
+            "are preserved per microbatch."
+        )
+    return metadata[module_id]

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -26,6 +26,12 @@ from torch.utils.data import DataLoader, Dataset, DistributedSampler
 
 from cornstarch.distributed.context_parallel import apply_context_parallel
 from cornstarch.distributed.context_parallel.splitters import ContextParallelSplitter
+from cornstarch.distributed.cross_mesh_routing import (
+    CP_MODALITY_MASKS_KEY,
+    CP_ROUTING_OFFSETS_KEY,
+    CrossMeshGroup,
+    build_cross_mesh_groups,
+)
 from cornstarch.distributed.data_parallel import GradientSynchronizer
 from cornstarch.distributed.expert_parallel import apply_expert_parallel
 from cornstarch.distributed.parallel_config import ParallelConfig
@@ -78,6 +84,7 @@ class ParallelContext:
         dp_group: Optional[dist.ProcessGroup],
         gradient_synchronizer: Optional[GradientSynchronizer],
         cp_gradient_synchronizers: Sequence[GradientSynchronizer] = (),
+        cross_mesh_groups: dict[tuple[int, int], list[CrossMeshGroup]] | None = None,
         uses_pipeline_parallel: bool = False,
     ) -> None:
         self._modules = modules
@@ -89,6 +96,7 @@ class ParallelContext:
         self._dp_group = dp_group
         self._gradient_synchronizer = gradient_synchronizer
         self._cp_gradient_synchronizers = list(cp_gradient_synchronizers)
+        self._cross_mesh_groups = dict(cross_mesh_groups or {})
         self._uses_pipeline_parallel = uses_pipeline_parallel
 
     # ------------------------------------------------------------------
@@ -161,6 +169,16 @@ class ParallelContext:
         each microbatch independently. Pipeline schedules consume this list as
         their microbatches; without pipeline parallelism the training loop
         iterates it with gradient accumulation.
+
+        **Multimodal CP seam metadata.** A collator whose modality projector
+        emits padded context-sharded rows should include
+        ``cp_modality_attention_masks`` as a mapping from modality name to its
+        boolean ``(batch, projected_sequence)`` mask. The encoder splitter's
+        actual offsets are computed from that modality-specific mask, while the
+        LLM splitter's offsets come from the full text mask. If the mapping is
+        omitted, the schedule derives a left-packed mask from each sample's
+        placeholder count; non-left-packed or independently padded projectors
+        must provide the explicit mask.
         """
         sampler = None
         if self._dp_size > 1:
@@ -172,7 +190,7 @@ class ParallelContext:
             )
 
         cp_targets = [
-            (cfg.context_parallel_splitter, self._meshes[id(m)].cp_group)
+            (m, cfg, self._meshes[id(m)].cp_group)
             for m, cfg in zip(self._modules, self._configs)
             if cfg.context_parallel_size > 1
             and cfg.context_parallel_splitter is not None
@@ -199,6 +217,39 @@ class ParallelContext:
                     torch.ones_like(input_ids, dtype=torch.bool),
                 )
 
+            # Preserve both sides' exact ownership for the encoder->LLM seam.
+            # Every rank derives this pure metadata from the same global mask;
+            # membership in the other modality's CP process group is unnecessary.
+            global_ids = batch.get("cp_global_input_ids")
+            text_routing_mask = batch.get("attention_mask")
+            modality_masks = batch.get(CP_MODALITY_MASKS_KEY, {})
+            if (
+                self._cross_mesh_groups
+                and isinstance(global_ids, torch.Tensor)
+                and text_routing_mask is not None
+            ):
+                routing_offsets: dict[int, tuple[torch.Tensor, ...]] = {}
+                for module, config in zip(self._modules, self._configs):
+                    splitter = config.context_parallel_splitter
+                    if isinstance(module, CornstarchModalityEncoder):
+                        routing_mask = modality_masks.get(module.modality)
+                        if routing_mask is None:
+                            # The schedule can derive a validated one-row-per-
+                            # placeholder mask once it knows this plan's token ID.
+                            continue
+                    else:
+                        routing_mask = text_routing_mask
+                    if splitter is None:
+                        offsets = [
+                            torch.arange(routing_mask.shape[1], dtype=torch.long)
+                        ]
+                    else:
+                        offsets = splitter.offsets_for_size(
+                            routing_mask, config.context_parallel_size
+                        )
+                    routing_offsets[id(module)] = tuple(offsets)
+                batch[CP_ROUTING_OFFSETS_KEY] = routing_offsets
+
             labels = batch.get("labels")
             if isinstance(labels, torch.Tensor) and labels.ndim >= 2:
                 shift_labels = torch.empty_like(labels)
@@ -215,14 +266,30 @@ class ParallelContext:
             # given key only once rather than repeatedly shortening it.
             source_batch = dict(batch)
             split_keys_seen: set[str] = set()
-            for splitter, cp_group in cp_targets:
-                mask = source_batch.get("attention_mask")
+            for module, config, cp_group in cp_targets:
+                splitter = config.context_parallel_splitter
+                is_modality = isinstance(module, CornstarchModalityEncoder)
+                mask = (
+                    source_batch.get(CP_MODALITY_MASKS_KEY, {}).get(module.modality)
+                    if is_modality
+                    else source_batch.get("attention_mask")
+                )
                 if mask is None:
+                    if is_modality:
+                        # Modality inputs may already have been sharded by their
+                        # processor/collator. Their routing offsets are derived
+                        # at schedule time from placeholder counts.
+                        continue
                     ref = source_batch.get("input_ids")
                     if ref is None:
                         continue
                     mask = torch.ones_like(ref, dtype=torch.float32)
                 splitter.compute_offsets(mask, cp_group)
+                if is_modality:
+                    # Text fields belong to the LLM CP layout. Modality tensor
+                    # sharding remains processor-specific; only its actual
+                    # offsets/mask are retained here for seam routing.
+                    continue
                 for key in cp_split_keys:
                     if key in split_keys_seen:
                         continue
@@ -286,6 +353,11 @@ class ParallelContext:
             {id(module): self._layouts[id(module)] for module in self._modules},
             self._meshes,
             self._dp_size,
+            self._cross_mesh_groups,
+            {
+                id(module): (config.context_parallel_splitter, config.context_parallel_size)
+                for module, config in zip(self._modules, self._configs)
+            },
         )
 
     # ------------------------------------------------------------------
@@ -479,6 +551,7 @@ class ParallelizationPlan:
             meshes
         )
         cp_grad_syncs = self._build_cp_gradient_synchronizers(meshes)
+        cross_mesh_groups = self._build_cross_mesh_groups(layouts)
 
         return ParallelContext(
             modules=self._modules,
@@ -490,8 +563,35 @@ class ParallelizationPlan:
             dp_group=dp_group,
             gradient_synchronizer=grad_sync,
             cp_gradient_synchronizers=cp_grad_syncs,
+            cross_mesh_groups=cross_mesh_groups,
             uses_pipeline_parallel=pipelined,
         )
+
+    def _build_cross_mesh_groups(
+        self, layouts: dict[int, MeshLayout]
+    ) -> dict[tuple[int, int], list[CrossMeshGroup]]:
+        """Build every encoder->LLM seam group in registration order.
+
+        ``dist.new_group`` creation is a world-order-sensitive operation. Every
+        rank executes these nested loops over the identical module list, even
+        when it belongs to neither side of a particular seam.
+        """
+        encoders = [
+            module for module in self._modules
+            if isinstance(module, CornstarchModalityEncoder)
+        ]
+        language_models = [
+            module for module in self._modules
+            if isinstance(module, CornstarchLanguageModel)
+        ]
+        result: dict[tuple[int, int], list[CrossMeshGroup]] = {}
+        for encoder in encoders:
+            for language_model in language_models:
+                result[(id(encoder), id(language_model))] = build_cross_mesh_groups(
+                    producer_layout=layouts[id(encoder)],
+                    consumer_layout=layouts[id(language_model)],
+                )
+        return result
 
     def _assign_ranks(
         self, global_ranks: list[int], world_size: int

--- a/cornstarch/distributed/pipeline_parallel/schedule.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule.py
@@ -15,10 +15,9 @@ rank ranges and form a pipeline:
   stage; the language model is pipelined across the rest).
 
 The boundary between the encoder mesh and the language-model mesh is a
-pipeline-stage boundary — a *seam* — crossed with the same point-to-point
-transport as an ordinary stage hop, but with the cross-mesh rank pairing
-(producer representative broadcasts to the consumer's first-stage TP/EP group;
-mirrored on the backward).
+pipeline-stage boundary — a *seam*. Projected rows cross it through a DP-local,
+variable-split all-to-all that maps the encoder and language-model CP layouts;
+ordinary point-to-point transport remains in use for intra-model PP hops.
 
 ``TrainingSchedule``
     Abstract base: ``step(microbatches, criterion, optimizer)`` runs one
@@ -36,7 +35,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any, Callable, Mapping
 
 import torch
 import torch.distributed as dist
@@ -44,7 +43,14 @@ from torch.optim import Optimizer
 
 from cornstarch.distributed.pipeline_parallel.p2p import (
     PipelineP2PCommunication,
-    exchange_objects,
+)
+from cornstarch.distributed.cross_mesh_routing import (
+    CP_MODALITY_MASKS_KEY,
+    CP_ROUTING_OFFSETS_KEY,
+    CrossMeshGroup,
+    CrossMeshRouter,
+    SeamExchangeState,
+    routing_offsets_from_batch,
 )
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.models.multimodal.execution import (
@@ -226,6 +232,8 @@ class BasePipelineSchedule(TrainingSchedule):
         layouts: dict[int, MeshLayout],
         meshes: dict[int, ModalProcessGroupMesh],
         dp_size: int,
+        cross_mesh_groups: dict[tuple[int, int], list[CrossMeshGroup]] | None = None,
+        routing_splitters: dict[int, tuple[Any, int]] | None = None,
     ) -> None:
         self._plan = plan
         self._output_future = output_future
@@ -233,6 +241,8 @@ class BasePipelineSchedule(TrainingSchedule):
         self._dp_size = dp_size
         self._my_rank = dist.get_rank()
         self._device: torch.device | None = None
+        self._seam_states: list[SeamExchangeState] = []
+        self._routing_splitters = dict(routing_splitters or {})
 
         nodes = plan._topological_nodes(output_future.name)
         self._encoder_nodes = [n for n in nodes if n.kind == "run_modality_encoder"]
@@ -279,6 +289,22 @@ class BasePipelineSchedule(TrainingSchedule):
             ]
             # The merge consumes the encoder output under this future name.
             self._encoder_output_name = self._encoder_nodes[0].name
+            producer_module = self._encoder_nodes[0].params["module"]
+            consumer_module = self._lm_node.params["module"]
+            self._seam_producer_module_id = id(producer_module)
+            self._seam_consumer_module_id = id(consumer_module)
+            seam_groups = (cross_mesh_groups or {}).get(
+                (self._seam_producer_module_id, self._seam_consumer_module_id)
+            )
+            if seam_groups is None:
+                raise ValueError(
+                    "A multimodal pipeline schedule requires cross-mesh seam "
+                    "groups. Construct it with ParallelContext.create_schedule()."
+                )
+            self._seam_router = CrossMeshRouter(seam_groups)
+            self._seam_modality = getattr(producer_module, "modality", None)
+            if self._seam_modality is None:
+                raise ValueError("A modality encoder seam must declare its modality name.")
 
         self._modality_token_ids: dict[str, int] = (
             dict(self._merge_node.params.get("modality_token_ids", {}))
@@ -442,96 +468,142 @@ class BasePipelineSchedule(TrainingSchedule):
     # Seam transport (encoder <-> language-model boundary)
     # ------------------------------------------------------------------
 
-    def _seam_send_forward(self, obj: Any) -> None:
-        prod, cons = self._seam_producer, self._lm_layout
-        for d in range(self._dp_size):
-            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
-            if self._my_rank == producer_rep:
-                exchange_objects(obj, cons.stage_ranks(d, 0), [], self._device)
+    def _seam_spec(self, obj: torch.Tensor | None) -> tuple[int, torch.dtype]:
+        hidden_size = int(self._lm_node.params["module"].hf_config.hidden_size)
+        if obj is not None:
+            if obj.shape[-1] != hidden_size:
+                raise ValueError(
+                    f"Projected modality hidden size {obj.shape[-1]} does not match "
+                    f"language-model hidden size {hidden_size}."
+                )
+            return hidden_size, obj.dtype
+        embedding = self._lm_node.params["module"].pre_decoder["embed_tokens"]
+        parameter = next(embedding.parameters())
+        return hidden_size, parameter.dtype
 
-    def _seam_recv_forward(self) -> Any | None:
-        prod, cons = self._seam_producer, self._lm_layout
-        for d in range(self._dp_size):
-            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
-            if self._my_rank in cons.stage_ranks(d, 0):
-                received = exchange_objects(None, [], [producer_rep], self._device)[0]
-                if isinstance(received, torch.Tensor):
-                    received.requires_grad_(True)
-                return received
-        return None
+    def _routing_offsets(self, microbatch: dict, module_id: int, layout: MeshLayout):
+        metadata = microbatch.get(CP_ROUTING_OFFSETS_KEY)
+        if isinstance(metadata, dict) and module_id in metadata:
+            return routing_offsets_from_batch(microbatch, module_id)
+        if module_id == self._seam_producer_module_id:
+            global_ids = microbatch.get("cp_global_input_ids", microbatch["input_ids"])
+            counts = (global_ids == self._modality_token_ids[self._seam_modality]).sum(
+                dim=1
+            )
+            modality_length = int(counts.max().item()) if counts.numel() else 0
+            mask = (
+                torch.arange(modality_length, device=global_ids.device).unsqueeze(0)
+                < counts.unsqueeze(1)
+            )
+            splitter, cp_size = self._routing_splitters[module_id]
+            if splitter is None:
+                return (torch.arange(modality_length, dtype=torch.long),)
+            return tuple(splitter.offsets_for_size(mask, cp_size))
+        if layout.cp_size == 1:
+            global_ids = microbatch.get("cp_global_input_ids", microbatch["input_ids"])
+            return (torch.arange(global_ids.shape[1], dtype=torch.long),)
+        raise ValueError(
+            "Context-sharded modality routing requires per-microbatch offsets; "
+            "build batches with ParallelContext.prepare_dataloader()."
+        )
+
+    def _seam_forward(
+        self, obj: torch.Tensor | None, microbatch: dict
+    ) -> torch.Tensor | None:
+        global_ids = microbatch.get("cp_global_input_ids", microbatch.get("input_ids"))
+        if not isinstance(global_ids, torch.Tensor):
+            raise ValueError("Cross-mesh routing requires global input_ids metadata.")
+        modality_masks = microbatch.get(CP_MODALITY_MASKS_KEY, {})
+        if not isinstance(modality_masks, Mapping):
+            raise ValueError("cp_modality_attention_masks must be a modality mapping.")
+        source_attention_mask = modality_masks.get(self._seam_modality)
+        if source_attention_mask is None:
+            counts = (global_ids == self._modality_token_ids[self._seam_modality]).sum(
+                dim=1
+            )
+            modality_length = int(counts.max().item()) if counts.numel() else 0
+            source_attention_mask = (
+                torch.arange(modality_length, device=global_ids.device).unsqueeze(0)
+                < counts.unsqueeze(1)
+            )
+        hidden_size, dtype = self._seam_spec(obj)
+        received, state = self._seam_router.forward(
+            obj,
+            global_input_ids=global_ids,
+            token_id=self._modality_token_ids[self._seam_modality],
+            source_attention_mask=source_attention_mask,
+            source_offsets=self._routing_offsets(
+                microbatch, self._seam_producer_module_id, self._seam_producer
+            ),
+            destination_offsets=self._routing_offsets(
+                microbatch, self._seam_consumer_module_id, self._lm_layout
+            ),
+            hidden_size=hidden_size,
+            dtype=dtype,
+            device=self._device,
+        )
+        self._seam_states.append(state)
+        if received is not None:
+            received.requires_grad_(True)
+        return received
+
+    def _seam_backward(self, grad: torch.Tensor | None) -> torch.Tensor | None:
+        if not self._seam_states:
+            raise RuntimeError("Cross-mesh backward has no matching forward state.")
+        state = self._seam_states.pop(0)
+        hidden_size, dtype = self._seam_spec(grad)
+        return self._seam_router.backward(
+            grad,
+            state,
+            hidden_size=hidden_size,
+            dtype=dtype,
+            device=self._device,
+        )
+
+    def _seam_send_forward(self, obj: Any, microbatch: dict) -> None:
+        self._seam_forward(obj, microbatch)
+
+    def _seam_recv_forward(self, microbatch: dict) -> Any | None:
+        return self._seam_forward(None, microbatch)
 
     def _seam_send_backward(self, grad: Any) -> None:
-        prod, cons = self._seam_producer, self._lm_layout
-        for d in range(self._dp_size):
-            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
-            if self._my_rank == consumer_rep:
-                exchange_objects(grad, prod.stage_ranks(d, prod.last_stage), [], self._device)
+        self._seam_backward(grad)
 
     def _seam_recv_backward(self) -> Any | None:
-        prod, cons = self._seam_producer, self._lm_layout
-        for d in range(self._dp_size):
-            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
-            if self._my_rank in prod.stage_ranks(d, prod.last_stage):
-                return exchange_objects(None, [], [consumer_rep], self._device)[0]
-        return None
+        return self._seam_backward(None)
 
-    def _seam_send_forward_recv_backward(self, obj: Any) -> Any | None:
-        """Encoder side: send features forward and receive the gradient back.
+    def _seam_send_forward_recv_backward(
+        self, obj: Any, microbatch: dict
+    ) -> Any | None:
+        self._seam_forward(obj, microbatch)
+        return self._seam_backward(None)
 
-        Issued as a single ``batch_isend_irecv`` (send + recv together) so the
-        encoder and language-model meshes do not both block on a send.
-        """
-        prod, cons = self._seam_producer, self._lm_layout
-        grad = None
-        for d in range(self._dp_size):
-            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
-            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
-            if self._my_rank == producer_rep:
-                grad = exchange_objects(
-                    obj, cons.stage_ranks(d, 0), [consumer_rep], self._device
-                )[0]
-            elif self._my_rank in prod.stage_ranks(d, prod.last_stage):
-                grad = exchange_objects(None, [], [consumer_rep], self._device)[0]
-        return grad
-
-    def _seam_send_backward_recv_forward(self, grad: Any) -> Any | None:
-        """Language-model side: send the gradient back and receive features.
-
-        Mirror of :meth:`_seam_send_forward_recv_backward`; the consumer
-        representative ships the gradient to every producer rank and all consumer
-        ranks receive the next microbatch's features in the same exchange.
-        """
-        prod, cons = self._seam_producer, self._lm_layout
-        feat = None
-        for d in range(self._dp_size):
-            producer_rep = prod.rank_at(d, prod.last_stage, 0, 0, 0)
-            consumer_rep = cons.rank_at(d, 0, 0, 0, 0)
-            if self._my_rank == consumer_rep:
-                feat = exchange_objects(
-                    grad, prod.stage_ranks(d, prod.last_stage), [producer_rep], self._device
-                )[0]
-            elif self._my_rank in cons.stage_ranks(d, 0):
-                feat = exchange_objects(None, [], [producer_rep], self._device)[0]
-        if isinstance(feat, torch.Tensor):
-            feat.requires_grad_(True)
+    def _seam_send_backward_recv_forward(
+        self, grad: Any, microbatch: dict
+    ) -> Any | None:
+        # Both sides issue collectives in forward-then-backward order. This is
+        # the deterministic ordering required when adjacent 1F1B microbatches
+        # overlap at a cross-mesh seam.
+        feat = self._seam_forward(None, microbatch)
+        self._seam_backward(grad)
         return feat
 
     # ------------------------------------------------------------------
     # Neighbor communication (dispatch seam vs intra-mesh)
     # ------------------------------------------------------------------
 
-    def _recv_forward(self) -> Any | None:
+    def _recv_forward(self, microbatch: dict) -> Any | None:
         if self.is_first_stage():
             return None
         if self._seam_on_recv():
-            return self._seam_recv_forward()
+            return self._seam_recv_forward(microbatch)
         return self._lm_comm.recv_forward()
 
-    def _send_forward(self, obj: Any) -> None:
+    def _send_forward(self, obj: Any, microbatch: dict) -> None:
         if self.is_last_stage():
             return
         if self._seam_on_send():
-            self._seam_send_forward(obj)
+            self._seam_send_forward(obj, microbatch)
             return
         self._lm_comm.send_forward(obj)
 
@@ -550,18 +622,18 @@ class BasePipelineSchedule(TrainingSchedule):
             return
         self._lm_comm.send_backward(grad)
 
-    def _send_forward_recv_backward(self, obj: Any) -> Any | None:
+    def _send_forward_recv_backward(self, obj: Any, microbatch: dict) -> Any | None:
         if self.is_last_stage():
             return None
         if self._seam_on_send():
-            return self._seam_send_forward_recv_backward(obj)
+            return self._seam_send_forward_recv_backward(obj, microbatch)
         return self._lm_comm.send_forward_recv_backward(obj)
 
-    def _send_backward_recv_forward(self, grad: Any) -> Any | None:
+    def _send_backward_recv_forward(self, grad: Any, microbatch: dict) -> Any | None:
         if self.is_first_stage():
             return None
         if self._seam_on_recv():
-            return self._seam_send_backward_recv_forward(grad)
+            return self._seam_send_backward_recv_forward(grad, microbatch)
         return self._lm_comm.send_backward_recv_forward(grad)
 
 
@@ -606,28 +678,32 @@ class OneForwardOneBackwardSchedule(BasePipelineSchedule):
 
         # Warmup.
         for _ in range(num_warmup):
-            input_obj = self._recv_forward()
+            active_microbatch = microbatches[mb_index]
+            input_obj = self._recv_forward(active_microbatch)
             output_obj = self._forward_step(
-                microbatches[mb_index], input_obj, criterion,
+                active_microbatch, input_obj, criterion,
                 num_microbatches, accum_loss, outputs,
             )
             mb_index += 1
-            self._send_forward(output_obj)
+            self._send_forward(output_obj, active_microbatch)
             input_objs.append(input_obj)
             output_objs.append(output_obj)
 
         if num_steady > 0:
-            input_obj = self._recv_forward()
+            input_obj = self._recv_forward(microbatches[mb_index])
 
         # Steady state.
         for i in range(num_steady):
             last = i == num_steady - 1
+            active_microbatch = microbatches[mb_index]
             output_obj = self._forward_step(
-                microbatches[mb_index], input_obj, criterion,
+                active_microbatch, input_obj, criterion,
                 num_microbatches, accum_loss, outputs,
             )
             mb_index += 1
-            output_obj_grad = self._send_forward_recv_backward(output_obj)
+            output_obj_grad = self._send_forward_recv_backward(
+                output_obj, active_microbatch
+            )
             input_objs.append(input_obj)
             output_objs.append(output_obj)
 
@@ -638,7 +714,9 @@ class OneForwardOneBackwardSchedule(BasePipelineSchedule):
             if last:
                 self._send_backward(input_obj_grad)
             else:
-                input_obj = self._send_backward_recv_forward(input_obj_grad)
+                input_obj = self._send_backward_recv_forward(
+                    input_obj_grad, microbatches[mb_index]
+                )
 
         # Cooldown.
         for _ in range(num_warmup):

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -12,14 +12,28 @@ path is covered by ``test_colocation``; the LM-only pipeline by
 from __future__ import annotations
 
 import unittest
+from unittest.mock import patch
+from types import MethodType, SimpleNamespace
 
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 
 from tests.distributed.distributed_base import GlooDistributedTestBase
 from tests.model.model_configs import clip_vision_config, llama_config
 
 from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.distributed.context_parallel.splitters import (
+    HeadTailContextParallelSplitter,
+    UniformContextParallelSplitter,
+)
+from cornstarch.distributed.cross_mesh_routing import (
+    CP_MODALITY_MASKS_KEY,
+    CP_ROUTING_OFFSETS_KEY,
+    CrossMeshGroup,
+    build_route_plan,
+    route_autograd,
+)
 from cornstarch.models import (
     CornstarchExecutionPlan,
     ExecutionFuture,
@@ -284,6 +298,333 @@ class TestCrossMeshFlexibility(GlooDistributedTestBase):
             self.assertIsNotNone(result["loss"])
             self.assertTrue(result["loss"].isfinite().all())
             self.assertTrue(_has_grad(language_model))
+
+
+class TestCrossMeshCPRouting(GlooDistributedTestBase):
+    """The CP seam routes only owned rows and applies the transpose in backward."""
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def test_vision_cp2_to_llm_cp4_forward_backward(self) -> None:
+        rank = dist.get_rank()
+        token = 99
+        input_ids = torch.arange(16).unsqueeze(0)
+        input_ids[:, 4:10] = token
+        modality_mask = torch.ones(1, 6, dtype=torch.bool)
+        source_offsets = UniformContextParallelSplitter().offsets_for_size(
+            modality_mask, 2
+        )
+        destination_offsets = UniformContextParallelSplitter().offsets_for_size(
+            input_ids, 4
+        )
+        group = CrossMeshGroup(
+            ranks=(0, 1, 2, 3),
+            producer_ranks=(0, 1),
+            consumer_ranks=(0, 1, 2, 3),
+            process_group=dist.group.WORLD,
+            dp_rank=0,
+            producer_tp_rank=0,
+            producer_ep_rank=0,
+            consumer_tp_rank=0,
+            consumer_ep_rank=0,
+        )
+        plan = build_route_plan(
+            global_input_ids=input_ids,
+            token_id=token,
+            source_attention_mask=modality_mask,
+            source_offsets=source_offsets,
+            destination_offsets=destination_offsets,
+            seam_group=group,
+            global_rank=rank,
+        )
+        if rank == 0:
+            features = torch.tensor([[4.0], [5.0], [6.0]], requires_grad=True)
+        elif rank == 1:
+            features = torch.tensor([[7.0], [8.0], [9.0]], requires_grad=True)
+        else:
+            features = torch.empty((0, 1), requires_grad=True)
+
+        # The routing path is only a variable all-to-all. A full-feature
+        # gather/broadcast on either forward or backward is a test failure.
+        with (
+            patch.object(dist, "all_gather", side_effect=AssertionError("full gather")),
+            patch.object(dist, "broadcast", side_effect=AssertionError("broadcast")),
+        ):
+            received = route_autograd(features, plan, dist.group.WORLD)
+            (received * float(rank + 1)).sum().backward()
+
+        expected = {
+            0: torch.empty((0, 1)),
+            1: torch.tensor([[4.0], [5.0], [6.0], [7.0]]),
+            2: torch.tensor([[8.0], [9.0]]),
+            3: torch.empty((0, 1)),
+        }[rank]
+        torch.testing.assert_close(received, expected)
+        if rank == 0:
+            torch.testing.assert_close(features.grad, torch.full_like(features, 2.0))
+        elif rank == 1:
+            torch.testing.assert_close(
+                features.grad, torch.tensor([[2.0], [3.0], [3.0]])
+            )
+
+    def test_one_to_many_many_to_one_and_headtail(self) -> None:
+        rank = dist.get_rank()
+        token = 99
+        input_ids = torch.full((1, 8), token, dtype=torch.long)
+        modality_mask = torch.ones(1, 8, dtype=torch.bool)
+        cases = (
+            (1, 4, UniformContextParallelSplitter(), UniformContextParallelSplitter()),
+            (4, 1, UniformContextParallelSplitter(), UniformContextParallelSplitter()),
+            (2, 2, UniformContextParallelSplitter(), HeadTailContextParallelSplitter()),
+        )
+        for source_size, destination_size, source_splitter, destination_splitter in cases:
+            source_offsets = source_splitter.offsets_for_size(
+                modality_mask, source_size
+            )
+            destination_offsets = destination_splitter.offsets_for_size(
+                input_ids, destination_size
+            )
+            group = CrossMeshGroup(
+                ranks=(0, 1, 2, 3),
+                producer_ranks=tuple(range(source_size)),
+                consumer_ranks=tuple(range(destination_size)),
+                process_group=dist.group.WORLD,
+                dp_rank=0,
+                producer_tp_rank=0,
+                producer_ep_rank=0,
+                consumer_tp_rank=0,
+                consumer_ep_rank=0,
+            )
+            plan = build_route_plan(
+                global_input_ids=input_ids,
+                token_id=token,
+                source_attention_mask=modality_mask,
+                source_offsets=source_offsets,
+                destination_offsets=destination_offsets,
+                seam_group=group,
+                global_rank=rank,
+            )
+            if rank < source_size:
+                features = source_offsets[rank].float().unsqueeze(1).requires_grad_(True)
+            else:
+                features = torch.empty((0, 1), requires_grad=True)
+            received = route_autograd(features, plan, dist.group.WORLD)
+            (received * float(rank + 1)).sum().backward()
+
+            expected_received = (
+                destination_offsets[rank].float().unsqueeze(1)
+                if rank < destination_size
+                else torch.empty((0, 1))
+            )
+            torch.testing.assert_close(received, expected_received)
+            if rank < source_size:
+                destination_owner = {
+                    int(position): cp_rank
+                    for cp_rank, offsets in enumerate(destination_offsets)
+                    for position in offsets.tolist()
+                }
+                expected_grad = torch.tensor(
+                    [
+                        [float(destination_owner[int(position)] + 1)]
+                        for position in source_offsets[rank].tolist()
+                    ]
+                )
+                torch.testing.assert_close(features.grad, expected_grad)
+
+
+class TestCrossMeshCPCompiledSchedule(GlooDistributedTestBase):
+    """An actual ParallelContext routes CP2 projected rows into an LLM CP4."""
+
+    @property
+    def world_size(self) -> int:
+        return 6
+
+    def test_variable_count_loss_and_gradient_parity(self) -> None:
+        language_model, modality_encoder, _ = _build_models()
+        source_splitter = UniformContextParallelSplitter()
+        destination_splitter = UniformContextParallelSplitter()
+        parallel = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        parallel.parallelize(
+            modality_encoder,
+            ParallelConfig(
+                pipeline_parallel_size=1,
+                context_parallel_size=2,
+                context_parallel_splitter=source_splitter,
+            ),
+        )
+        parallel.parallelize(
+            language_model,
+            ParallelConfig(
+                pipeline_parallel_size=1,
+                context_parallel_size=4,
+                context_parallel_splitter=destination_splitter,
+            ),
+        )
+        ctx = parallel.materialize("cpu", dtype=torch.float32)
+
+        token = IMAGE_TOKEN_ID
+        input_ids = torch.tensor(
+            [
+                [token, token, token, 1, 2, 3, token, token, token, 4, 5, 6],
+                [7, token, token, 8, 9, token, 10, 11, token, 12, 13, 14],
+            ]
+        )
+        labels = input_ids.clone()
+        modality_mask = torch.tensor(
+            [[1, 1, 1, 1, 1, 1], [1, 1, 1, 1, 0, 0]], dtype=torch.bool
+        )
+        source_offsets = source_splitter.offsets_for_size(modality_mask, 2)
+        destination_offsets = destination_splitter.offsets_for_size(input_ids, 4)
+        vision_hidden = modality_encoder.projector.config.in_features
+        language_hidden = modality_encoder.projector.config.out_features
+        raw_full = (
+            torch.arange(2 * 6 * vision_hidden, dtype=torch.float32)
+            .reshape(2, 6, vision_hidden)
+            .div(100.0)
+        )
+
+        rank = dist.get_rank()
+        if rank < 2:
+            local_raw = raw_full[:, source_offsets[rank]].clone().requires_grad_(True)
+
+            def projected_forward(self, modality_features):
+                return self.projector(modality_features)
+
+            modality_encoder.forward = MethodType(projected_forward, modality_encoder)
+            proj = modality_encoder.projector.projection
+            with torch.no_grad():
+                proj.weight.copy_(
+                    torch.arange(proj.weight.numel()).reshape_as(proj.weight).div(10000)
+                )
+                proj.bias.copy_(torch.arange(proj.bias.numel()).div(10000))
+        else:
+            local_raw = torch.empty(0)
+            cp_rank = rank - 2
+
+            def local_language_forward(
+                self, input_ids=None, inputs_embeds=None, labels=None, **kwargs
+            ):
+                logits = self.post_decoder["lm_head"](inputs_embeds)
+                self._test_local_logits = logits.detach()
+                return SimpleNamespace(loss=logits.square().sum(), logits=logits)
+
+            language_model.forward = MethodType(
+                local_language_forward, language_model
+            )
+            embed = language_model.pre_decoder["embed_tokens"].weight
+            head = language_model.post_decoder["lm_head"].weight
+            with torch.no_grad():
+                embed.copy_(
+                    torch.arange(embed.numel()).reshape_as(embed).div(100000)
+                )
+                head.copy_(torch.arange(head.numel()).reshape_as(head).div(100000))
+
+        # An analytical non-CP reference uses the same deterministic seam
+        # parameters, full text sequence, and padded modality batch.
+        proj_weight = (
+            torch.arange(language_hidden * vision_hidden, dtype=torch.float32)
+            .reshape(language_hidden, vision_hidden)
+            .div(10000)
+            .requires_grad_(True)
+        )
+        proj_bias = (
+            torch.arange(language_hidden, dtype=torch.float32)
+            .div(10000)
+            .requires_grad_(True)
+        )
+        vocab_size = language_model.hf_config.vocab_size
+        embed_weight = (
+            torch.arange(vocab_size * language_hidden, dtype=torch.float32)
+            .reshape(vocab_size, language_hidden)
+            .div(100000)
+            .requires_grad_(True)
+        )
+        head_weight = embed_weight.detach().clone().requires_grad_(True)
+        reference_raw = raw_full.clone().requires_grad_(True)
+        projected = F.linear(reference_raw, proj_weight, proj_bias)
+        safe_ids = input_ids.masked_fill(input_ids == token, 0)
+        reference_embeds = F.embedding(safe_ids, embed_weight)
+        for batch_index in range(input_ids.shape[0]):
+            reference_embeds[batch_index, input_ids[batch_index] == token] = projected[
+                batch_index, modality_mask[batch_index]
+            ]
+        reference_logits = F.linear(reference_embeds, head_weight)
+        reference_loss = reference_logits.square().sum()
+        reference_loss.backward()
+
+        if rank >= 2:
+            offsets = destination_offsets[cp_rank]
+            local_ids = input_ids[:, offsets].contiguous()
+            local_labels = labels[:, offsets].contiguous()
+            local_positions = offsets.unsqueeze(0).expand(input_ids.shape[0], -1)
+        else:
+            local_ids = input_ids
+            local_labels = labels
+            local_positions = torch.arange(input_ids.shape[1]).unsqueeze(0).expand(
+                input_ids.shape[0], -1
+            )
+        microbatch = {
+            "input_ids": local_ids,
+            "labels": local_labels,
+            "position_ids": local_positions,
+            "cp_global_input_ids": input_ids,
+            CP_MODALITY_MASKS_KEY: {"vision": modality_mask},
+            CP_ROUTING_OFFSETS_KEY: {
+                id(modality_encoder): tuple(source_offsets),
+                id(language_model): tuple(destination_offsets),
+            },
+            "modality_features": local_raw,
+        }
+        exec_plan = CornstarchExecutionPlan()
+        vision_outputs = exec_plan.run_modality_encoder(
+            module=modality_encoder,
+            modality_features=ExecutionFuture("modality_features"),
+        )
+        merged = exec_plan.merge_modality_encoder_outputs(
+            language_model=language_model,
+            input_ids=ExecutionFuture("input_ids"),
+            labels=ExecutionFuture("labels"),
+            modality_token_ids={"vision": token},
+            encoder_outputs={"vision": vision_outputs},
+            language_model_inputs={"position_ids": ExecutionFuture("position_ids")},
+        )
+        output = exec_plan.run_language_model(language_model, merged)
+        with (
+            patch.object(dist, "all_gather", side_effect=AssertionError("full gather")),
+            patch.object(dist, "broadcast", side_effect=AssertionError("broadcast")),
+        ):
+            result = ctx.create_schedule(exec_plan, output).step(
+                [microbatch], _criterion, return_loss=True
+            )
+            ctx.sync_gradients()
+
+        distributed_loss = torch.zeros(1)
+        if result["loss"] is not None:
+            distributed_loss.copy_(result["loss"])
+        dist.all_reduce(distributed_loss)
+        torch.testing.assert_close(distributed_loss.squeeze(), reference_loss.detach())
+        if rank < 2:
+            proj = modality_encoder.projector.projection
+            torch.testing.assert_close(proj.weight.grad, proj_weight.grad)
+            torch.testing.assert_close(proj.bias.grad, proj_bias.grad)
+            torch.testing.assert_close(
+                local_raw.grad, reference_raw.grad[:, source_offsets[rank]]
+            )
+        else:
+            torch.testing.assert_close(
+                language_model._test_local_logits,
+                reference_logits.detach()[:, destination_offsets[cp_rank]],
+            )
+            torch.testing.assert_close(
+                language_model.pre_decoder["embed_tokens"].weight.grad,
+                embed_weight.grad,
+            )
+            torch.testing.assert_close(
+                language_model.post_decoder["lm_head"].weight.grad,
+                head_weight.grad,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/model/test_cross_mesh_routing.py
+++ b/tests/model/test_cross_mesh_routing.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import torch
+
+from cornstarch.distributed.context_parallel.splitters import (
+    ContextParallelSplitter,
+    HeadTailContextParallelSplitter,
+    UniformContextParallelSplitter,
+)
+from cornstarch.distributed.cross_mesh_routing import (
+    CrossMeshGroup,
+    build_cross_mesh_groups,
+    build_route_plan,
+)
+from cornstarch.distributed.pipeline_parallel.schedule import MeshLayout
+
+
+def _group(source: tuple[int, ...], destination: tuple[int, ...]) -> CrossMeshGroup:
+    return CrossMeshGroup(
+        ranks=tuple(dict.fromkeys((*source, *destination))),
+        producer_ranks=source,
+        consumer_ranks=destination,
+        process_group=None,  # type: ignore[arg-type]
+        dp_rank=0,
+        producer_tp_rank=0,
+        producer_ep_rank=0,
+        consumer_tp_rank=0,
+        consumer_ep_rank=0,
+    )
+
+
+def test_acceptance_route_vision_cp2_to_llm_cp4() -> None:
+    token = 99
+    ids = torch.arange(16).unsqueeze(0)
+    ids[:, 4:10] = token
+    modality_mask = torch.ones(1, 6, dtype=torch.bool)
+    source = UniformContextParallelSplitter().offsets_for_size(modality_mask, 2)
+    destination = UniformContextParallelSplitter().offsets_for_size(ids, 4)
+    group = _group((0, 1), (2, 3, 4, 5))
+
+    source0 = build_route_plan(
+        global_input_ids=ids,
+        token_id=token,
+        source_attention_mask=modality_mask,
+        source_offsets=source,
+        destination_offsets=destination,
+        seam_group=group,
+        global_rank=0,
+    )
+    source1 = build_route_plan(
+        global_input_ids=ids,
+        token_id=token,
+        source_attention_mask=modality_mask,
+        source_offsets=source,
+        destination_offsets=destination,
+        seam_group=group,
+        global_rank=1,
+    )
+    llm0 = build_route_plan(
+        global_input_ids=ids,
+        token_id=token,
+        source_attention_mask=modality_mask,
+        source_offsets=source,
+        destination_offsets=destination,
+        seam_group=group,
+        global_rank=2,
+    )
+
+    assert source0.send_counts == (0, 0, 0, 3, 0, 0)
+    assert source1.send_counts == (0, 0, 0, 1, 2, 0)
+    assert llm0.destination_rows == 0
+    assert sum(llm0.recv_counts) == 0
+
+
+def test_variable_sample_counts_select_padded_source_rows() -> None:
+    token = 9
+    ids = torch.tensor(
+        [
+            [1, token, token, 2, 3, 4, token, 5],
+            [token, 1, 2, 3, 4, token, 6, 7],
+        ]
+    )
+    modality_mask = torch.tensor([[1, 1, 1], [1, 1, 0]], dtype=torch.bool)
+    source = UniformContextParallelSplitter().offsets_for_size(modality_mask, 2)
+    destination = HeadTailContextParallelSplitter().offsets_for_size(ids, 2)
+    group = _group((0, 1), (2, 3))
+
+    source_tail = build_route_plan(
+        global_input_ids=ids,
+        token_id=token,
+        source_attention_mask=modality_mask,
+        source_offsets=source,
+        destination_offsets=destination,
+        seam_group=group,
+        global_rank=1,
+    )
+
+    # CP1 owns modality ordinal 2. It is valid only in sample 0, while its
+    # projector output still has one padded slot for sample 1.
+    assert source_tail.source_storage_rows == 2
+    assert source_tail.source_rows == 1
+    assert source_tail.source_select_indices == (0,)
+    assert sum(source_tail.send_counts) == 1
+
+
+def test_route_rejects_projected_mask_placeholder_mismatch() -> None:
+    token = 9
+    ids = torch.tensor([[token, token, 1, 2]])
+    bad_mask = torch.tensor([[1, 0]], dtype=torch.bool)
+    offsets = UniformContextParallelSplitter().offsets_for_size(bad_mask, 1)
+    group = _group((0,), (1,))
+
+    try:
+        build_route_plan(
+            global_input_ids=ids,
+            token_id=token,
+            source_attention_mask=bad_mask,
+            source_offsets=offsets,
+            destination_offsets=(torch.arange(4),),
+            seam_group=group,
+            global_rank=0,
+        )
+    except ValueError as error:
+        assert "placeholder count" in str(error)
+    else:
+        raise AssertionError("expected one-row-per-placeholder validation failure")
+
+
+def test_legacy_splitter_subclass_retains_compute_offsets_contract() -> None:
+    class LegacySplitter(ContextParallelSplitter):
+        def compute_offsets(self, attention_mask, cp_group):
+            self._offsets_per_rank = [torch.arange(attention_mask.shape[1])]
+            return self._offsets_per_rank
+
+    splitter = LegacySplitter()
+    offsets = splitter.compute_offsets(torch.ones(1, 3), None)
+    assert torch.equal(offsets[0], torch.arange(3))
+    try:
+        splitter.offsets_for_size(torch.ones(1, 3), 1)
+    except NotImplementedError as error:
+        assert "cross-mesh routing" in str(error)
+    else:
+        raise AssertionError("legacy splitter should require explicit routing support")
+
+
+def test_offsets_for_size_rejects_nonpositive_cp_size() -> None:
+    try:
+        UniformContextParallelSplitter().offsets_for_size(torch.ones(1, 3), 0)
+    except ValueError as error:
+        assert "cp_size" in str(error)
+    else:
+        raise AssertionError("expected cp_size validation failure")
+
+
+def test_incompatible_producer_hidden_shards_are_rejected() -> None:
+    producer = MeshLayout((0, 1), 1, 1, 1, 2, 1)
+    consumer = MeshLayout((2,), 1, 1, 1, 1, 1)
+    try:
+        build_cross_mesh_groups(
+            producer_layout=producer, consumer_layout=consumer
+        )
+    except ValueError as error:
+        assert "Incompatible TP layout" in str(error)
+    else:
+        raise AssertionError("expected incompatible TP seam validation failure")


### PR DESCRIPTION
## Summary
- add deterministic DP/TP/EP lane-aware cross-mesh groups for encoder-last-stage to LLM-first-stage routing
- derive source modality-row and destination placeholder ownership from each splitter’s actual offsets, including uniform and head-tail layouts
- exchange only owned feature rows through variable-split all-to-all and transpose the exchange in backward without full-feature gathers or broadcasts
- integrate per-microbatch routing metadata and deterministic forward/backward ordering into the existing pipeline and 1F1B schedule
- retain third-party splitter compatibility while exposing a process-group-independent ownership helper for certified splitters

## Validation
- routing/model/plan tests: 16 passed
- multimodal/colocation tests: 9 passed
- CP/pipeline/microbatch/composition tests: 26 passed
- independent B4 unit suite: 6 passed
- independent full multimodal distributed file: 7 passed
- ruff, compileall, and diff checks passed

The unrelated multi-rank Gloo ring-peer regression discovered by these tests was fixed separately and merged in #80.