### PR TITLE
docs(examples): expose LoRA training modes

### DIFF
--- a/docs/using_cornstarch/training_mllm.md
+++ b/docs/using_cornstarch/training_mllm.md
@@ -14,8 +14,49 @@ for microbatch in microbatches:
 optimizer.step()
 ```
 
-Modules can be frozen independently with normal `requires_grad_(False)` or by
-choosing which parameters enter the optimizer.
+## Full, frozen, and LoRA fine-tuning
+
+Use the same per-module configuration before local or distributed
+materialization. PEFT adapter injection is deferred automatically for lazy
+Cornstarch models, so checkpoint loading and parallel rank ownership are already
+resolved when the adapter is created.
+
+```python
+from peft import LoraConfig
+from cornstarch.models import configure_finetuning
+
+lora = LoraConfig(
+    target_modules="all-linear",
+    r=8,
+    lora_alpha=16,
+)
+
+configure_finetuning(vision_module, "lora", lora_config=lora)
+configure_finetuning(language_model, "frozen")
+
+# Local:
+vision_module.materialize(device)
+language_model.materialize(device)
+
+# Distributed uses the same configuration calls above:
+# context = parallelization_plan.materialize(device)
+```
+
+Each encoder and the language model accepts `full`, `frozen`, or `lora`
+independently. Passing a `CornstarchModalityEncoder` configures only its encoder;
+the modality projector remains trainable unless the caller freezes it explicitly.
+
+| Encoder mode | LLM mode | Result |
+| --- | --- | --- |
+| `lora` | `full` | encoder adapters plus full LLM fine-tuning |
+| `lora` | `frozen` | encoder adapters with a completely frozen LLM |
+| `full` | `lora` | full encoder fine-tuning plus LLM adapters |
+| `frozen` | `lora` | frozen encoder plus LLM adapters |
+
+In `lora` mode, PEFT freezes the base module and exposes only adapter parameters
+to the optimizer. In `frozen` mode, the whole selected base module has
+`requires_grad=False`. Optimizers remain ordinary PyTorch optimizers and should
+continue to select parameters with `requires_grad=True`.
 
 ## Pipeline execution
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@ Run the local examples from the repository root on a CUDA GPU:
 ```bash
 python -m examples.pretrain_vlm
 python -m examples.pretrain_valm
+
+# LoRA vision encoder with a frozen LLM; the projector remains trainable.
+python -m examples.pretrain_vlm \
+    --vision-train-mode lora --llm-train-mode frozen
 ```
 
 The distributed examples model a production one-process-per-GPU setup. They
@@ -25,6 +29,11 @@ torchrun --nproc-per-node=8 --module examples.distributed.pretrain_llm \
 # Three GPUs: one vision pipeline stage plus a two-way-TP language stage.
 torchrun --nproc-per-node=3 --module examples.distributed.pretrain_vlm \
     --llm-pp 1 --llm-tp 2
+
+# The same fine-tuning options work with the distributed plan.
+torchrun --nproc-per-node=3 --module examples.distributed.pretrain_vlm \
+    --llm-pp 1 --llm-tp 2 \
+    --vision-train-mode frozen --llm-train-mode lora
 ```
 
 For a multi-node launch, add torchrun's `--nnodes`, `--node-rank`,

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -28,6 +28,7 @@ from typing import Any, Callable
 import tyro
 
 import torch
+from peft import LoraConfig
 from torch.utils.data import Dataset
 from tqdm import tqdm
 from transformers import AutoConfig, get_linear_schedule_with_warmup
