### PR TITLE
fix(model): materialize partially meta pipeline stages

### DIFF
--- a/cornstarch/models/model_base.py
+++ b/cornstarch/models/model_base.py
@@ -261,9 +261,9 @@ class CornstarchModelBase(nn.Module):
                 layer.to(device)
 
     def _is_meta(self) -> bool:
-        """Return whether every registered tensor still lives on the meta device."""
+        """Return whether any registered tensor still lives on the meta device."""
         tensors = list(self.parameters()) + list(self.buffers())
-        return bool(tensors) and all(tensor.is_meta for tensor in tensors)
+        return any(tensor.is_meta for tensor in tensors)
 
     def _to_hf_keys(self, keys: Iterable[str]) -> list[str]:
         """Translate internal key names into sorted Hugging Face key names."""

--- a/tests/model/test_model_materialization.py
+++ b/tests/model/test_model_materialization.py
@@ -217,3 +217,16 @@ def test_materialize_handles_duplicate_tied_parameter_names() -> None:
         if parameter.is_meta
     ]
     assert meta_parameters == []
+
+
+def test_materialize_handles_mixed_meta_and_materialized_tensors() -> None:
+    """A concrete buffer must not hide parameters that still need allocation."""
+    model = from_hf_config(llama_config(), attn_implementation=ATTN_IMPLEMENTATION)
+    model.register_buffer("materialized_sentinel", torch.ones(1), persistent=False)
+    model.set_random_init()
+
+    model.materialize("cpu")
+
+    tensors = list(model.parameters()) + list(model.buffers())
+    assert tensors
+    assert all(not tensor.is_meta for tensor in tensors)


### PR DESCRIPTION
## What changed

- Treat a Cornstarch model as lazy while any registered parameter or buffer remains on the meta device.
- Add a regression covering models with a concrete buffer mixed with meta parameters.

## Why

Pipeline partitioning can leave a stage with materialized bookkeeping buffers while its trainable parameters are still meta tensors. The previous all-tensors check classified that mixed state as already materialized and returned early, so the second Qwen pipeline stage reached forward with meta RMSNorm weights.

## Impact

Partially materialized pipeline stages now allocate and initialize all remaining meta tensors before execution. Fully materialized models still return immediately.

## Validation

- `pytest -q tests/model/test_model_materialization.py -x` — 48 passed
- Full 16-rank, one-GPU Gloo dense 4D test progressed through materialization, forward, backward, and gradient synchronization; it then exposed a separate mixed Tensor/DTensor optimizer issue, which is intentionally excluded from this PR.
