### PR TITLE
test(distributed): use DTensor-safe optimizer path

### DIFF
--- a/examples/distributed/validate_qwen_full_parallel.py
+++ b/examples/distributed/validate_qwen_full_parallel.py
@@ -226,7 +226,10 @@ def _run(case: AcceptanceCase, args: argparse.Namespace) -> dict[str, object]:
     )
     output = execution.run_language_model(module=model, inputs=merged)
     schedule = context.create_schedule(execution, output)
-    optimizer = torch.optim.SGD(model.parameters(), lr=1e-3)
+    # A PP stage contains both ordinary stage-local tensors and TP-sharded
+    # DTensors. CUDA's automatic foreach path cannot update that mixed list,
+    # while the scalar optimizer path supports both parameter kinds.
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-3, foreach=False)
 
     result = schedule.step(
         microbatches, _criterion, optimizer=None, return_loss=True


### PR DESCRIPTION
## What changed

- Force the full-parallel acceptance runner's SGD optimizer onto PyTorch's scalar update path.
- Document why a combined PP+TP stage cannot use CUDA's automatic foreach path.

## Why

A pipeline stage legitimately owns both ordinary stage-local tensors and TP-sharded DTensors. CUDA SGD automatically selected a foreach update for the mixed list, but DTensor rejects foreach operations containing both tensor kinds.

## Impact

The release gate still performs a real optimizer update over every local parameter, using the DTensor-compatible scalar implementation.

## Validation

- `env PYTHONPATH=/tmp/cornstarch-fla pytest -q tests/distributed/test_full_parallel_gloo.py::TestQwenDenseFullParallelGloo::test_dense_hybrid_4d -x -s` — 1 passed across 16 one-GPU Gloo ranks
