### PR TITLE
Fix FLA backward USE_BG dispatch

### DIFF
--- a/cornstarch/distributed/context_parallel/gated_delta_fla.py
+++ b/cornstarch/distributed/context_parallel/gated_delta_fla.py
@@ -56,6 +56,7 @@ _REQUIRED_KERNEL_ARGUMENTS = {
         "init_offsets",
     },
     "pre_process_bwd_kernel_merged": {
+        "USE_BG",
         "USE_EXP2",
         "cu_seqlens",
         "dhm",
@@ -309,6 +310,7 @@ def _run_aware_backward_preprocess(
             BT=64,
             BK1=block_key,
             BLOCK_SIZE=block_size,
+            USE_BG=bg is not None,
             USE_EXP2=use_exp2,
         )
     global_summaries = _all_reduce_summaries(summaries, context)

--- a/tests/distributed/test_gated_delta_context_parallel.py
+++ b/tests/distributed/test_gated_delta_context_parallel.py
@@ -294,6 +294,7 @@ def test_fla_adapter_uses_logical_run_prefixes_suffixes_and_boundaries() -> None
         [0, 2],
         [2, 4],
     ]
+    assert all(call["USE_BG"] is False for call in backward_kernel.calls)
     assert [
         (call["FORWARD"], call["rank"], call["pre_or_post_num_ranks"])
         for call in merge_kernel.calls


### PR DESCRIPTION
Pass FLA 0.5's required USE_BG constexpr to the run-aware backward pre-scan and validate it as part of the pinned kernel contract. Adds a focused adapter assertion. The real one-GPU Gloo rerun advances past compilation: the empty-lane/halo case passes and the packed case reaches a separate numerical gradient mismatch.