### PR TITLE
feat(models): integrate LoRA fine-tuning

### DIFF
--- a/cornstarch/models/__init__.py
+++ b/cornstarch/models/__init__.py
@@ -12,7 +12,7 @@ from cornstarch.models.hf_conversion import (
 from cornstarch.models.language_model import CornstarchLanguageModel
 from cornstarch.models.layer_compile import RepeatedLayerCompileConfig
 from cornstarch.models.layer_offload import RepeatedLayerOffloadConfig
-from cornstarch.models.lora import attach_lora
+from cornstarch.models.lora import FinetuningMode, attach_lora, configure_finetuning
 from cornstarch.models.multimodal import (
     CornstarchEncoderToLanguageProjectorConfig,
     CornstarchExecutionPlan,
@@ -37,10 +37,12 @@ __all__ = [
     "CornstarchProjector",
     "CornstarchVisionEncoder",
     "ExecutionFuture",
+    "FinetuningMode",
     "RepeatedLayerCompileConfig",
     "RepeatedLayerOffloadConfig",
     "attach_lora",
     "build_modality_encoder",
+    "configure_finetuning",
     "from_hf_config",
     "from_pretrained_config",
     "load_hf_state_dict",

--- a/cornstarch/models/__init__.py
+++ b/cornstarch/models/__init__.py
@@ -12,6 +12,7 @@ from cornstarch.models.hf_conversion import (
 from cornstarch.models.language_model import CornstarchLanguageModel
 from cornstarch.models.layer_compile import RepeatedLayerCompileConfig
 from cornstarch.models.layer_offload import RepeatedLayerOffloadConfig
+from cornstarch.models.lora import attach_lora
 from cornstarch.models.multimodal import (
     CornstarchEncoderToLanguageProjectorConfig,
     CornstarchExecutionPlan,
@@ -38,6 +39,7 @@ __all__ = [
     "ExecutionFuture",
     "RepeatedLayerCompileConfig",
     "RepeatedLayerOffloadConfig",
+    "attach_lora",
     "build_modality_encoder",
     "from_hf_config",
     "from_pretrained_config",

--- a/cornstarch/models/lora.py
+++ b/cornstarch/models/lora.py
@@ -3,12 +3,55 @@
 from __future__ import annotations
 
 import copy
+from typing import Literal
 
 import torch.nn as nn
 from peft import LoraConfig, inject_adapter_in_model
 
 from cornstarch.models.model_base import CornstarchModelBase
 from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
+
+
+FinetuningMode = Literal["full", "frozen", "lora"]
+
+
+def configure_finetuning(
+    module: nn.Module,
+    mode: FinetuningMode,
+    *,
+    lora_config: LoraConfig | None = None,
+    adapter_name: str = "default",
+) -> nn.Module:
+    """Configure one encoder or language model for fine-tuning.
+
+    ``full`` trains every parameter, ``frozen`` trains none, and ``lora``
+    freezes base parameters while attaching trainable PEFT adapters.  A
+    :class:`CornstarchModalityEncoder` delegates to its encoder; the projector
+    is intentionally unaffected and can be configured independently with normal
+    PyTorch ``requires_grad_`` calls.
+
+    Calls are independent per module, so heterogeneous combinations such as a
+    LoRA encoder plus fully trainable LLM, or a frozen encoder plus LoRA LLM,
+    require no composite wrapper or distributed-specific configuration.
+    """
+    if mode not in {"full", "frozen", "lora"}:
+        raise ValueError(
+            f"Unsupported fine-tuning mode {mode!r}; expected 'full', "
+            "'frozen', or 'lora'."
+        )
+
+    target = _adapter_target(module)
+    if mode == "lora":
+        if lora_config is None:
+            raise ValueError("lora_config is required when mode='lora'.")
+        target.requires_grad_(False)
+        attach_lora(module, lora_config, adapter_name=adapter_name)
+        return module
+
+    if lora_config is not None:
+        raise ValueError("lora_config is only valid when mode='lora'.")
+    target.requires_grad_(mode == "full")
+    return module
 
 
 def attach_lora(
@@ -37,7 +80,7 @@ def attach_lora(
     if not adapter_name:
         raise ValueError("adapter_name must not be empty.")
 
-    target = module.encoder if isinstance(module, CornstarchModalityEncoder) else module
+    target = _adapter_target(module)
     adapter_names: set[str] = getattr(target, "_cornstarch_lora_adapter_names", set())
     if adapter_name in adapter_names:
         raise ValueError(
@@ -74,3 +117,9 @@ def _has_meta_tensors(module: nn.Module) -> bool:
     return any(tensor.is_meta for tensor in module.parameters()) or any(
         tensor.is_meta for tensor in module.buffers()
     )
+
+
+def _adapter_target(module: nn.Module) -> nn.Module:
+    if isinstance(module, CornstarchModalityEncoder):
+        return module.encoder
+    return module

--- a/cornstarch/models/lora.py
+++ b/cornstarch/models/lora.py
@@ -1,0 +1,76 @@
+"""LoRA adapter attachment that preserves Cornstarch model interfaces."""
+
+from __future__ import annotations
+
+import copy
+
+import torch.nn as nn
+from peft import LoraConfig, inject_adapter_in_model
+
+from cornstarch.models.model_base import CornstarchModelBase
+from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
+
+
+def attach_lora(
+    module: nn.Module,
+    config: LoraConfig,
+    *,
+    adapter_name: str = "default",
+) -> nn.Module:
+    """Attach a PEFT LoRA adapter in place and return ``module`` unchanged.
+
+    Passing a :class:`CornstarchModalityEncoder` targets its encoder only; its
+    projector remains an ordinary independently trainable module.  Passing a
+    language model targets that model directly, so encoder and language-model
+    adapters can be selected independently.
+
+    Cornstarch models begin on the ``meta`` device.  For those models adapter
+    injection is deferred until base checkpoint or random initialization has
+    completed.  This preserves Hugging Face checkpoint key translation while
+    keeping the call site identical for local and distributed materialization.
+    PEFT injects into already-materialized modules immediately.
+    """
+    if not isinstance(config, LoraConfig):
+        raise TypeError(
+            f"config must be a peft.LoraConfig, got {type(config).__name__}."
+        )
+    if not adapter_name:
+        raise ValueError("adapter_name must not be empty.")
+
+    target = module.encoder if isinstance(module, CornstarchModalityEncoder) else module
+    adapter_names: set[str] = getattr(target, "_cornstarch_lora_adapter_names", set())
+    if adapter_name in adapter_names:
+        raise ValueError(
+            f"LoRA adapter {adapter_name!r} is already attached to "
+            f"{type(target).__name__}."
+        )
+
+    deferred_config = copy.deepcopy(config)
+
+    def inject(target_module: nn.Module) -> None:
+        inject_adapter_in_model(
+            deferred_config,
+            target_module,
+            adapter_name=adapter_name,
+        )
+
+    if isinstance(target, CornstarchModelBase):
+        target._register_post_materialize_callback(inject)
+    elif _has_meta_tensors(target):
+        raise RuntimeError(
+            "Cannot attach LoRA to a generic module on the meta device. "
+            "Materialize it first, or pass a Cornstarch model so injection can "
+            "be deferred safely."
+        )
+    else:
+        inject(target)
+
+    adapter_names.add(adapter_name)
+    target._cornstarch_lora_adapter_names = adapter_names
+    return module
+
+
+def _has_meta_tensors(module: nn.Module) -> bool:
+    return any(tensor.is_meta for tensor in module.parameters()) or any(
+        tensor.is_meta for tensor in module.buffers()
+    )

--- a/cornstarch/models/model_base.py
+++ b/cornstarch/models/model_base.py
@@ -72,6 +72,9 @@ class CornstarchModelBase(nn.Module):
         self._init_plan = init_plan or InitializationPlan.empty()
         self._state_mapper = StateDictPrefixMap(hf_to_cornstarch_prefixes)
         self._hf_model_factory = hf_model_factory
+        self._post_materialize_callbacks: list[
+            Callable[[CornstarchModelBase], None]
+        ] = []
 
     @property
     def attention_kernel(self) -> Any:
@@ -145,6 +148,7 @@ class CornstarchModelBase(nn.Module):
         to materialize a sharded (DTensor) meta model in, e.g., bf16.
         """
         if not self._is_meta():
+            self._run_post_materialize_callbacks()
             return self
 
         device = torch.device(device)
@@ -164,7 +168,32 @@ class CornstarchModelBase(nn.Module):
         else:
             raise ValueError(f"Unknown initialization plan: {self._init_plan.mode}")
 
+        self._run_post_materialize_callbacks()
         return self
+
+    def _register_post_materialize_callback(
+        self, callback: Callable[[CornstarchModelBase], None]
+    ) -> None:
+        """Run ``callback`` after this model's base tensors materialize.
+
+        Structural extensions such as PEFT adapters must not wrap the lazy model
+        before checkpoint keys have been translated and loaded.  This private
+        lifecycle hook lets those extensions declare their intent while the
+        model is still on ``meta`` and apply the mutation at the safe boundary.
+        """
+        if self._is_meta():
+            self._post_materialize_callbacks.append(callback)
+        else:
+            callback(self)
+
+    def _run_post_materialize_callbacks(self) -> None:
+        """Apply and clear structural mutations queued for materialization."""
+        callbacks = self._post_materialize_callbacks
+        if not callbacks:
+            return
+        for callback in callbacks:
+            callback(self)
+        self._post_materialize_callbacks = []
 
     def load_hf_state_dict(
         self, state_dict: Mapping[str, torch.Tensor], strict: bool = True

--- a/docs/using_cornstarch/training_mllm.md
+++ b/docs/using_cornstarch/training_mllm.md
@@ -14,8 +14,49 @@ for microbatch in microbatches:
 optimizer.step()
 ```
 
-Modules can be frozen independently with normal `requires_grad_(False)` or by
-choosing which parameters enter the optimizer.
+## Full, frozen, and LoRA fine-tuning
+
+Use the same per-module configuration before local or distributed
+materialization. PEFT adapter injection is deferred automatically for lazy
+Cornstarch models, so checkpoint loading and parallel rank ownership are already
+resolved when the adapter is created.
+
+```python
+from peft import LoraConfig
+from cornstarch.models import configure_finetuning
+
+lora = LoraConfig(
+    target_modules="all-linear",
+    r=8,
+    lora_alpha=16,
+)
+
+configure_finetuning(vision_module, "lora", lora_config=lora)
+configure_finetuning(language_model, "frozen")
+
+# Local:
+vision_module.materialize(device)
+language_model.materialize(device)
+
+# Distributed uses the same configuration calls above:
+# context = parallelization_plan.materialize(device)
+```
+
+Each encoder and the language model accepts `full`, `frozen`, or `lora`
+independently. Passing a `CornstarchModalityEncoder` configures only its encoder;
+the modality projector remains trainable unless the caller freezes it explicitly.
+
+| Encoder mode | LLM mode | Result |
+| --- | --- | --- |
+| `lora` | `full` | encoder adapters plus full LLM fine-tuning |
+| `lora` | `frozen` | encoder adapters with a completely frozen LLM |
+| `full` | `lora` | full encoder fine-tuning plus LLM adapters |
+| `frozen` | `lora` | frozen encoder plus LLM adapters |
+
+In `lora` mode, PEFT freezes the base module and exposes only adapter parameters
+to the optimizer. In `frozen` mode, the whole selected base module has
+`requires_grad=False`. Optimizers remain ordinary PyTorch optimizers and should
+continue to select parameters with `requires_grad=True`.
 
 ## Pipeline execution
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@ Run the local examples from the repository root on a CUDA GPU:
 ```bash
 python -m examples.pretrain_vlm
 python -m examples.pretrain_valm
+
+# LoRA vision encoder with a frozen LLM; the projector remains trainable.
+python -m examples.pretrain_vlm \
+    --vision-train-mode lora --llm-train-mode frozen
 ```
 
 The distributed examples model a production one-process-per-GPU setup. They
@@ -25,6 +29,11 @@ torchrun --nproc-per-node=8 --module examples.distributed.pretrain_llm \
 # Three GPUs: one vision pipeline stage plus a two-way-TP language stage.
 torchrun --nproc-per-node=3 --module examples.distributed.pretrain_vlm \
     --llm-pp 1 --llm-tp 2
+
+# The same fine-tuning options work with the distributed plan.
+torchrun --nproc-per-node=3 --module examples.distributed.pretrain_vlm \
+    --llm-pp 1 --llm-tp 2 \
+    --vision-train-mode frozen --llm-train-mode lora
 ```
 
 For a multi-node launch, add torchrun's `--nnodes`, `--node-rank`,

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,9 @@ Run the local examples from the repository root on a CUDA GPU:
 python -m examples.pretrain_vlm
 python -m examples.pretrain_valm
 
+# One-device lazy base-checkpoint loading followed by LoRA initialization.
+python -m examples.finetune_llm_lora --steps 3
+
 # LoRA vision encoder with a frozen LLM; the projector remains trainable.
 python -m examples.pretrain_vlm \
     --vision-train-mode lora --llm-train-mode frozen

--- a/examples/distributed/pretrain_vlm.py
+++ b/examples/distributed/pretrain_vlm.py
@@ -28,6 +28,7 @@ from typing import Any, Callable
 import tyro
 
 import torch
+from peft import LoraConfig
 from torch.utils.data import Dataset
 from tqdm import tqdm
 from transformers import AutoConfig, get_linear_schedule_with_warmup
@@ -51,7 +52,9 @@ from cornstarch.distributed import (
 from cornstarch.models import (
     CornstarchExecutionPlan,
     ExecutionFuture,
+    FinetuningMode,
     build_modality_encoder,
+    configure_finetuning,
     from_hf_config,
 )
 
@@ -157,6 +160,17 @@ def _training_step(
     return result
 
 
+def _lora_config(mode: FinetuningMode) -> LoraConfig | None:
+    if mode != "lora":
+        return None
+    return LoraConfig(
+        target_modules="all-linear",
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.05,
+    )
+
+
 def pretrain(
     vision_name_or_path: str = "openai/clip-vit-base-patch32",
     llm_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
@@ -164,6 +178,8 @@ def pretrain(
     llm_pp: int | None = None,
     llm_cp: int = 1,
     dp: int = 1,
+    vision_train_mode: FinetuningMode = "full",
+    llm_train_mode: FinetuningMode = "full",
     batch_size: int = 4,
     seq_len: int = 128,
     num_microbatches: int = 2,
@@ -185,6 +201,16 @@ def pretrain(
 
     language_model.set_random_init()
     modality_encoder.set_random_init()
+    configure_finetuning(
+        modality_encoder,
+        vision_train_mode,
+        lora_config=_lora_config(vision_train_mode),
+    )
+    configure_finetuning(
+        language_model,
+        llm_train_mode,
+        lora_config=_lora_config(llm_train_mode),
+    )
 
     # Per-modality declarative configs. All modules must agree on pipeline
     # parallelism: when ``llm_pp`` is None there is no PP and the encoder + LLM are

--- a/examples/finetune_llm_lora.py
+++ b/examples/finetune_llm_lora.py
@@ -1,0 +1,172 @@
+"""Fine-tune a lazily loaded language model with LoRA on one device.
+
+The ordering in this example is intentional:
+
+1. Construct only the Cornstarch base-model topology on ``meta``.
+2. Record how the base checkpoint should be loaded.
+3. Record the LoRA configuration while leaving adapter tensors unallocated.
+4. Materialize the base checkpoint on the execution device. Cornstarch then
+   injects randomly initialized LoRA tensors on that device.
+5. Optionally overwrite those random tensors from a LoRA adapter checkpoint.
+
+PEFT wraps adapted layers under ``base_layer``. Injecting it before Cornstarch
+loads the base checkpoint would therefore change parameter paths too early and
+break Hugging Face-to-Cornstarch checkpoint mapping. Deferring injection also
+means distributed materialization can determine local layer ownership first,
+although this example deliberately uses one device and ordinary PyTorch.
+
+Run on one GPU::
+
+    python -m examples.finetune_llm_lora --steps 3
+
+The CPU option follows the same lifecycle and is useful as a small smoke test::
+
+    python -m examples.finetune_llm_lora \
+        --device cpu --dtype float32 --steps 1 --batch-size 1 --seq-len 8
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import torch
+import tyro
+from peft import (
+    LoraConfig,
+    get_peft_model_state_dict,
+    set_peft_model_state_dict,
+)
+from safetensors.torch import load_file, save_file
+from transformers import AutoConfig
+
+from cornstarch.models import (
+    RepeatedLayerCompileConfig,
+    configure_finetuning,
+    from_hf_config,
+)
+
+
+DTypeName = Literal["float32", "bfloat16", "float16"]
+
+
+def _torch_dtype(name: DTypeName) -> torch.dtype:
+    return {
+        "float32": torch.float32,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+    }[name]
+
+
+def _adapter_parameters(model: torch.nn.Module) -> list[torch.nn.Parameter]:
+    return [
+        parameter for name, parameter in model.named_parameters() if "lora_" in name
+    ]
+
+
+def finetune(
+    model_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
+    device: str = "cuda:0",
+    dtype: DTypeName = "bfloat16",
+    adapter_checkpoint: Path | None = None,
+    adapter_output: Path | None = None,
+    steps: int = 3,
+    batch_size: int = 2,
+    seq_len: int = 32,
+    learning_rate: float = 1e-4,
+) -> None:
+    """Load a base checkpoint lazily, then initialize or load LoRA adapters."""
+    execution_device = torch.device(device)
+    if execution_device.type == "cuda":
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested, but no CUDA device is available.")
+        torch.cuda.set_device(execution_device)
+    parameter_dtype = _torch_dtype(dtype)
+
+    # Step 1: from_hf_config creates Cornstarch's topology on meta. No model
+    # parameter storage is allocated on CPU or GPU at this point.
+    root_config = AutoConfig.from_pretrained(model_name_or_path)
+    config = getattr(root_config, "text_config", root_config)
+    model = from_hf_config(
+        config,
+        model_kind="language",
+        attn_implementation="eager",
+        layer_compile_config=RepeatedLayerCompileConfig(enabled=False),
+    )
+    assert all(parameter.is_meta for parameter in model.parameters())
+
+    # Step 2: record the base initialization source. The checkpoint is not read
+    # until materialize(), so this still consumes no base-model parameter RAM.
+    model.set_checkpoint_init(model_name_or_path=model_name_or_path)
+
+    # Step 3: record LoRA intent while the base remains on meta. Cornstarch does
+    # not inject PEFT yet, so there are deliberately no lora_A/lora_B tensors.
+    configure_finetuning(
+        model,
+        "lora",
+        lora_config=LoraConfig(
+            target_modules="all-linear",
+            r=8,
+            lora_alpha=16,
+            lora_dropout=0.05,
+        ),
+    )
+    assert not _adapter_parameters(model)
+    assert all(parameter.is_meta for parameter in model.parameters())
+    print("Base topology is on meta; LoRA configuration is queued without tensors.")
+
+    # Step 4: materialize the base first. Its original parameter paths are used
+    # for checkpoint loading; only afterward does the queued callback inject
+    # randomly initialized LoRA parameters directly on the execution device.
+    model.materialize(execution_device, dtype=parameter_dtype)
+    adapter_parameters = _adapter_parameters(model)
+    assert adapter_parameters
+    assert all(not parameter.is_meta for parameter in model.parameters())
+    assert all(parameter.requires_grad for parameter in adapter_parameters)
+    assert all(
+        not parameter.requires_grad
+        for name, parameter in model.named_parameters()
+        if "lora_" not in name
+    )
+    print(
+        f"Base checkpoint materialized on {execution_device}; "
+        f"created {sum(parameter.numel() for parameter in adapter_parameters):,} "
+        "trainable LoRA parameters."
+    )
+
+    # Step 5 (optional): PEFT can only load adapter tensors after the adapter
+    # modules exist. This overwrites their random initialization while leaving
+    # the already-loaded base checkpoint untouched. The checkpoint must match
+    # the LoRA target modules, rank, and alpha configured above.
+    if adapter_checkpoint is not None:
+        adapter_state = load_file(str(adapter_checkpoint), device="cpu")
+        set_peft_model_state_dict(model, adapter_state, adapter_name="default")
+
+    model.train()
+    optimizer = torch.optim.AdamW(adapter_parameters, lr=learning_rate)
+    for step in range(steps):
+        input_ids = torch.randint(
+            0,
+            int(config.vocab_size),
+            (batch_size, seq_len),
+            device=execution_device,
+        )
+        output = model(input_ids=input_ids, labels=input_ids, use_cache=False)
+        loss = output.loss
+        loss.backward()
+        optimizer.step()
+        optimizer.zero_grad()
+        print(f"step={step + 1} loss={loss.item():.4f}")
+
+    if adapter_output is not None:
+        adapter_output.parent.mkdir(parents=True, exist_ok=True)
+        adapter_state = {
+            name: tensor.detach().cpu().contiguous()
+            for name, tensor in get_peft_model_state_dict(model).items()
+        }
+        save_file(adapter_state, str(adapter_output))
+        print(f"Saved LoRA adapter tensors to {adapter_output}")
+
+
+if __name__ == "__main__":
+    tyro.cli(finetune)

--- a/examples/pretrain_vlm.py
+++ b/examples/pretrain_vlm.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import torch
 import tyro
+from peft import LoraConfig
 from torch.optim import Adam
 from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data import DataLoader, Dataset
@@ -35,8 +36,10 @@ from cornstarch.models import (
     CornstarchExecutionPlan,
     CornstarchLanguageModel,
     CornstarchModalityEncoder,
+    FinetuningMode,
     RepeatedLayerCompileConfig,
     build_modality_encoder,
+    configure_finetuning,
     from_hf_config,
 )
 
@@ -100,10 +103,23 @@ def _training_step(
     return language_outputs.execute()
 
 
+def _lora_config(mode: FinetuningMode) -> LoraConfig | None:
+    if mode != "lora":
+        return None
+    return LoraConfig(
+        target_modules="all-linear",
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.05,
+    )
+
+
 def pretrain(
     vision_encoder_name_or_path: str = "openai/clip-vit-base-patch32",
     llm_name_or_path: str = "hf-internal-testing/tiny-random-LlamaForCausalLM",
     use_layer_offload: bool = False,
+    vision_train_mode: FinetuningMode = "full",
+    llm_train_mode: FinetuningMode = "full",
     profile_output_path: Path | None = None,
     max_train_steps: int = 10,
 ) -> None:
@@ -145,6 +161,16 @@ def pretrain(
 
     language_model.set_random_init()
     vision_module.set_random_init()
+    configure_finetuning(
+        vision_module,
+        vision_train_mode,
+        lora_config=_lora_config(vision_train_mode),
+    )
+    configure_finetuning(
+        language_model,
+        llm_train_mode,
+        lora_config=_lora_config(llm_train_mode),
+    )
     language_model.materialize(device, dtype=DTYPE)
     vision_module.materialize(device, dtype=DTYPE)
     language_model.train()

--- a/tests/distributed/test_lora.py
+++ b/tests/distributed/test_lora.py
@@ -1,0 +1,52 @@
+"""LoRA remains trainable after Cornstarch tensor-parallel materialization."""
+
+import torch
+from peft import LoraConfig
+
+from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.models import configure_finetuning, from_hf_config
+from tests.distributed.distributed_base import GlooDistributedTestBase
+from tests.model.model_configs import llama_config
+
+
+class TestLoRATensorParallel(GlooDistributedTestBase):
+    @property
+    def world_size(self) -> int:
+        return 2
+
+    def test_all_linear_lora_backward_with_tensor_parallelism(self) -> None:
+        model = from_hf_config(
+            llama_config(), model_kind="language", attn_implementation="eager"
+        )
+        model.set_random_init()
+        configure_finetuning(
+            model,
+            "lora",
+            lora_config=LoraConfig(target_modules="all-linear", r=2, lora_alpha=4),
+        )
+
+        plan = ParallelizationPlan()
+        plan.parallelize(
+            model,
+            ParallelConfig(tensor_parallel_size=2, data_parallel_size=1),
+        )
+        plan.materialize("cpu")
+
+        output = model(input_ids=torch.tensor([[1, 2, 3, 4]]))
+        output.logits.sum().backward()
+
+        adapter_parameters = [
+            parameter for name, parameter in model.named_parameters() if "lora_" in name
+        ]
+        base_parameters = [
+            parameter
+            for name, parameter in model.named_parameters()
+            if "lora_" not in name
+        ]
+        self.assertTrue(adapter_parameters)
+        self.assertTrue(
+            any(parameter.grad is not None for parameter in adapter_parameters)
+        )
+        self.assertTrue(
+            all(not parameter.requires_grad for parameter in base_parameters)
+        )

--- a/tests/model/test_lora.py
+++ b/tests/model/test_lora.py
@@ -5,7 +5,12 @@ import torch
 from peft import LoraConfig
 from peft.tuners.lora import LoraLayer
 
-from cornstarch.models import attach_lora, build_modality_encoder, from_hf_config
+from cornstarch.models import (
+    attach_lora,
+    build_modality_encoder,
+    configure_finetuning,
+    from_hf_config,
+)
 from tests.model.model_configs import clip_vision_config, llama_config
 
 
@@ -15,6 +20,28 @@ def _lora_config() -> LoraConfig:
 
 def _lora_layers(module: torch.nn.Module) -> list[LoraLayer]:
     return [child for child in module.modules() if isinstance(child, LoraLayer)]
+
+
+def _assert_mode(module: torch.nn.Module, mode: str) -> None:
+    adapter_parameters = [
+        parameter for name, parameter in module.named_parameters() if "lora_" in name
+    ]
+    base_parameters = [
+        parameter
+        for name, parameter in module.named_parameters()
+        if "lora_" not in name
+    ]
+    assert base_parameters
+    if mode == "full":
+        assert not adapter_parameters
+        assert all(parameter.requires_grad for parameter in base_parameters)
+    elif mode == "frozen":
+        assert not adapter_parameters
+        assert all(not parameter.requires_grad for parameter in base_parameters)
+    else:
+        assert adapter_parameters
+        assert all(parameter.requires_grad for parameter in adapter_parameters)
+        assert all(not parameter.requires_grad for parameter in base_parameters)
 
 
 def test_attach_lora_mutates_materialized_module_in_place() -> None:
@@ -90,3 +117,75 @@ def test_attach_lora_rejects_duplicate_adapter_name() -> None:
 
     with pytest.raises(ValueError, match="already attached"):
         attach_lora(language_model, _lora_config(), adapter_name="experiment")
+
+
+def test_lora_mode_trains_adapters_while_base_is_frozen() -> None:
+    module = torch.nn.Sequential(torch.nn.Linear(4, 4))
+    configure_finetuning(
+        module,
+        "lora",
+        lora_config=LoraConfig(target_modules=["0"], r=2, lora_alpha=4),
+    )
+
+    loss = module(torch.randn(3, 4)).sum()
+    loss.backward()
+
+    _assert_mode(module, "lora")
+    base_parameter = module[0].base_layer.weight
+    adapter_parameters = [
+        parameter for name, parameter in module.named_parameters() if "lora_" in name
+    ]
+    assert base_parameter.grad is None
+    assert any(parameter.grad is not None for parameter in adapter_parameters)
+
+
+@pytest.mark.parametrize(
+    ("encoder_mode", "language_mode"),
+    [
+        pytest.param("lora", "full", id="lora-encoder-full-llm"),
+        pytest.param("lora", "frozen", id="lora-encoder-frozen-llm"),
+        pytest.param("full", "lora", id="full-encoder-lora-llm"),
+        pytest.param("frozen", "lora", id="frozen-encoder-lora-llm"),
+    ],
+)
+def test_encoder_and_language_modes_can_be_heterogeneous(
+    encoder_mode: str,
+    language_mode: str,
+) -> None:
+    encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    modality_encoder = build_modality_encoder(
+        encoder, language_model, modality="vision"
+    )
+    modality_encoder.set_random_init()
+    language_model.set_random_init()
+
+    configure_finetuning(
+        modality_encoder,
+        encoder_mode,
+        lora_config=_lora_config() if encoder_mode == "lora" else None,
+    )
+    configure_finetuning(
+        language_model,
+        language_mode,
+        lora_config=_lora_config() if language_mode == "lora" else None,
+    )
+    modality_encoder.materialize("cpu")
+    language_model.materialize("cpu")
+
+    _assert_mode(modality_encoder.encoder, encoder_mode)
+    _assert_mode(language_model, language_mode)
+    assert all(
+        parameter.requires_grad for parameter in modality_encoder.projector.parameters()
+    )
+
+
+def test_configure_finetuning_validates_mode_and_lora_config() -> None:
+    module = torch.nn.Linear(2, 2)
+
+    with pytest.raises(ValueError, match="Unsupported fine-tuning mode"):
+        configure_finetuning(module, "partial")
+    with pytest.raises(ValueError, match="lora_config is required"):
+        configure_finetuning(module, "lora")
+    with pytest.raises(ValueError, match="only valid"):
+        configure_finetuning(module, "full", lora_config=_lora_config())

--- a/tests/model/test_lora.py
+++ b/tests/model/test_lora.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from peft import LoraConfig
+from peft.tuners.lora import LoraLayer
+
+from cornstarch.models import attach_lora, build_modality_encoder, from_hf_config
+from tests.model.model_configs import clip_vision_config, llama_config
+
+
+def _lora_config() -> LoraConfig:
+    return LoraConfig(target_modules=["q_proj"], r=2, lora_alpha=4)
+
+
+def _lora_layers(module: torch.nn.Module) -> list[LoraLayer]:
+    return [child for child in module.modules() if isinstance(child, LoraLayer)]
+
+
+def test_attach_lora_mutates_materialized_module_in_place() -> None:
+    module = torch.nn.Sequential(torch.nn.Linear(4, 4))
+
+    returned = attach_lora(
+        module,
+        LoraConfig(target_modules=["0"], r=2, lora_alpha=4),
+    )
+
+    assert returned is module
+    assert len(_lora_layers(module)) == 1
+
+
+def test_attach_lora_defers_until_cornstarch_model_materializes() -> None:
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    language_model.set_random_init()
+
+    returned = attach_lora(language_model, _lora_config())
+
+    assert returned is language_model
+    assert not _lora_layers(language_model)
+
+    language_model.materialize("cpu")
+
+    assert _lora_layers(language_model)
+    assert all(not parameter.is_meta for parameter in language_model.parameters())
+
+
+def test_deferred_lora_preserves_checkpoint_initialization() -> None:
+    reference = from_hf_config(llama_config(), model_kind="language")
+    reference.set_random_init()
+    reference.materialize("cpu")
+    hf_state_dict = reference.to_hf_state_dict()
+
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    language_model.set_checkpoint_init(state_dict=hf_state_dict)
+    attach_lora(language_model, _lora_config())
+    language_model.materialize("cpu")
+
+    adapted_projection = language_model.decoder_layers[0].self_attn.q_proj
+    torch.testing.assert_close(
+        adapted_projection.base_layer.weight,
+        reference.decoder_layers[0].self_attn.q_proj.weight,
+    )
+
+
+def test_encoder_and_language_lora_are_attached_independently() -> None:
+    encoder = from_hf_config(clip_vision_config(), model_kind="vision")
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    modality_encoder = build_modality_encoder(
+        encoder, language_model, modality="vision"
+    )
+    modality_encoder.set_random_init()
+    language_model.set_random_init()
+
+    attach_lora(modality_encoder, _lora_config())
+    modality_encoder.materialize("cpu")
+
+    assert _lora_layers(modality_encoder.encoder)
+    assert not _lora_layers(modality_encoder.projector)
+    assert not _lora_layers(language_model)
+
+    attach_lora(language_model, _lora_config())
+    language_model.materialize("cpu")
+
+    assert _lora_layers(language_model)
+
+
+def test_attach_lora_rejects_duplicate_adapter_name() -> None:
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    attach_lora(language_model, _lora_config(), adapter_name="experiment")
+
+    with pytest.raises(ValueError, match="already attached"):
+        attach_lora(language_model, _lora_config(), adapter_name="experiment")


### PR DESCRIPTION
## Summary

Merge the completed Hugging Face PEFT LoRA work into the main `refactor` development branch.

## Included features

- independent in-place LoRA attachment for modality encoders and language models
- deferred adapter injection that preserves Cornstarch lazy/meta initialization and base checkpoint key mapping
- independent `full`, `frozen`, and `lora` training modes for heterogeneous multimodal fine-tuning
- matching local and distributed VLM interfaces
- tensor-parallel LoRA forward/backward coverage
- a GPU-verified one-device example for base-checkpoint loading followed by random or checkpoint-loaded LoRA initialization

## Merged feature PRs

- #88 adapter lifecycle
- #89 heterogeneous training modes
- #90 local/distributed training interface
- #91 lazy initialization example

## Validation

- focused LoRA, materialization, distributed, and example suites passed
- two-rank Gloo tensor-parallel LoRA backward passed
- NVIDIA GH200 BF16 training, adapter save, and adapter reload completed successfully
- broad suite: 245 passed, 5 skipped; the sole PyTorch Inductor ARM compiler failure was reproduced unchanged on the pre-LoRA `refactor` baseline