@@ -51,7 +52,9 @@ from cornstarch.distributed import (
 from cornstarch.models import (
     CornstarchExecutionPlan,
     ExecutionFuture,
+    FinetuningMode,
     build_modality_encoder,
+    configure_finetuning,
     from_hf_config,
 )
 
@@ -157,6 +160,17 @@ def _training_step(
     return result
 
 
+def _lora_config(mode: FinetuningMode) -> LoraConfig | None:
+    if mode != "lora":
+        return None
+    return LoraConfig(
+        target_modules="all-linear",
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.05,
+    )
+
+
 def pretrain(
     vision_name_or_path: str = "openai/clip-vit-base-patch32",
     llm_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -164,6 +178,8 @@ def pretrain(
     llm_pp: int | None = None,
     llm_cp: int = 1,
     dp: int = 1,
+    vision_train_mode: FinetuningMode = "full",
+    llm_train_mode: FinetuningMode = "full",
     batch_size: int = 4,
     seq_len: int = 128,
     num_microbatches: int = 2,
@@ -185,6 +201,16 @@ def pretrain(
 
     language_model.set_random_init()
     modality_encoder.set_random_init()
+    configure_finetuning(
+        modality_encoder,
+        vision_train_mode,
+        lora_config=_lora_config(vision_train_mode),
+    )
+    configure_finetuning(
+        language_model,
+        llm_train_mode,
+        lora_config=_lora_config(llm_train_mode),
+    )
 
     # Per-modality declarative configs. All modules must agree on pipeline
     # parallelism: when ``llm_pp`` is None there is no PP and the encoder + LLM are

--- a/examples/pretrain_vlm.py
+++ b/examples/pretrain_vlm.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import torch
 import tyro
+from peft import LoraConfig
 from torch.optim import Adam
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader, Dataset
@@ -35,8 +36,10 @@ from cornstarch.models import (
     CornstarchExecutionPlan,
     CornstarchLanguageModel,
     CornstarchModalityEncoder,
+    FinetuningMode,
     RepeatedLayerCompileConfig,
     build_modality_encoder,
+    configure_finetuning,
     from_hf_config,
 )
 
@@ -100,10 +103,23 @@ def _training_step(
     return language_outputs.execute()
 
 
+def _lora_config(mode: FinetuningMode) -> LoraConfig | None:
+    if mode != "lora":
+        return None
+    return LoraConfig(
+        target_modules="all-linear",
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.05,
+    )
+
+
 def pretrain(
     vision_encoder_name_or_path: str = "openai/clip-vit-base-patch32",
     llm_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
     use_layer_offload: bool = False,
+    vision_train_mode: FinetuningMode = "full",
+    llm_train_mode: FinetuningMode = "full",
     profile_output_path: Path | None = None,
     max_train_steps: int = 10,
 ) -> None:
@@ -145,6 +161,16 @@ def pretrain(
 
     language_model.set_random_init()
     vision_module.set_random_init()
+    configure_finetuning(
+        vision_module,
+        vision_train_mode,
+        lora_config=_lora_config(vision_train_mode),
+    )
+    configure_finetuning(
+        language_model,
+        llm_train_mode,
+        lora_config=_lora_config(llm_train_mode),
+    )
     language_model.materialize(device, dtype=DTYPE)
     vision_module.materialize(device, dtype=DTYPE)
     language_model.train()

--- a/tests/distributed/test_lora.py
+++ b/tests/distributed/test_lora.py
@@ -1,0 +1,52 @@
+"""LoRA remains trainable after Cornstarch tensor-parallel materialization."""
+
+import torch
+from peft import LoraConfig
+
+from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import configure_finetuning, from_hf_config
+from tests.distributed.distributed_base import GlooDistributedTestBase
+from tests.model.model_configs import llama_config
+
+
+class TestLoRATensorParallel(GlooDistributedTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_all_linear_lora_backward_with_tensor_parallelism(self) -> None:
+        model = from_hf_config(
+            llama_config(), model_kind="language", attn_implementation="eager"
+        )
+        model.set_random_init()
+        configure_finetuning(
+            model,
+            "lora",
+            lora_config=LoraConfig(target_modules="all-linear", r=2, lora_alpha=4),
+        )
+
+        plan = ParallelizationPlan()
+        plan.parallelize(
+            model,
+            ParallelConfig(tensor_parallel_size=2, data_parallel_size=1),
+        )
+        plan.materialize("cpu")
+
+        output = model(input_ids=torch.tensor([[1, 2, 3, 4]]))
+        output.logits.sum().backward()
+
+        adapter_parameters = [
+            parameter for name, parameter in model.named_parameters() if "lora_" in name
+        ]
+        base_parameters = [
+            parameter
+            for name, parameter in model.named_parameters()
+            if "lora_" not in name
+        ]
+        self.assertTrue(adapter_parameters)
+        self.assertTrue(
+            any(parameter.grad is not None for parameter in adapter_parameters)
+        )
+        self.assertTrue(
+            all(not parameter.requires_grad for parameter in base_parameters)
+        )


### PR DESCRIPTION
## What changed

- expose matching `vision_train_mode` and `llm_train_mode` options in local and distributed VLM examples
- use the same `configure_finetuning` calls before either local or parallel-plan materialization
- document heterogeneous full/frozen/LoRA combinations and projector behavior
- add a two-rank Gloo regression covering all-linear LoRA through TP forward and backward

## Impact

Switching between local and distributed training does not require a different LoRA wrapper or trainability API. The only distributed-specific code remains the existing parallelization plan.

## Validation

- both example CLIs render `{full,frozen,lora}` for encoder and LLM modes
- `ruff check examples/pretrain_vlm.py examples/distributed/pretrain_vlm.py tests/distributed/test_lora.py`
- `pytest -q tests/distributed/test_lora.py tests/test_examples.py tests/model/test_lora.py` (18 passed)
