### PR TITLE
Fix GDN GPU acceptance softplus call

### DIFF
--- a/tests/distributed/test_gated_delta_context_parallel_gloo.py
+++ b/tests/distributed/test_gated_delta_context_parallel_gloo.py
@@ -80,7 +80,7 @@ class TestGatedDeltaContextParallelGloo(GlooDistributedTestBase):
             torch.randn(shape, generator=generator, device=device, dtype=torch.bfloat16)
             for shape in shapes
         ]
-        full[3] = -full[3].float().softplus().to(torch.bfloat16)
+        full[3] = -F.softplus(full[3].float()).to(torch.bfloat16)
         full[4] = full[4].sigmoid()
         valid = int(mask.sum())
         full_cu = [0]


### PR DESCRIPTION
Fix the first one-GPU Gloo acceptance failure by replacing the nonexistent Tensor.softplus method with torch.nn.functional.softplus. This PR intentionally fixes only that test bug; the rerun then advances to the next independent FLA dispatch failure.