### PR TITLE
feat(models): configure heterogeneous fine-tuning modes

### DIFF
--- a/cornstarch/models/__init__.py
+++ b/cornstarch/models/__init__.py
@@ -12,7 +12,7 @@ from cornstarch.models.hf_conversion import (
 from cornstarch.models.language_model import CornstarchLanguageModel
 from cornstarch.models.layer_compile import RepeatedLayerCompileConfig
 from cornstarch.models.layer_offload import RepeatedLayerOffloadConfig
-from cornstarch.models.lora import attach_lora
+from cornstarch.models.lora import FinetuningMode, attach_lora, configure_finetuning
 from cornstarch.models.multimodal import (
     CornstarchEncoderToLanguageProjectorConfig,
     CornstarchExecutionPlan,
@@ -37,10 +37,12 @@ __all__ = [
     "CornstarchProjector",
     "CornstarchVisionEncoder",
     "ExecutionFuture",
+    "FinetuningMode",
     "RepeatedLayerCompileConfig",
     "RepeatedLayerOffloadConfig",
     "attach_lora",
     "build_modality_encoder",
+    "configure_finetuning",
     "from_hf_config",
     "from_pretrained_config",
     "load_hf_state_dict",

--- a/cornstarch/models/lora.py
+++ b/cornstarch/models/lora.py
@@ -3,12 +3,55 @@
 from __future__ import annotations
 
 import copy
+from typing import Literal
 
 import torch.nn as nn
 from peft import LoraConfig, inject_adapter_in_model
 
 from cornstarch.models.model_base import CornstarchModelBase
 from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
+
+
+FinetuningMode = Literal["full", "frozen", "lora"]
+
+
+def configure_finetuning(
+    module: nn.Module,
+    mode: FinetuningMode,
+    *,
+    lora_config: LoraConfig | None = None,
+    adapter_name: str = "default",
+) -> nn.Module:
+    """Configure one encoder or language model for fine-tuning.
+
+    ``full`` trains every parameter, ``frozen`` trains none, and ``lora``
+    freezes base parameters while attaching trainable PEFT adapters.  A
+    :class:`CornstarchModalityEncoder` delegates to its encoder; the projector
+    is intentionally unaffected and can be configured independently with normal
+    PyTorch ``requires_grad_`` calls.
+
+    Calls are independent per module, so heterogeneous combinations such as a
+    LoRA encoder plus fully trainable LLM, or a frozen encoder plus LoRA LLM,
+    require no composite wrapper or distributed-specific configuration.
+    """
+    if mode not in {"full", "frozen", "lora"}:
+        raise ValueError(
+            f"Unsupported fine-tuning mode {mode!r}; expected 'full', "
+            "'frozen', or 'lora'."
+        )
+
+    target = _adapter_target(module)
+    if mode == "lora":
+        if lora_config is None:
+            raise ValueError("lora_config is required when mode='lora'.")
+        target.requires_grad_(False)
+        attach_lora(module, lora_config, adapter_name=adapter_name)
+        return module
+
+    if lora_config is not None:
+        raise ValueError("lora_config is only valid when mode='lora'.")
+    target.requires_grad_(mode == "full")
+    return module
 
 
 def attach_lora(
@@ -37,7 +80,7 @@ def attach_lora(
     if not adapter_name:
         raise ValueError("adapter_name must not be empty.")
 
-    target = module.encoder if isinstance(module, CornstarchModalityEncoder) else module
+    target = _adapter_target(module)
     adapter_names: set[str] = getattr(target, "_cornstarch_lora_adapter_names", set())
     if adapter_name in adapter_names:
         raise ValueError(
@@ -74,3 +117,9 @@ def _has_meta_tensors(module: nn.Module) -> bool:
     return any(tensor.is_meta for tensor in module.parameters()) or any(
         tensor.is_meta for tensor in module.buffers()
     )
+
+
+def _adapter_target(module: nn.Module) -> nn.Module:
+    if isinstance(module, CornstarchModalityEncoder):
+        return module.encoder
+    return module

--- a/tests/model/test_lora.py
+++ b/tests/model/test_lora.py
@@ -5,7 +5,12 @@ import torch
 from peft import LoraConfig
 from peft.tuners.lora import LoraLayer
 
-from cornstarch.models import attach_lora, build_modality_encoder, from_hf_config
+from cornstarch.models import (
+    attach_lora,
+    build_modality_encoder,
+    configure_finetuning,
+    from_hf_config,
+)
 from tests.model.model_configs import clip_vision_config, llama_config
 
 
@@ -15,6 +20,28 @@ def _lora_config() -> LoraConfig:
 
 def _lora_layers(module: torch.nn.Module) -> list[LoraLayer]:
     return [child for child in module.modules() if isinstance(child, LoraLayer)]
+
+
+def _assert_mode(module: torch.nn.Module, mode: str) -> None:
+    adapter_parameters = [
+        parameter for name, parameter in module.named_parameters() if "lora_" in name
+    ]
+    base_parameters = [
+        parameter
+        for name, parameter in module.named_parameters()
+        if "lora_" not in name
+    ]
+    assert base_parameters
+    if mode == "full":
+        assert not adapter_parameters
+        assert all(parameter.requires_grad for parameter in base_parameters)
+    elif mode == "frozen":
+        assert not adapter_parameters
+        assert all(not parameter.requires_grad for parameter in base_parameters)
+    else:
+        assert adapter_parameters
+        assert all(parameter.requires_grad for parameter in adapter_parameters)
+        assert all(not parameter.requires_grad for parameter in base_parameters)
 
 
 def test_attach_lora_mutates_materialized_module_in_place() -> None:
@@ -90,3 +117,75 @@ def test_attach_lora_rejects_duplicate_adapter_name() -> None:
 
     with pytest.raises(ValueError, match="already attached"):
         attach_lora(language_model, _lora_config(), adapter_name="experiment")
+
+
+def test_lora_mode_trains_adapters_while_base_is_frozen() -> None:
+    module = torch.nn.Sequential(torch.nn.Linear(4, 4))
+    configure_finetuning(
+        module,
+        "lora",
+        lora_config=LoraConfig(target_modules=["0"], r=2, lora_alpha=4),
+    )
+
+    loss = module(torch.randn(3, 4)).sum()
+    loss.backward()
+
+    _assert_mode(module, "lora")
+    base_parameter = module[0].base_layer.weight
+    adapter_parameters = [
+        parameter for name, parameter in module.named_parameters() if "lora_" in name
+    ]
+    assert base_parameter.grad is None
+    assert any(parameter.grad is not None for parameter in adapter_parameters)
+
+
+@pytest.mark.parametrize(
+    ("encoder_mode", "language_mode"),
+    [
+        pytest.param("lora", "full", id="lora-encoder-full-llm"),
+        pytest.param("lora", "frozen", id="lora-encoder-frozen-llm"),
+        pytest.param("full", "lora", id="full-encoder-lora-llm"),
+        pytest.param("frozen", "lora", id="frozen-encoder-lora-llm"),
+    ],
+)
+def test_encoder_and_language_modes_can_be_heterogeneous(
+    encoder_mode: str,
+    language_mode: str,
+) -> None:
+    encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    modality_encoder = build_modality_encoder(
+        encoder, language_model, modality="vision"
+    )
+    modality_encoder.set_random_init()
+    language_model.set_random_init()
+
+    configure_finetuning(
+        modality_encoder,
+        encoder_mode,
+        lora_config=_lora_config() if encoder_mode == "lora" else None,
+    )
+    configure_finetuning(
+        language_model,
+        language_mode,
+        lora_config=_lora_config() if language_mode == "lora" else None,
+    )
+    modality_encoder.materialize("cpu")
+    language_model.materialize("cpu")
+
+    _assert_mode(modality_encoder.encoder, encoder_mode)
+    _assert_mode(language_model, language_mode)
+    assert all(
+        parameter.requires_grad for parameter in modality_encoder.projector.parameters()
+    )
+
+
+def test_configure_finetuning_validates_mode_and_lora_config() -> None:
+    module = torch.nn.Linear(2, 2)
+
+    with pytest.raises(ValueError, match="Unsupported fine-tuning mode"):
+        configure_finetuning(module, "partial")
+    with pytest.raises(ValueError, match="lora_config is required"):
+        configure_finetuning(module, "lora")
+    with pytest.raises(ValueError, match="only valid"):
+        configure_finetuning(module, "full", lora_config=_lora_config())


### PR DESCRIPTION
## What changed

- add a shared `configure_finetuning` API with `full`, `frozen`, and `lora` modes
- keep modality projectors independent when configuring encoder trainability
- allow encoder and language-model modes to be selected independently
- verify LoRA gradients reach adapters while base parameters remain frozen
- cover full/frozen/LoRA heterogeneous encoder and LLM combinations

## Impact

Local and distributed callers configure trainability on the same module objects before materialization. No composite multimodal training wrapper or parallelism-specific mode API is required.

## Validation

- `ruff check cornstarch/models/lora.py cornstarch/models/__init__.py tests/model/test_lora.py`
- `pytest -q tests/model/test_lora.py` (11 passed)
