### PR TITLE
feat(models): attach LoRA adapters after materialization

### DIFF
--- a/cornstarch/models/__init__.py
+++ b/cornstarch/models/__init__.py
@@ -12,6 +12,7 @@ from cornstarch.models.hf_conversion import (
 from cornstarch.models.language_model import CornstarchLanguageModel
 from cornstarch.models.layer_compile import RepeatedLayerCompileConfig
 from cornstarch.models.layer_offload import RepeatedLayerOffloadConfig
+from cornstarch.models.lora import attach_lora
 from cornstarch.models.multimodal import (
     CornstarchEncoderToLanguageProjectorConfig,
     CornstarchExecutionPlan,
@@ -38,6 +39,7 @@ __all__ = [
     "ExecutionFuture",
     "RepeatedLayerCompileConfig",
     "RepeatedLayerOffloadConfig",
+    "attach_lora",
     "build_modality_encoder",
     "from_hf_config",
     "from_pretrained_config",

--- a/cornstarch/models/lora.py
+++ b/cornstarch/models/lora.py
@@ -1,0 +1,76 @@
+"""LoRA adapter attachment that preserves Cornstarch model interfaces."""
+
+from __future__ import annotations
+
+import copy
+
+import torch.nn as nn
+from peft import LoraConfig, inject_adapter_in_model
+
+from cornstarch.models.model_base import CornstarchModelBase
+from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
+
+
+def attach_lora(
+    module: nn.Module,
+    config: LoraConfig,
+    *,
+    adapter_name: str = "default",
+) -> nn.Module:
+    """Attach a PEFT LoRA adapter in place and return ``module`` unchanged.
+
+    Passing a :class:`CornstarchModalityEncoder` targets its encoder only; its
+    projector remains an ordinary independently trainable module.  Passing a
+    language model targets that model directly, so encoder and language-model
+    adapters can be selected independently.
+
+    Cornstarch models begin on the ``meta`` device.  For those models adapter
+    injection is deferred until base checkpoint or random initialization has
+    completed.  This preserves Hugging Face checkpoint key translation while
+    keeping the call site identical for local and distributed materialization.
+    PEFT injects into already-materialized modules immediately.
+    """
+    if not isinstance(config, LoraConfig):
+        raise TypeError(
+            f"config must be a peft.LoraConfig, got {type(config).__name__}."
+        )
+    if not adapter_name:
+        raise ValueError("adapter_name must not be empty.")
+
+    target = module.encoder if isinstance(module, CornstarchModalityEncoder) else module
+    adapter_names: set[str] = getattr(target, "_cornstarch_lora_adapter_names", set())
+    if adapter_name in adapter_names:
+        raise ValueError(
+            f"LoRA adapter {adapter_name!r} is already attached to "
+            f"{type(target).__name__}."
+        )
+
+    deferred_config = copy.deepcopy(config)
+
+    def inject(target_module: nn.Module) -> None:
+        inject_adapter_in_model(
+            deferred_config,
+            target_module,
+            adapter_name=adapter_name,
+        )
+
+    if isinstance(target, CornstarchModelBase):
+        target._register_post_materialize_callback(inject)
+    elif _has_meta_tensors(target):
+        raise RuntimeError(
+            "Cannot attach LoRA to a generic module on the meta device. "
+            "Materialize it first, or pass a Cornstarch model so injection can "
+            "be deferred safely."
+        )
+    else:
+        inject(target)
+
+    adapter_names.add(adapter_name)
+    target._cornstarch_lora_adapter_names = adapter_names
+    return module
+
+
+def _has_meta_tensors(module: nn.Module) -> bool:
+    return any(tensor.is_meta for tensor in module.parameters()) or any(
+        tensor.is_meta for tensor in module.buffers()
+    )

--- a/cornstarch/models/model_base.py
+++ b/cornstarch/models/model_base.py
@@ -72,6 +72,9 @@ class CornstarchModelBase(nn.Module):
         self._init_plan = init_plan or InitializationPlan.empty()
         self._state_mapper = StateDictPrefixMap(hf_to_cornstarch_prefixes)
         self._hf_model_factory = hf_model_factory
+        self._post_materialize_callbacks: list[
+            Callable[[CornstarchModelBase], None]
+        ] = []
 
     @property
     def attention_kernel(self) -> Any:
@@ -145,6 +148,7 @@ class CornstarchModelBase(nn.Module):
         to materialize a sharded (DTensor) meta model in, e.g., bf16.
         """
         if not self._is_meta():
+            self._run_post_materialize_callbacks()
             return self
 
         device = torch.device(device)
@@ -164,7 +168,32 @@ class CornstarchModelBase(nn.Module):
         else:
             raise ValueError(f"Unknown initialization plan: {self._init_plan.mode}")
 
+        self._run_post_materialize_callbacks()
         return self
+
+    def _register_post_materialize_callback(
+        self, callback: Callable[[CornstarchModelBase], None]
+    ) -> None:
+        """Run ``callback`` after this model's base tensors materialize.
+
+        Structural extensions such as PEFT adapters must not wrap the lazy model
+        before checkpoint keys have been translated and loaded.  This private
+        lifecycle hook lets those extensions declare their intent while the
+        model is still on ``meta`` and apply the mutation at the safe boundary.
+        """
+        if self._is_meta():
+            self._post_materialize_callbacks.append(callback)
+        else:
+            callback(self)
+
+    def _run_post_materialize_callbacks(self) -> None:
+        """Apply and clear structural mutations queued for materialization."""
+        callbacks = self._post_materialize_callbacks
+        if not callbacks:
+            return
+        for callback in callbacks:
+            callback(self)
+        self._post_materialize_callbacks = []
 
     def load_hf_state_dict(
         self, state_dict: Mapping[str, torch.Tensor], strict: bool = True

--- a/tests/model/test_lora.py
+++ b/tests/model/test_lora.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from peft import LoraConfig
+from peft.tuners.lora import LoraLayer
+
+from cornstarch.models import attach_lora, build_modality_encoder, from_hf_config
+from tests.model.model_configs import clip_vision_config, llama_config
+
+
+def _lora_config() -> LoraConfig:
+    return LoraConfig(target_modules=["q_proj"], r=2, lora_alpha=4)
+
+
+def _lora_layers(module: torch.nn.Module) -> list[LoraLayer]:
+    return [child for child in module.modules() if isinstance(child, LoraLayer)]
+
+
+def test_attach_lora_mutates_materialized_module_in_place() -> None:
+    module = torch.nn.Sequential(torch.nn.Linear(4, 4))
+
+    returned = attach_lora(
+        module,
+        LoraConfig(target_modules=["0"], r=2, lora_alpha=4),
+    )
+
+    assert returned is module
+    assert len(_lora_layers(module)) == 1
+
+
+def test_attach_lora_defers_until_cornstarch_model_materializes() -> None:
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    language_model.set_random_init()
+
+    returned = attach_lora(language_model, _lora_config())
+
+    assert returned is language_model
+    assert not _lora_layers(language_model)
+
+    language_model.materialize("cpu")
+
+    assert _lora_layers(language_model)
+    assert all(not parameter.is_meta for parameter in language_model.parameters())
+
+
+def test_deferred_lora_preserves_checkpoint_initialization() -> None:
+    reference = from_hf_config(llama_config(), model_kind="language")
+    reference.set_random_init()
+    reference.materialize("cpu")
+    hf_state_dict = reference.to_hf_state_dict()
+
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    language_model.set_checkpoint_init(state_dict=hf_state_dict)
+    attach_lora(language_model, _lora_config())
+    language_model.materialize("cpu")
+
+    adapted_projection = language_model.decoder_layers[0].self_attn.q_proj
+    torch.testing.assert_close(
+        adapted_projection.base_layer.weight,
+        reference.decoder_layers[0].self_attn.q_proj.weight,
+    )
+
+
+def test_encoder_and_language_lora_are_attached_independently() -> None:
+    encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    modality_encoder = build_modality_encoder(
+        encoder, language_model, modality="vision"
+    )
+    modality_encoder.set_random_init()
+    language_model.set_random_init()
+
+    attach_lora(modality_encoder, _lora_config())
+    modality_encoder.materialize("cpu")
+
+    assert _lora_layers(modality_encoder.encoder)
+    assert not _lora_layers(modality_encoder.projector)
+    assert not _lora_layers(language_model)
+
+    attach_lora(language_model, _lora_config())
+    language_model.materialize("cpu")
+
+    assert _lora_layers(language_model)
+
+
+def test_attach_lora_rejects_duplicate_adapter_name() -> None:
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    attach_lora(language_model, _lora_config(), adapter_name="experiment")
+
+    with pytest.raises(ValueError, match="already attached"):
+        attach_lora(language_model, _lora_config(), adapter_name="experiment")


### PR DESCRIPTION
## What changed

- add an in-place `attach_lora` API backed by Hugging Face PEFT
- target a modality encoder's encoder without modifying its projector
- defer adapter injection for lazy Cornstarch models until base materialization completes
- preserve the original Cornstarch module class, forward signature, and object identity

## Why

Injecting PEFT adapters into a meta model before checkpoint loading introduces `base_layer` into parameter paths and breaks Cornstarch's Hugging Face checkpoint mapping. The deferred lifecycle hook records adapter intent before local or distributed materialization and performs the structural mutation only after base weights are ready.

## Validation

- `ruff check cornstarch/models/model_base.py cornstarch/models/lora.py cornstarch/models/__init__.py tests/model/test_lora.py`
- `pytest -q tests/model/test_lora.py tests/model/test_model_materialization.py` (54 passed)
