### PR TITLE
Add fused multimodal pipeline extension points

### DIFF
--- a/cornstarch/__init__.py
+++ b/cornstarch/__init__.py
@@ -4,6 +4,7 @@ from cornstarch.models import (
     CornstarchAudioEncoder,
     CornstarchEncoder,
     CornstarchEncoderBase,
+    CornstarchFusedModalityEncoder,
     CornstarchLanguageModel,
     CornstarchVisionEncoder,
 )
@@ -12,6 +13,7 @@ __all__ = [
     "CornstarchAudioEncoder",
     "CornstarchEncoder",
     "CornstarchEncoderBase",
+    "CornstarchFusedModalityEncoder",
     "CornstarchLanguageModel",
     "CornstarchVisionEncoder",
 ]

--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -55,8 +55,12 @@ from cornstarch.distributed.parallel_config import ParallelConfig
 from cornstarch.distributed.parallelization import (
     ParallelContext,
     ParallelizationPlan,
+    ScheduleContext,
 )
-from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
+from cornstarch.distributed.pipeline_parallel import (
+    PipelinePartitionSpec,
+    apply_pipeline_parallel,
+)
 from cornstarch.distributed.pipeline_parallel.schedule import (
     BasePipelineSchedule,
     MeshLayout,
@@ -84,6 +88,7 @@ __all__ = [
     "MakespanMinContextParallelSplitter",
     # pipeline parallel
     "apply_pipeline_parallel",
+    "PipelinePartitionSpec",
     "TrainingSchedule",
     "BasePipelineSchedule",
     "OneForwardOneBackwardSchedule",
@@ -97,4 +102,5 @@ __all__ = [
     "ParallelConfig",
     "ParallelizationPlan",
     "ParallelContext",
+    "ScheduleContext",
 ]

--- a/cornstarch/distributed/cross_mesh_routing.py
+++ b/cornstarch/distributed/cross_mesh_routing.py
@@ -481,17 +481,17 @@ def build_cross_mesh_groups(
 ) -> list[CrossMeshGroup]:
     """Collectively construct deterministic DP-local seam groups on all ranks.
 
-    The projected hidden dimension is replicated today. Equal TP/EP degrees pair
-    like lanes; a producer degree of one may fan out to replicated consumer
-    lanes. A producer-sharded layout cannot be collapsed implicitly and is
-    rejected rather than mixing incompatible hidden-dimension shards.
+    The projected hidden dimension is replicated. Equal TP/EP degrees pair like
+    lanes; a smaller producer degree may fan out evenly to a divisible consumer
+    degree. Collapsing more producer lanes into fewer consumer lanes is rejected
+    because it would require a distinct replicated-gradient reduction contract.
     """
     if producer_layout.dp_size != consumer_layout.dp_size:
         raise ValueError("Encoder and language-model seam layouts must have equal DP size.")
     for axis in ("tp_size", "ep_size"):
         producer_degree = getattr(producer_layout, axis)
         consumer_degree = getattr(consumer_layout, axis)
-        if producer_degree not in (1, consumer_degree):
+        if consumer_degree % producer_degree:
             label = axis.removesuffix("_size").upper()
             raise ValueError(
                 f"Incompatible {label} layout at modality seam: producer degree "
@@ -503,9 +503,9 @@ def build_cross_mesh_groups(
     groups: list[CrossMeshGroup] = []
     for dp_rank in range(producer_layout.dp_size):
         for consumer_tp in range(consumer_layout.tp_size):
-            producer_tp = 0 if producer_layout.tp_size == 1 else consumer_tp
+            producer_tp = consumer_tp % producer_layout.tp_size
             for consumer_ep in range(consumer_layout.ep_size):
-                producer_ep = 0 if producer_layout.ep_size == 1 else consumer_ep
+                producer_ep = consumer_ep % producer_layout.ep_size
                 producer_ranks = tuple(
                     producer_layout.rank_at(
                         dp_rank,

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -19,7 +19,8 @@ parallelisms remain independently togglable.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Sequence
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Mapping, Optional, Sequence
 
 import torch
 import torch.distributed as dist
@@ -39,7 +40,10 @@ from cornstarch.distributed.cross_mesh_routing import (
 from cornstarch.distributed.data_parallel import GradientSynchronizer
 from cornstarch.distributed.expert_parallel import apply_expert_parallel
 from cornstarch.distributed.parallel_config import ParallelConfig
-from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
+from cornstarch.distributed.pipeline_parallel import (
+    PipelinePartitionSpec,
+    apply_pipeline_parallel,
+)
 from cornstarch.distributed.pipeline_parallel.schedule import (
     MeshLayout,
     OneForwardOneBackwardSchedule,
@@ -49,7 +53,10 @@ from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.distributed.tensor_parallel import apply_tensor_parallel
 from cornstarch.models.model_base import CornstarchModelBase
 from cornstarch.models.language_model import CornstarchLanguageModel
-from cornstarch.models.multimodal.modeling import CornstarchModalityEncoder
+from cornstarch.models.multimodal.modeling import (
+    CornstarchFusedModalityEncoder,
+    CornstarchModalityEncoder,
+)
 
 if TYPE_CHECKING:
     from cornstarch.models.multimodal.execution import (
@@ -67,7 +74,16 @@ _DEFAULT_CP_SPLIT_KEYS = (
     "document_ids",
 )
 
-ParallelModule = CornstarchModelBase | CornstarchModalityEncoder
+ParallelModule = (
+    CornstarchModelBase
+    | CornstarchModalityEncoder
+    | CornstarchFusedModalityEncoder
+)
+PipelinePartitions = (
+    PipelinePartitionSpec
+    | Mapping[str, PipelinePartitionSpec]
+    | None
+)
 
 
 @dataclass(frozen=True)
@@ -146,6 +162,23 @@ class _ContextBatchTransform:
                     # The schedule can derive a one-row-per-placeholder mask
                     # once the DAG supplies this modality's token id.
                     continue
+            elif isinstance(module, CornstarchFusedModalityEncoder):
+                splitter = config.context_parallel_splitter
+                modality_offsets = {}
+                for modality in module.modalities:
+                    modality_mask = modality_masks.get(modality)
+                    if modality_mask is None:
+                        continue
+                    offsets = (
+                        [torch.arange(modality_mask.shape[1], dtype=torch.long)]
+                        if splitter is None
+                        else splitter.offsets_for_size(
+                            modality_mask, config.context_parallel_size
+                        )
+                    )
+                    modality_offsets[modality] = tuple(offsets)
+                routing_offsets[id(module)] = modality_offsets
+                continue
             splitter = config.context_parallel_splitter
             offsets = (
                 [torch.arange(routing_mask.shape[1], dtype=torch.long)]
@@ -231,6 +264,33 @@ class _ContextBatchTransform:
         )
 
 
+@dataclass(frozen=True)
+class ScheduleContext:
+    """Public immutable inputs for a caller-supplied pipeline schedule."""
+
+    plan: "CornstarchExecutionPlan"
+    output_future: "ExecutionFuture"
+    layouts: Mapping[int, MeshLayout]
+    meshes: Mapping[int, ModalProcessGroupMesh]
+    data_parallel_size: int
+    cross_mesh_groups: Mapping[tuple[int, int], tuple[CrossMeshGroup, ...]]
+    routing_splitters: Mapping[int, tuple[Any, int]]
+
+    def create_default_1f1b(self) -> OneForwardOneBackwardSchedule:
+        return OneForwardOneBackwardSchedule(
+            self.plan,
+            self.output_future,
+            dict(self.layouts),
+            dict(self.meshes),
+            self.data_parallel_size,
+            {
+                key: list(groups)
+                for key, groups in self.cross_mesh_groups.items()
+            },
+            dict(self.routing_splitters),
+        )
+
+
 class ParallelContext:
     """Runtime handle returned by :meth:`ParallelizationPlan.materialize`.
 
@@ -313,10 +373,14 @@ class ParallelContext:
     def prepare_dataloader(
         self,
         dataset: Dataset,
-        batch_size: int,
+        batch_size: int | None = None,
         collate_fn: Optional[Callable[[list], "dict | list[dict]"]] = None,
         *,
         shuffle: bool = False,
+        sampler: Any | None = None,
+        batch_sampler: Any | None = None,
+        per_microbatch_transform: Callable[[Any], Any] | None = None,
+        microbatch_views: Callable[[Any], Iterable[dict[str, Any]]] | None = None,
         cp_split_keys: Sequence[str] = _DEFAULT_CP_SPLIT_KEYS,
         **loader_kwargs: Any,
     ) -> DataLoader:
@@ -338,6 +402,11 @@ class ParallelContext:
         their microbatches; without pipeline parallelism the training loop
         iterates it with gradient accumulation.
 
+        **Structured views.** Pass ``microbatch_views`` for a caller-owned
+        microbatch object. It must yield each mutable batch dictionary that needs
+        Cornstarch's CP metadata/slicing (for example separate encoder and LLM
+        views); the surrounding object is preserved and returned unchanged.
+
         **Multimodal CP seam metadata.** A collator whose modality projector
         emits padded context-sharded rows should include
         ``cp_modality_attention_masks`` as a mapping from modality name to its
@@ -348,8 +417,17 @@ class ParallelContext:
         placeholder count; non-left-packed or independently padded projectors
         must provide the explicit mask.
         """
-        sampler = None
-        if self._dp_size > 1:
+        if batch_sampler is not None:
+            if sampler is not None or shuffle:
+                raise ValueError(
+                    "batch_sampler is mutually exclusive with sampler and shuffle."
+                )
+            if batch_size is not None:
+                raise ValueError("Omit batch_size when providing batch_sampler.")
+        elif batch_size is None:
+            raise ValueError("batch_size is required when batch_sampler is absent.")
+
+        if sampler is None and batch_sampler is None and self._dp_size > 1:
             sampler = DistributedSampler(
                 dataset,
                 num_replicas=self._dp_size,
@@ -373,24 +451,48 @@ class ParallelContext:
             has_cross_mesh_seams=bool(self._cross_mesh_groups),
         )
 
-        def wrapped_collate(samples: list) -> list[dict]:
+        def wrapped_collate(samples: list) -> list[Any]:
             collated = (
                 collate_fn(samples)
                 if collate_fn is not None
                 else _default_collate(samples)
             )
-            # Normalize to a microbatch list (a bare dict = a single microbatch),
-            # then apply the DP/CP transforms per microbatch.
+            # Normalize to one optimizer-step list. A caller-owned view selector
+            # lets structured microbatches expose distinct encoder/LLM dictionaries
+            # without Cornstarch knowing the structure's concrete type.
             microbatches = collated if isinstance(collated, list) else [collated]
-            return [apply_cp_split(mb) for mb in microbatches]
+            result: list[Any] = []
+            for microbatch in microbatches:
+                if per_microbatch_transform is not None:
+                    microbatch = per_microbatch_transform(microbatch)
+                views = (
+                    tuple(microbatch_views(microbatch))
+                    if microbatch_views is not None
+                    else (microbatch,)
+                )
+                if not views:
+                    raise ValueError("A planned microbatch must expose at least one view.")
+                for view in views:
+                    if not isinstance(view, dict):
+                        raise TypeError(
+                            "Every context-parallel microbatch view must be a dict."
+                        )
+                    apply_cp_split(view)
+                result.append(microbatch)
+            return result
 
+        common_kwargs = dict(
+            dataset=dataset,
+            collate_fn=wrapped_collate,
+            **loader_kwargs,
+        )
+        if batch_sampler is not None:
+            return DataLoader(batch_sampler=batch_sampler, **common_kwargs)
         return DataLoader(
-            dataset,
             batch_size=batch_size,
             sampler=sampler,
             shuffle=shuffle if sampler is None else False,
-            collate_fn=wrapped_collate,
-            **loader_kwargs,
+            **common_kwargs,
         )
 
     # ------------------------------------------------------------------
@@ -401,6 +503,8 @@ class ParallelContext:
         self,
         plan: "CornstarchExecutionPlan",
         output_future: "ExecutionFuture",
+        *,
+        schedule_factory: Callable[[ScheduleContext], TrainingSchedule] | None = None,
     ) -> TrainingSchedule:
         """Return the pipeline-parallel training schedule for the plan.
 
@@ -421,18 +525,33 @@ class ParallelContext:
                 "parallelism the modules are co-located; run the plan directly "
                 "(output_future.execute() + backward()) per microbatch instead."
             )
-        return OneForwardOneBackwardSchedule(
-            plan,
-            output_future,
-            {id(module): self._layouts[id(module)] for module in self._modules},
-            self._meshes,
-            self._dp_size,
-            self._cross_mesh_groups,
-            {
-                id(module): (config.context_parallel_splitter, config.context_parallel_size)
-                for module, config in zip(self._modules, self._configs)
-            },
+        context = ScheduleContext(
+            plan=plan,
+            output_future=output_future,
+            layouts=MappingProxyType(
+                {id(module): self._layouts[id(module)] for module in self._modules}
+            ),
+            meshes=MappingProxyType(dict(self._meshes)),
+            data_parallel_size=self._dp_size,
+            cross_mesh_groups=MappingProxyType(
+                {
+                    key: tuple(groups)
+                    for key, groups in self._cross_mesh_groups.items()
+                }
+            ),
+            routing_splitters=MappingProxyType(
+                {
+                    id(module): (
+                        config.context_parallel_splitter,
+                        config.context_parallel_size,
+                    )
+                    for module, config in zip(self._modules, self._configs)
+                }
+            ),
         )
+        if schedule_factory is not None:
+            return schedule_factory(context)
+        return context.create_default_1f1b()
 
     # ------------------------------------------------------------------
     # Gradient sync
@@ -493,6 +612,7 @@ class ParallelizationPlan:
     def __init__(self, global_ranks: Optional[Iterable[int]] = None) -> None:
         self._modules: list[ParallelModule] = []
         self._configs: list[ParallelConfig] = []
+        self._pipeline_partitions: list[PipelinePartitions] = []
         self._global_ranks: Optional[list[int]] = (
             list(global_ranks) if global_ranks is not None else None
         )
@@ -501,6 +621,8 @@ class ParallelizationPlan:
         self,
         module: ParallelModule,
         config: ParallelConfig,
+        *,
+        pipeline_partitions: PipelinePartitions = None,
     ) -> None:
         """Record a module-to-config binding for later distribution.
 
@@ -510,15 +632,56 @@ class ParallelizationPlan:
         ``apply_*`` helpers to walk. Wrap such an encoder with
         ``build_modality_encoder(encoder, language_model, modality=...)`` first.
         """
-        if not isinstance(module, (CornstarchModelBase, CornstarchModalityEncoder)):
+        if not isinstance(
+            module,
+            (
+                CornstarchModelBase,
+                CornstarchModalityEncoder,
+                CornstarchFusedModalityEncoder,
+            ),
+        ):
             raise TypeError(
-                f"parallelize() requires a CornstarchModelBase or "
-                f"CornstarchModalityEncoder, got {type(module).__name__}. Wrap a "
+                f"parallelize() requires a CornstarchModelBase, "
+                f"CornstarchModalityEncoder, or CornstarchFusedModalityEncoder; "
+                f"got {type(module).__name__}. Wrap a "
                 f"raw Hugging Face encoder with build_modality_encoder(encoder, "
                 f"language_model, modality=...) before parallelizing it."
             )
+        if pipeline_partitions is not None and not config.uses_pipeline_parallel:
+            raise ValueError(
+                "pipeline_partitions requires a positive pipeline_parallel_size."
+            )
+        if isinstance(module, CornstarchFusedModalityEncoder):
+            if pipeline_partitions is not None:
+                if not isinstance(pipeline_partitions, Mapping):
+                    raise TypeError(
+                        "A fused module requires a modality-to-partition mapping."
+                    )
+                expected = set(module.modalities)
+                actual = set(pipeline_partitions)
+                if actual != expected:
+                    raise ValueError(
+                        "Fused partition keys must exactly match registered "
+                        f"modalities; expected {sorted(expected)}, got {sorted(actual)}."
+                    )
+                if any(
+                    len(spec.boundaries) != config.num_pp_stages
+                    for spec in pipeline_partitions.values()
+                ):
+                    raise ValueError(
+                        "Every fused partition must contain one boundary per PP stage."
+                    )
+        elif isinstance(pipeline_partitions, Mapping):
+            raise TypeError("A non-fused module accepts one PipelinePartitionSpec.")
+        elif (
+            pipeline_partitions is not None
+            and len(pipeline_partitions.boundaries) != config.num_pp_stages
+        ):
+            raise ValueError("Partition must contain one boundary per PP stage.")
+
         self._modules.append(module)
         self._configs.append(config)
+        self._pipeline_partitions.append(pipeline_partitions)
 
     def materialize(
         self,
@@ -546,8 +709,11 @@ class ParallelizationPlan:
 
         meshes: dict[int, ModalProcessGroupMesh] = {}
         layouts: dict[int, MeshLayout] = {}
-        for module, config, ranks in zip(
-            self._modules, self._configs, module_ranks
+        for module, config, ranks, partitions in zip(
+            self._modules,
+            self._configs,
+            module_ranks,
+            self._pipeline_partitions,
         ):
             layout, mesh = self._build_module_mesh(
                 config, ranks, dp_size, device.type
@@ -556,7 +722,14 @@ class ParallelizationPlan:
             if not mesh.is_member:
                 continue
             meshes[id(module)] = mesh
-            self._materialize_local_module(module, config, mesh, device, dtype)
+            self._materialize_local_module(
+                module,
+                config,
+                mesh,
+                device,
+                dtype,
+                pipeline_partitions=partitions,
+            )
 
         dp_size_final, dp_rank, dp_group, grad_sync = self._build_dp_handles(
             meshes
@@ -648,6 +821,8 @@ class ParallelizationPlan:
         mesh: ModalProcessGroupMesh,
         device: torch.device,
         dtype: torch.dtype | None,
+        *,
+        pipeline_partitions: PipelinePartitions = None,
     ) -> None:
         """Apply model-side axes around rank-local lazy materialization.
 
@@ -658,26 +833,48 @@ class ParallelizationPlan:
         batched weights. This ordering is the central lazy-initialization
         invariant and is intentionally expressed once.
         """
-        target = (
-            module.encoder
-            if isinstance(module, CornstarchModalityEncoder)
-            else module
-        )
-        if config.tensor_parallel_size > 1:
-            apply_tensor_parallel(target, mesh.tp_mesh)
-        if config.context_parallel_size > 1:
-            apply_context_parallel(
-                target,
-                mesh.cp_group,
-                causal=isinstance(target, CornstarchLanguageModel),
-                splitter=config.context_parallel_splitter,
+        if isinstance(module, CornstarchFusedModalityEncoder):
+            partition_map = dict(pipeline_partitions or {})
+            targets = [
+                (name, child.encoder, partition_map.get(name))
+                for name, child in module.encoders.items()
+            ]
+        else:
+            target = (
+                module.encoder
+                if isinstance(module, CornstarchModalityEncoder)
+                else module
             )
-        if config.num_pp_stages > 1:
-            apply_pipeline_parallel(target, mesh)
+            partition = (
+                pipeline_partitions
+                if isinstance(pipeline_partitions, PipelinePartitionSpec)
+                else None
+            )
+            targets = [(None, target, partition)]
+
+        for _, target, partition in targets:
+            if config.tensor_parallel_size > 1:
+                apply_tensor_parallel(target, mesh.tp_mesh)
+            if config.context_parallel_size > 1:
+                apply_context_parallel(
+                    target,
+                    mesh.cp_group,
+                    causal=isinstance(target, CornstarchLanguageModel),
+                    splitter=config.context_parallel_splitter,
+                )
+            if config.num_pp_stages > 1:
+                apply_pipeline_parallel(target, mesh, partition=partition)
+
+        if isinstance(module, CornstarchFusedModalityEncoder):
+            for child in module.encoders.values():
+                child._pipeline_mesh = mesh
+        elif isinstance(module, CornstarchModalityEncoder):
+            module._pipeline_mesh = mesh
 
         module.materialize(device, dtype=dtype)
         if config.expert_parallel_size > 1:
-            apply_expert_parallel(target, mesh.ep_group)
+            for _, target, _ in targets:
+                apply_expert_parallel(target, mesh.ep_group)
 
     def _build_cross_mesh_groups(
         self, layouts: dict[int, MeshLayout]
@@ -689,8 +886,12 @@ class ParallelizationPlan:
         when it belongs to neither side of a particular seam.
         """
         encoders = [
-            module for module in self._modules
-            if isinstance(module, CornstarchModalityEncoder)
+            module
+            for module in self._modules
+            if isinstance(
+                module,
+                (CornstarchModalityEncoder, CornstarchFusedModalityEncoder),
+            )
         ]
         language_models = [
             module for module in self._modules

--- a/cornstarch/distributed/pipeline_parallel/__init__.py
+++ b/cornstarch/distributed/pipeline_parallel/__init__.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from cornstarch.distributed.pipeline_parallel.forward_spec_wrapper import (
     PipelineParallelForwardSpec,
 )
+from cornstarch.distributed.pipeline_parallel.partition import PipelinePartitionSpec
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.models.model_base import CornstarchModelBase
 
@@ -13,6 +14,7 @@ from cornstarch.models.model_base import CornstarchModelBase
 def apply_pipeline_parallel(
     module: CornstarchModelBase,
     mesh: ModalProcessGroupMesh,
+    partition: PipelinePartitionSpec | None = None,
 ) -> None:
     """Distribute a model across pipeline stages.
 
@@ -35,7 +37,15 @@ def apply_pipeline_parallel(
 
     layers = getattr(module, layers_name)
     total_layers = len(layers)
-    start, end = mesh.distribute_layers(total_layers)
+    start, end = (
+        mesh.distribute_layers(total_layers)
+        if partition is None
+        else partition.layer_range(
+            total_layers=total_layers,
+            stage=mesh.stage,
+            num_stages=mesh.num_stages,
+        )
+    )
     setattr(module, layers_name, nn.ModuleList(list(layers)[start:end]))
     # Materialization still maps this sliced ModuleList back to the original HF
     # checkpoint/topology.  Preserve the global index so constant parameters

--- a/cornstarch/distributed/pipeline_parallel/partition.py
+++ b/cornstarch/distributed/pipeline_parallel/partition.py
@@ -1,0 +1,45 @@
+"""Validated explicit contiguous pipeline partition specifications."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PipelinePartitionSpec:
+    """Exclusive layer boundaries, one per pipeline stage."""
+
+    boundaries: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.boundaries:
+            raise ValueError("Pipeline partition boundaries must be nonempty.")
+        if any(
+            left >= right
+            for left, right in zip((0, *self.boundaries[:-1]), self.boundaries)
+        ):
+            raise ValueError(
+                "Pipeline partition boundaries must define ordered nonempty ranges."
+            )
+
+    def layer_range(
+        self,
+        *,
+        total_layers: int,
+        stage: int,
+        num_stages: int,
+    ) -> tuple[int, int]:
+        if len(self.boundaries) != num_stages:
+            raise ValueError(
+                f"Expected {num_stages} partition boundaries, got "
+                f"{len(self.boundaries)}."
+            )
+        if self.boundaries[-1] != total_layers:
+            raise ValueError(
+                f"Partition must be exhaustive: final boundary "
+                f"{self.boundaries[-1]} != total_layers {total_layers}."
+            )
+        if not 0 <= stage < num_stages:
+            raise ValueError(f"Invalid pipeline stage {stage} for {num_stages} stages.")
+        start = 0 if stage == 0 else self.boundaries[stage - 1]
+        return start, self.boundaries[stage]

--- a/cornstarch/distributed/pipeline_parallel/schedule.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule.py
@@ -57,6 +57,7 @@ from cornstarch.models.multimodal.execution import (
     CornstarchExecutionPlan,
     ExecutionFuture,
     _first_output_tensor,
+    _resolve_optional_modality_inputs,
     _resolve_value,
 )
 
@@ -243,7 +244,7 @@ class BasePipelineSchedule(TrainingSchedule):
         self._dp_size = dp_size
         self._my_rank = dist.get_rank()
         self._device: torch.device | None = None
-        self._seam_states: list[tuple[str, SeamExchangeState]] = []
+        self._seam_states: list[tuple[tuple[str, SeamExchangeState], ...]] = []
         self._routing_splitters = dict(routing_splitters or {})
 
         nodes = plan._topological_nodes(output_future.name)
@@ -407,14 +408,13 @@ class BasePipelineSchedule(TrainingSchedule):
                 stage_inputs: dict[str, dict[str, Any]] = {}
                 for modality, declared in self._encoder_node.params["inputs"].items():
                     if modality not in input_obj:
+                        continue
+                    kwargs = _resolve_optional_modality_inputs(declared, values)
+                    if kwargs is None:
                         raise ValueError(
-                            f"Missing {modality!r} activation at fused PP stage "
-                            f"{self._encoder_stage}."
+                            f"{modality!r} has a pipeline activation but its "
+                            "optional source inputs are absent."
                         )
-                    kwargs = {
-                        key: _resolve_value(value, values)
-                        for key, value in declared.items()
-                    }
                     activation = input_obj[modality]
                     if isinstance(activation, Mapping):
                         kwargs.update(activation)
@@ -511,7 +511,9 @@ class BasePipelineSchedule(TrainingSchedule):
                 grads = [
                     output_obj_grad[k] for k in keys if isinstance(output_obj[k], torch.Tensor)
                 ]
-                if len(tensors) == 1:
+                if not tensors:
+                    pass
+                elif len(tensors) == 1:
                     torch.autograd.backward(tensors[0], grads[0])
                 else:
                     torch.autograd.backward(tensors, grads)
@@ -543,6 +545,9 @@ class BasePipelineSchedule(TrainingSchedule):
                     f"language-model hidden size {hidden_size}."
                 )
             return hidden_size, obj.dtype
+        device_type = self._device.type
+        if torch.is_autocast_enabled(device_type):
+            return hidden_size, torch.get_autocast_dtype(device_type)
         embedding = self._lm_node.params["module"].pre_decoder["embed_tokens"]
         parameter = next(embedding.parameters())
         return hidden_size, parameter.dtype
@@ -597,8 +602,20 @@ class BasePipelineSchedule(TrainingSchedule):
         )
         if obj is not None and fused and not isinstance(obj, Mapping):
             raise TypeError("A fused seam sender must provide a modality mapping.")
+        active_modalities = tuple(
+            modality
+            for modality in self._seam_modalities
+            if bool((global_ids == self._modality_token_ids[modality]).any().item())
+        )
+        if isinstance(obj, Mapping) and set(obj) != set(active_modalities):
+            raise ValueError(
+                "Fused encoder outputs must exactly match modalities present in "
+                f"the language microbatch: outputs={sorted(obj)}, "
+                f"present={sorted(active_modalities)}"
+            )
         received_by_modality: dict[str, torch.Tensor] = {}
-        for modality in self._seam_modalities:
+        forward_states: list[tuple[str, SeamExchangeState]] = []
+        for modality in active_modalities:
             feature = obj.get(modality) if isinstance(obj, Mapping) else obj
             source_attention_mask = modality_masks.get(modality)
             if source_attention_mask is None:
@@ -630,13 +647,14 @@ class BasePipelineSchedule(TrainingSchedule):
                 dtype=dtype,
                 device=self._device,
             )
-            self._seam_states.append((modality, state))
+            forward_states.append((modality, state))
             if received is not None:
                 received.requires_grad_(True)
                 received_by_modality[modality] = received
 
+        self._seam_states.append(tuple(forward_states))
         if fused:
-            return received_by_modality if received_by_modality else None
+            return received_by_modality
         return received_by_modality.get(self._seam_modalities[0])
 
     def _seam_backward(self, grad: Any | None) -> Any | None:
@@ -645,15 +663,11 @@ class BasePipelineSchedule(TrainingSchedule):
         )
         if grad is not None and fused and not isinstance(grad, Mapping):
             raise TypeError("A fused seam receiver must provide modality gradients.")
+        if not self._seam_states:
+            raise RuntimeError("Cross-mesh backward has no matching forward state.")
+        forward_states = self._seam_states.pop(0)
         returned_by_modality: dict[str, torch.Tensor] = {}
-        for modality in self._seam_modalities:
-            if not self._seam_states:
-                raise RuntimeError("Cross-mesh backward has no matching forward state.")
-            state_modality, state = self._seam_states.pop(0)
-            if state_modality != modality:
-                raise RuntimeError(
-                    "Cross-mesh backward modality order differs from forward order."
-                )
+        for modality, state in forward_states:
             modality_grad = grad.get(modality) if isinstance(grad, Mapping) else grad
             hidden_size, dtype = self._seam_spec(modality_grad)
             returned = self._seam_router.backward(
@@ -667,7 +681,7 @@ class BasePipelineSchedule(TrainingSchedule):
                 returned_by_modality[modality] = returned
 
         if fused:
-            return returned_by_modality if returned_by_modality else None
+            return returned_by_modality
         return returned_by_modality.get(self._seam_modalities[0])
 
     def _seam_send_forward(self, obj: Any, microbatch: dict) -> None:

--- a/cornstarch/distributed/pipeline_parallel/schedule.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule.py
@@ -9,10 +9,10 @@ schedule is involved.
 When pipeline parallelism is used the modules are disaggregated onto disjoint
 rank ranges and form a pipeline:
 
-- each **modality encoder is a leading pipeline stage** (one stage; intra-encoder
-  pipelining is out of scope), feeding
-- the **language-model stages** (``merge`` runs on the first language-model
-  stage; the language model is pipelined across the rest).
+- one ordinary or fused **modality encoder pipeline** leads the graph; every
+  fused child spans the same encoder stages and moves in registry order, feeding
+- the independently configured **language-model pipeline** (``merge`` runs on
+  its first stage).
 
 The boundary between the encoder mesh and the language-model mesh is a
 pipeline-stage boundary — a *seam*. Projected rows cross it through a DP-local,
@@ -57,6 +57,7 @@ from cornstarch.models.multimodal.execution import (
     CornstarchExecutionPlan,
     ExecutionFuture,
     _first_output_tensor,
+    _resolve_value,
 )
 
 
@@ -211,13 +212,14 @@ class MeshLayout:
 class BasePipelineSchedule(TrainingSchedule):
     """Drive an execution plan across a pipeline that may span several meshes.
 
-    The global pipeline is ``[encoder stages..., language-model stages...]``. This
-    rank owns exactly one global stage (the meshes are disjoint): an encoder rank
-    owns its encoder's leading stage; a language-model rank owns its language-model
-    pipeline stage. The base class resolves that placement, runs this rank's stage
+    The global pipeline is ``[encoder PP stages..., language-model PP stages...]``.
+    This rank owns exactly one global stage because the module meshes are disjoint.
+    For a fused producer, every registered child runs its corresponding local
+    partition on every encoder stage. The base class resolves that placement,
+    runs this rank's stage
     forward/backward per microbatch, and moves activations to its neighbors —
-    using ordinary pipeline P2P for an intra-mesh hop and the cross-mesh *seam*
-    transport for the encoder→language-model boundary. Subclasses choose the
+    using ordinary pipeline P2P for intra-mesh hops and the cross-mesh *seam*
+    transport once per modality at the encoder→language-model boundary. Subclasses choose the
     microbatch ordering (1F1B, etc.).
 
     The plan stays parallelism-agnostic; all rank/stage/transport knowledge lives
@@ -241,56 +243,65 @@ class BasePipelineSchedule(TrainingSchedule):
         self._dp_size = dp_size
         self._my_rank = dist.get_rank()
         self._device: torch.device | None = None
-        self._seam_states: list[SeamExchangeState] = []
+        self._seam_states: list[tuple[str, SeamExchangeState]] = []
         self._routing_splitters = dict(routing_splitters or {})
 
         nodes = plan._topological_nodes(output_future.name)
-        self._encoder_nodes = [n for n in nodes if n.kind == "run_modality_encoder"]
+        self._encoder_nodes = [
+            node
+            for node in nodes
+            if node.kind in {"run_modality_encoder", "run_fused_modality_encoder"}
+        ]
+        if len(self._encoder_nodes) > 1:
+            raise ValueError(
+                "Pipeline schedules accept one encoder producer. Compose multiple "
+                "modalities with CornstarchFusedModalityEncoder."
+            )
+        self._encoder_node = self._encoder_nodes[0] if self._encoder_nodes else None
         self._merge_node = next(
-            (n for n in nodes if n.kind == "merge_modality_encoder_outputs"), None
+            (node for node in nodes if node.kind == "merge_modality_encoder_outputs"),
+            None,
         )
-        self._lm_node = next(n for n in nodes if n.kind == "run_language_model")
+        self._lm_node = next(node for node in nodes if node.kind == "run_language_model")
+        self._modality_token_ids: dict[str, int] = (
+            dict(self._merge_node.params.get("modality_token_ids", {}))
+            if self._merge_node is not None
+            else {}
+        )
 
         self._lm_layout = layouts[id(self._lm_node.params["module"])]
-        self._num_encoders = len(self._encoder_nodes)
-        self._num_stages = self._num_encoders + self._lm_layout.num_pp_stages
+        self._has_encoder = self._encoder_node is not None
+        self._num_encoder_stages = 0
+        if self._has_encoder:
+            producer_module = self._encoder_node.params["module"]
+            self._encoder_layout = layouts[id(producer_module)]
+            self._num_encoder_stages = self._encoder_layout.num_pp_stages
+        self._num_stages = self._num_encoder_stages + self._lm_layout.num_pp_stages
 
-        # Resolve this rank's role and global stage index.
+        # Resolve this rank's one local role in the disaggregated global pipeline.
         self._role: str | None = None
-        self._encoder_index = -1
-        for index, node in enumerate(self._encoder_nodes):
-            if self._my_rank in layouts[id(node.params["module"])].rankset:
-                self._role = "encoder"
-                self._encoder_index = index
-                self._encoder_node = node
-                self._encoder_layout = layouts[id(node.params["module"])]
-                self._stage = index
-                break
-        if self._role is None and self._my_rank in self._lm_layout.rankset:
+        if self._has_encoder and self._my_rank in self._encoder_layout.rankset:
+            self._role = "encoder"
+            self._encoder_mesh = meshes[id(self._encoder_node.params["module"])]
+            self._encoder_comm = PipelineP2PCommunication(self._encoder_mesh)
+            self._encoder_stage = self._encoder_mesh.stage
+            self._stage = self._encoder_stage
+        elif self._my_rank in self._lm_layout.rankset:
             self._role = "llm"
             self._lm_mesh = meshes[id(self._lm_node.params["module"])]
             self._lm_comm = PipelineP2PCommunication(self._lm_mesh)
             self._lm_stage = self._lm_mesh.stage
-            self._stage = self._num_encoders + self._lm_stage
+            self._stage = self._num_encoder_stages + self._lm_stage
 
-        # A rank with no stage in *this* batch's plan idles (e.g. the encoder
-        # ranks on a text-only step, whose plan has no run_modality_encoder node).
-        # Every rank derives the same plan from the same batch, so the active
-        # ranks never wait on a transfer from an idle one.
+        # A rank with no node in this batch's plan idles (for example encoder
+        # ranks on a text-only step).
         self._idle = self._role is None
 
-        # Cross-mesh seam between the (single) leading encoder and LM stage 0.
-        # The seam pairs the producing encoder with the language model; multiple
-        # encoders feeding one merge as parallel leading stages is out of scope.
-        self._has_encoder = self._num_encoders > 0
         if self._has_encoder:
-            self._seam_producer = layouts[
-                id(self._encoder_nodes[0].params["module"])
-            ]
-            # The merge consumes the encoder output under this future name.
-            self._encoder_output_name = self._encoder_nodes[0].name
-            producer_module = self._encoder_nodes[0].params["module"]
+            producer_module = self._encoder_node.params["module"]
             consumer_module = self._lm_node.params["module"]
+            self._seam_producer = self._encoder_layout
+            self._encoder_output_name = self._encoder_node.name
             self._seam_producer_module_id = id(producer_module)
             self._seam_consumer_module_id = id(consumer_module)
             seam_groups = (cross_mesh_groups or {}).get(
@@ -302,15 +313,26 @@ class BasePipelineSchedule(TrainingSchedule):
                     "groups. Construct it with ParallelContext.create_schedule()."
                 )
             self._seam_router = CrossMeshRouter(seam_groups)
-            self._seam_modality = getattr(producer_module, "modality", None)
-            if self._seam_modality is None:
-                raise ValueError("A modality encoder seam must declare its modality name.")
-
-        self._modality_token_ids: dict[str, int] = (
-            dict(self._merge_node.params.get("modality_token_ids", {}))
-            if self._merge_node is not None
-            else {}
-        )
+            if self._encoder_node.kind == "run_fused_modality_encoder":
+                provided = self._encoder_node.params["inputs"]
+                self._seam_modalities = tuple(
+                    modality
+                    for modality in producer_module.modalities
+                    if modality in provided
+                )
+            else:
+                modality = getattr(producer_module, "modality", None)
+                if modality is None:
+                    raise ValueError(
+                        "A modality encoder seam must declare its modality name."
+                    )
+                self._seam_modalities = (modality,)
+            missing_tokens = set(self._seam_modalities) - set(self._modality_token_ids)
+            if missing_tokens:
+                raise ValueError(
+                    "Missing modality token IDs for fused seam outputs: "
+                    f"{sorted(missing_tokens)}"
+                )
 
     # ------------------------------------------------------------------
     # Stage semantics
@@ -338,8 +360,11 @@ class BasePipelineSchedule(TrainingSchedule):
         return self._at_llm_first_stage() and self._has_encoder
 
     def _seam_on_send(self) -> bool:
-        """This rank sends its forward output across the seam (the encoder)."""
-        return self._role == "encoder"
+        """This rank sends across the seam only at the encoder's final stage."""
+        return (
+            self._role == "encoder"
+            and self._encoder_stage == self._num_encoder_stages - 1
+        )
 
     # ------------------------------------------------------------------
     # Forward computation for this rank's stage
@@ -369,9 +394,50 @@ class BasePipelineSchedule(TrainingSchedule):
     def _forward_compute(self, microbatch: dict, input_obj: Any | None) -> Any:
         """Run this rank's stage forward and return its output activation/result."""
         if self._role == "encoder":
-            output = CornstarchExecutionPlan._execute_node(
-                self._encoder_node, dict(microbatch)
-            )
+            values = dict(microbatch)
+            if self._encoder_stage == 0:
+                output = CornstarchExecutionPlan._execute_node(
+                    self._encoder_node, values
+                )
+            elif self._encoder_node.kind == "run_fused_modality_encoder":
+                if not isinstance(input_obj, Mapping):
+                    raise TypeError(
+                        "A fused encoder PP stage expects a modality activation mapping."
+                    )
+                stage_inputs: dict[str, dict[str, Any]] = {}
+                for modality, declared in self._encoder_node.params["inputs"].items():
+                    if modality not in input_obj:
+                        raise ValueError(
+                            f"Missing {modality!r} activation at fused PP stage "
+                            f"{self._encoder_stage}."
+                        )
+                    kwargs = {
+                        key: _resolve_value(value, values)
+                        for key, value in declared.items()
+                    }
+                    activation = input_obj[modality]
+                    if isinstance(activation, Mapping):
+                        kwargs.update(activation)
+                    else:
+                        kwargs["hidden_states"] = activation
+                    stage_inputs[modality] = kwargs
+                output = self._encoder_node.params["module"](inputs=stage_inputs)
+            else:
+                kwargs = {
+                    key: _resolve_value(value, values)
+                    for key, value in self._encoder_node.params["inputs"].items()
+                }
+                if isinstance(input_obj, Mapping):
+                    kwargs.update(input_obj)
+                elif input_obj is not None:
+                    kwargs["hidden_states"] = input_obj
+                output = self._encoder_node.params["module"](**kwargs)
+
+            if self._encoder_node.kind == "run_fused_modality_encoder":
+                return {
+                    modality: _first_output_tensor(modality_output)
+                    for modality, modality_output in output.items()
+                }
             return _first_output_tensor(output)
 
         # Language-model role.
@@ -481,15 +547,26 @@ class BasePipelineSchedule(TrainingSchedule):
         parameter = next(embedding.parameters())
         return hidden_size, parameter.dtype
 
-    def _routing_offsets(self, microbatch: dict, module_id: int, layout: MeshLayout):
+    def _routing_offsets(
+        self,
+        microbatch: dict,
+        module_id: int,
+        layout: MeshLayout,
+        modality: str,
+    ):
         metadata = microbatch.get(CP_ROUTING_OFFSETS_KEY)
-        if isinstance(metadata, dict) and module_id in metadata:
+        if isinstance(metadata, Mapping) and module_id in metadata:
+            module_offsets = metadata[module_id]
+            if isinstance(module_offsets, Mapping):
+                if modality not in module_offsets:
+                    raise ValueError(
+                        f"Missing CP routing offsets for fused modality {modality!r}."
+                    )
+                return module_offsets[modality]
             return routing_offsets_from_batch(microbatch, module_id)
         if module_id == self._seam_producer_module_id:
             global_ids = microbatch.get("cp_global_input_ids", microbatch["input_ids"])
-            counts = (global_ids == self._modality_token_ids[self._seam_modality]).sum(
-                dim=1
-            )
+            counts = (global_ids == self._modality_token_ids[modality]).sum(dim=1)
             modality_length = int(counts.max().item()) if counts.numel() else 0
             mask = (
                 torch.arange(modality_length, device=global_ids.device).unsqueeze(0)
@@ -507,58 +584,91 @@ class BasePipelineSchedule(TrainingSchedule):
             "build batches with ParallelContext.prepare_dataloader()."
         )
 
-    def _seam_forward(
-        self, obj: torch.Tensor | None, microbatch: dict
-    ) -> torch.Tensor | None:
+    def _seam_forward(self, obj: Any | None, microbatch: dict) -> Any | None:
         global_ids = microbatch.get("cp_global_input_ids", microbatch.get("input_ids"))
         if not isinstance(global_ids, torch.Tensor):
             raise ValueError("Cross-mesh routing requires global input_ids metadata.")
         modality_masks = microbatch.get(CP_MODALITY_MASKS_KEY, {})
         if not isinstance(modality_masks, Mapping):
             raise ValueError("cp_modality_attention_masks must be a modality mapping.")
-        source_attention_mask = modality_masks.get(self._seam_modality)
-        if source_attention_mask is None:
-            counts = (global_ids == self._modality_token_ids[self._seam_modality]).sum(
-                dim=1
-            )
-            modality_length = int(counts.max().item()) if counts.numel() else 0
-            source_attention_mask = (
-                torch.arange(modality_length, device=global_ids.device).unsqueeze(0)
-                < counts.unsqueeze(1)
-            )
-        hidden_size, dtype = self._seam_spec(obj)
-        received, state = self._seam_router.forward(
-            obj,
-            global_input_ids=global_ids,
-            token_id=self._modality_token_ids[self._seam_modality],
-            source_attention_mask=source_attention_mask,
-            source_offsets=self._routing_offsets(
-                microbatch, self._seam_producer_module_id, self._seam_producer
-            ),
-            destination_offsets=self._routing_offsets(
-                microbatch, self._seam_consumer_module_id, self._lm_layout
-            ),
-            hidden_size=hidden_size,
-            dtype=dtype,
-            device=self._device,
-        )
-        self._seam_states.append(state)
-        if received is not None:
-            received.requires_grad_(True)
-        return received
 
-    def _seam_backward(self, grad: torch.Tensor | None) -> torch.Tensor | None:
-        if not self._seam_states:
-            raise RuntimeError("Cross-mesh backward has no matching forward state.")
-        state = self._seam_states.pop(0)
-        hidden_size, dtype = self._seam_spec(grad)
-        return self._seam_router.backward(
-            grad,
-            state,
-            hidden_size=hidden_size,
-            dtype=dtype,
-            device=self._device,
+        fused = len(self._seam_modalities) > 1 or (
+            self._encoder_node.kind == "run_fused_modality_encoder"
         )
+        if obj is not None and fused and not isinstance(obj, Mapping):
+            raise TypeError("A fused seam sender must provide a modality mapping.")
+        received_by_modality: dict[str, torch.Tensor] = {}
+        for modality in self._seam_modalities:
+            feature = obj.get(modality) if isinstance(obj, Mapping) else obj
+            source_attention_mask = modality_masks.get(modality)
+            if source_attention_mask is None:
+                counts = (global_ids == self._modality_token_ids[modality]).sum(dim=1)
+                modality_length = int(counts.max().item()) if counts.numel() else 0
+                source_attention_mask = (
+                    torch.arange(modality_length, device=global_ids.device).unsqueeze(0)
+                    < counts.unsqueeze(1)
+                )
+            hidden_size, dtype = self._seam_spec(feature)
+            received, state = self._seam_router.forward(
+                feature,
+                global_input_ids=global_ids,
+                token_id=self._modality_token_ids[modality],
+                source_attention_mask=source_attention_mask,
+                source_offsets=self._routing_offsets(
+                    microbatch,
+                    self._seam_producer_module_id,
+                    self._seam_producer,
+                    modality,
+                ),
+                destination_offsets=self._routing_offsets(
+                    microbatch,
+                    self._seam_consumer_module_id,
+                    self._lm_layout,
+                    modality,
+                ),
+                hidden_size=hidden_size,
+                dtype=dtype,
+                device=self._device,
+            )
+            self._seam_states.append((modality, state))
+            if received is not None:
+                received.requires_grad_(True)
+                received_by_modality[modality] = received
+
+        if fused:
+            return received_by_modality if received_by_modality else None
+        return received_by_modality.get(self._seam_modalities[0])
+
+    def _seam_backward(self, grad: Any | None) -> Any | None:
+        fused = len(self._seam_modalities) > 1 or (
+            self._encoder_node.kind == "run_fused_modality_encoder"
+        )
+        if grad is not None and fused and not isinstance(grad, Mapping):
+            raise TypeError("A fused seam receiver must provide modality gradients.")
+        returned_by_modality: dict[str, torch.Tensor] = {}
+        for modality in self._seam_modalities:
+            if not self._seam_states:
+                raise RuntimeError("Cross-mesh backward has no matching forward state.")
+            state_modality, state = self._seam_states.pop(0)
+            if state_modality != modality:
+                raise RuntimeError(
+                    "Cross-mesh backward modality order differs from forward order."
+                )
+            modality_grad = grad.get(modality) if isinstance(grad, Mapping) else grad
+            hidden_size, dtype = self._seam_spec(modality_grad)
+            returned = self._seam_router.backward(
+                modality_grad,
+                state,
+                hidden_size=hidden_size,
+                dtype=dtype,
+                device=self._device,
+            )
+            if returned is not None:
+                returned_by_modality[modality] = returned
+
+        if fused:
+            return returned_by_modality if returned_by_modality else None
+        return returned_by_modality.get(self._seam_modalities[0])
 
     def _seam_send_forward(self, obj: Any, microbatch: dict) -> None:
         self._seam_forward(obj, microbatch)
@@ -597,6 +707,8 @@ class BasePipelineSchedule(TrainingSchedule):
             return None
         if self._seam_on_recv():
             return self._seam_recv_forward(microbatch)
+        if self._role == "encoder":
+            return self._encoder_comm.recv_forward()
         return self._lm_comm.recv_forward()
 
     def _send_forward(self, obj: Any, microbatch: dict) -> None:
@@ -605,6 +717,9 @@ class BasePipelineSchedule(TrainingSchedule):
         if self._seam_on_send():
             self._seam_send_forward(obj, microbatch)
             return
+        if self._role == "encoder":
+            self._encoder_comm.send_forward(obj)
+            return
         self._lm_comm.send_forward(obj)
 
     def _recv_backward(self) -> Any | None:
@@ -612,6 +727,8 @@ class BasePipelineSchedule(TrainingSchedule):
             return None
         if self._seam_on_send():
             return self._seam_recv_backward()
+        if self._role == "encoder":
+            return self._encoder_comm.recv_backward()
         return self._lm_comm.recv_backward()
 
     def _send_backward(self, grad: Any) -> None:
@@ -620,6 +737,9 @@ class BasePipelineSchedule(TrainingSchedule):
         if self._seam_on_recv():
             self._seam_send_backward(grad)
             return
+        if self._role == "encoder":
+            self._encoder_comm.send_backward(grad)
+            return
         self._lm_comm.send_backward(grad)
 
     def _send_forward_recv_backward(self, obj: Any, microbatch: dict) -> Any | None:
@@ -627,6 +747,8 @@ class BasePipelineSchedule(TrainingSchedule):
             return None
         if self._seam_on_send():
             return self._seam_send_forward_recv_backward(obj, microbatch)
+        if self._role == "encoder":
+            return self._encoder_comm.send_forward_recv_backward(obj)
         return self._lm_comm.send_forward_recv_backward(obj)
 
     def _send_backward_recv_forward(self, grad: Any, microbatch: dict) -> Any | None:
@@ -634,6 +756,8 @@ class BasePipelineSchedule(TrainingSchedule):
             return None
         if self._seam_on_recv():
             return self._seam_send_backward_recv_forward(grad, microbatch)
+        if self._role == "encoder":
+            return self._encoder_comm.send_backward_recv_forward(grad)
         return self._lm_comm.send_backward_recv_forward(grad)
 
 
@@ -643,6 +767,20 @@ class BasePipelineSchedule(TrainingSchedule):
 
 class OneForwardOneBackwardSchedule(BasePipelineSchedule):
     """One-forward-one-backward pipeline schedule over the global pipeline."""
+
+    def extra_warmup_microbatches(
+        self,
+        microbatches: list[dict[str, torch.Tensor]],
+        required_warmup: int,
+    ) -> int:
+        """Return coordinated eager forwards beyond the deadlock-safe minimum.
+
+        Subclasses may override this public extension hook. The returned value
+        must be identical on every active pipeline stage (coordinate it with a
+        collective when it depends on rank-local memory); negative values are
+        rejected and the total is capped by the iteration's microbatch count.
+        """
+        return 0
 
     def step(
         self,
@@ -662,7 +800,15 @@ class OneForwardOneBackwardSchedule(BasePipelineSchedule):
         num_microbatches = len(microbatches)
         self._device = _first_tensor_device(microbatches) or _default_device()
 
-        num_warmup = min(self._num_stages - self._stage - 1, num_microbatches)
+        required_warmup = min(
+            self._num_stages - self._stage - 1, num_microbatches
+        )
+        extra_warmup = self.extra_warmup_microbatches(
+            microbatches, required_warmup
+        )
+        if not isinstance(extra_warmup, int) or extra_warmup < 0:
+            raise ValueError("extra_warmup_microbatches must return a nonnegative int")
+        num_warmup = min(required_warmup + extra_warmup, num_microbatches)
         num_steady = num_microbatches - num_warmup
 
         accum_loss: torch.Tensor | None = None

--- a/cornstarch/distributed/tensor_parallel/plans.py
+++ b/cornstarch/distributed/tensor_parallel/plans.py
@@ -10,6 +10,7 @@ plan is unreachable and cannot be validated through Cornstarch's unified model
 lifecycle. Hybrid models select a plan by semantic ``layer_type``; the TP
 implementation itself does not contain a family-specific branch ladder.
 """
+
 from __future__ import annotations
 
 from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel
@@ -32,6 +33,32 @@ ATTENTION_ONLY_TP_PLAN: dict = {
     "self_attn.o_proj": RowwiseParallel(),
 }
 
+ENCODER_ATTN_MLP_TP_PLAN: dict = {
+    "self_attn.q_proj": ColwiseParallel(),
+    "self_attn.k_proj": ColwiseParallel(),
+    "self_attn.v_proj": ColwiseParallel(),
+    "self_attn.out_proj": RowwiseParallel(),
+    "mlp.fc1": ColwiseParallel(),
+    "mlp.fc2": RowwiseParallel(),
+}
+
+GEMMA4_VISION_TP_PLAN: dict = {
+    "self_attn.q_proj.linear": ColwiseParallel(),
+    "self_attn.k_proj.linear": ColwiseParallel(),
+    "self_attn.v_proj.linear": ColwiseParallel(),
+    "self_attn.o_proj.linear": RowwiseParallel(),
+    "mlp.gate_proj.linear": ColwiseParallel(),
+    "mlp.up_proj.linear": ColwiseParallel(),
+    "mlp.down_proj.linear": RowwiseParallel(),
+}
+WHISPER_TP_PLAN: dict = {
+    "self_attn.q_proj": ColwiseParallel(),
+    "self_attn.k_proj": ColwiseParallel(),
+    "self_attn.v_proj": ColwiseParallel(),
+    "self_attn.out_proj": RowwiseParallel(),
+    "fc1": ColwiseParallel(),
+    "fc2": RowwiseParallel(),
+}
 # MoE layers shard the token mixer over TP while their router and expert FFNs
 # remain replicated across TP lanes; EP independently owns expert placement.
 GATED_DELTA_TP_PLAN: dict = {
@@ -50,6 +77,11 @@ DENSE_GATED_DELTA_TP_PLAN: dict = {
 _DEFAULT_PLANS: dict[str, dict] = {
     "LlamaConfig": DENSE_ATTN_MLP_TP_PLAN,
     "Qwen3_5MoeTextConfig": ATTENTION_ONLY_TP_PLAN,
+    "CLIPVisionConfig": ENCODER_ATTN_MLP_TP_PLAN,
+    "Gemma4VisionConfig": GEMMA4_VISION_TP_PLAN,
+    "Llama4TextConfig": ATTENTION_ONLY_TP_PLAN,
+    "Siglip2VisionConfig": ENCODER_ATTN_MLP_TP_PLAN,
+    "WhisperConfig": WHISPER_TP_PLAN,
     "Qwen3_5TextConfig": DENSE_ATTN_MLP_TP_PLAN,
 }
 

--- a/cornstarch/models/__init__.py
+++ b/cornstarch/models/__init__.py
@@ -16,10 +16,12 @@ from cornstarch.models.lora import FinetuningMode, attach_lora, configure_finetu
 from cornstarch.models.multimodal import (
     CornstarchEncoderToLanguageProjectorConfig,
     CornstarchExecutionPlan,
+    CornstarchFusedModalityEncoder,
     CornstarchModalityEncoder,
     CornstarchMultimodalConfig,
     CornstarchProjector,
     ExecutionFuture,
+    build_fused_modality_encoder,
     build_modality_encoder,
 )
 from cornstarch.models.vision_encoder import CornstarchVisionEncoder
@@ -31,6 +33,7 @@ __all__ = [
     "CornstarchEncoder",
     "CornstarchEncoderToLanguageProjectorConfig",
     "CornstarchExecutionPlan",
+    "CornstarchFusedModalityEncoder",
     "CornstarchLanguageModel",
     "CornstarchModalityEncoder",
     "CornstarchMultimodalConfig",
@@ -41,6 +44,7 @@ __all__ = [
     "RepeatedLayerCompileConfig",
     "RepeatedLayerOffloadConfig",
     "attach_lora",
+    "build_fused_modality_encoder",
     "build_modality_encoder",
     "configure_finetuning",
     "from_hf_config",

--- a/cornstarch/models/multimodal/__init__.py
+++ b/cornstarch/models/multimodal/__init__.py
@@ -6,7 +6,9 @@ from cornstarch.models.multimodal.configuration import (
 )
 from cornstarch.models.multimodal.execution import CornstarchExecutionPlan, ExecutionFuture
 from cornstarch.models.multimodal.modeling import (
+    CornstarchFusedModalityEncoder,
     CornstarchModalityEncoder,
+    build_fused_modality_encoder,
     build_modality_encoder,
 )
 from cornstarch.models.multimodal.projector import CornstarchProjector
@@ -14,9 +16,11 @@ from cornstarch.models.multimodal.projector import CornstarchProjector
 __all__ = [
     "CornstarchExecutionPlan",
     "CornstarchEncoderToLanguageProjectorConfig",
+    "CornstarchFusedModalityEncoder",
     "CornstarchModalityEncoder",
     "CornstarchMultimodalConfig",
     "CornstarchProjector",
     "ExecutionFuture",
+    "build_fused_modality_encoder",
     "build_modality_encoder",
 ]

--- a/cornstarch/models/multimodal/execution.py
+++ b/cornstarch/models/multimodal/execution.py
@@ -138,13 +138,34 @@ class CornstarchExecutionPlan:
             )
         )
 
+    def run_fused_modality_encoder(
+        self,
+        module: Any,
+        inputs: Mapping[str, Mapping[str, Any]] | None = None,
+        name: str | None = None,
+        **modality_inputs: Mapping[str, Any],
+    ) -> ExecutionFuture:
+        """Add one fused producer node returning a modality-keyed output mapping."""
+        provided = dict(inputs or {})
+        duplicates = set(provided) & set(modality_inputs)
+        if duplicates:
+            raise ValueError(f"Duplicate fused modality inputs: {sorted(duplicates)}")
+        provided.update(modality_inputs)
+        return self._add_node(
+            ExecutionNode(
+                name=name or "fused_encoder_outputs",
+                kind="run_fused_modality_encoder",
+                params={"module": module, "inputs": provided},
+            )
+        )
+
     def merge_modality_encoder_outputs(
         self,
         language_model: Any,
         input_ids: Any,
         labels: Any,
         modality_token_ids: Mapping[str, int],
-        encoder_outputs: Mapping[str, Any] | None = None,
+        encoder_outputs: Mapping[str, Any] | ExecutionFuture | None = None,
         language_model_inputs: Mapping[str, Any] | None = None,
         name: str | None = None,
     ) -> ExecutionFuture:
@@ -157,7 +178,10 @@ class CornstarchExecutionPlan:
                     "language_model": language_model,
                     "input_ids": input_ids,
                     "labels": labels,
-                    "encoder_outputs": dict(encoder_outputs or {}),
+                    "encoder_outputs": (
+                        encoder_outputs if isinstance(encoder_outputs, ExecutionFuture)
+                        else dict(encoder_outputs or {})
+                    ),
                     "modality_token_ids": dict(modality_token_ids),
                     "language_model_inputs": dict(language_model_inputs or {}),
                 },
@@ -339,15 +363,23 @@ class CornstarchExecutionPlan:
                 for arg_name, value in node.params["inputs"].items()
             }
             return node.params["module"](**encoder_inputs)
+        if node.kind == "run_fused_modality_encoder":
+            fused_inputs = {
+                modality: {
+                    key: _resolve_value(value, values)
+                    for key, value in modality_inputs.items()
+                }
+                for modality, modality_inputs in node.params["inputs"].items()
+            }
+            return node.params["module"](inputs=fused_inputs)
         if node.kind == "merge_modality_encoder_outputs":
             return merge_modality_encoder_outputs(
                 language_model=node.params["language_model"],
                 input_ids=_resolve_value(node.params["input_ids"], values),
                 labels=_resolve_value(node.params["labels"], values),
-                encoder_outputs={
-                    modality: _resolve_value(value, values)
-                    for modality, value in node.params["encoder_outputs"].items()
-                },
+                encoder_outputs=_resolve_value(
+                    node.params["encoder_outputs"], values
+                ),
                 modality_token_ids=node.params["modality_token_ids"],
                 language_model_inputs={
                     key: _resolve_value(value, values)
@@ -559,7 +591,11 @@ def _first_output_tensor(output: Any) -> torch.Tensor:
     if hasattr(output, "last_hidden_state"):
         return output.last_hidden_state
     if isinstance(output, Mapping):
-        return output["last_hidden_state"]
+        if "last_hidden_state" in output:
+            return output["last_hidden_state"]
+        if "hidden_states" in output:
+            return output["hidden_states"]
+        raise KeyError("Output mapping has neither last_hidden_state nor hidden_states.")
     if isinstance(output, tuple):
         return output[0]
     raise TypeError(f"Cannot extract hidden states from output of type {type(output).__name__}.")

--- a/cornstarch/models/multimodal/execution.py
+++ b/cornstarch/models/multimodal/execution.py
@@ -49,6 +49,7 @@ class ExecutionFuture:
 
     name: str
     _plan: CornstarchExecutionPlan | None = field(default=None, repr=False, compare=False)
+    optional: bool = False
 
     def execute(self, inputs: Mapping[str, Any] | None = None) -> Any:
         """Execute only this future's dependency subgraph and return its value."""
@@ -78,8 +79,13 @@ class ExecutionNode:
 
     @property
     def dependencies(self) -> set[str]:
-        """Return named tensor dependencies consumed by this node."""
+        """Return all named dependencies consumed by this node."""
         return _collect_future_names(self.params)
+
+    @property
+    def required_dependencies(self) -> set[str]:
+        """Return dependencies that must be supplied by the caller."""
+        return _collect_future_names(self.params, required_only=True)
 
 
 class CornstarchExecutionPlan:
@@ -346,7 +352,9 @@ class CornstarchExecutionPlan:
         values = dict(inputs or {})
         last_output = None
         for node in ordered_nodes:
-            missing = sorted(dep for dep in node.dependencies if dep not in values)
+            missing = sorted(
+                dep for dep in node.required_dependencies if dep not in values
+            )
             if missing:
                 raise ValueError(
                     f"Node {node.name!r} cannot run because inputs are missing: {missing}"
@@ -364,13 +372,11 @@ class CornstarchExecutionPlan:
             }
             return node.params["module"](**encoder_inputs)
         if node.kind == "run_fused_modality_encoder":
-            fused_inputs = {
-                modality: {
-                    key: _resolve_value(value, values)
-                    for key, value in modality_inputs.items()
-                }
-                for modality, modality_inputs in node.params["inputs"].items()
-            }
+            fused_inputs = {}
+            for modality, modality_inputs in node.params["inputs"].items():
+                resolved = _resolve_optional_modality_inputs(modality_inputs, values)
+                if resolved is not None:
+                    fused_inputs[modality] = resolved
             return node.params["module"](inputs=fused_inputs)
         if node.kind == "merge_modality_encoder_outputs":
             return merge_modality_encoder_outputs(
@@ -398,20 +404,40 @@ class CornstarchExecutionPlan:
         return "".join(char if char.isalnum() else "_" for char in name)
 
 
-def _collect_future_names(value: Any) -> set[str]:
+def _collect_future_names(value: Any, *, required_only: bool = False) -> set[str]:
     if isinstance(value, ExecutionFuture):
-        return {value.name}
+        return set() if required_only and value.optional else {value.name}
     if isinstance(value, Mapping):
         names: set[str] = set()
         for item in value.values():
-            names.update(_collect_future_names(item))
+            names.update(_collect_future_names(item, required_only=required_only))
         return names
     if isinstance(value, (list, tuple)):
         names: set[str] = set()
         for item in value:
-            names.update(_collect_future_names(item))
+            names.update(_collect_future_names(item, required_only=required_only))
         return names
     return set()
+
+
+def _resolve_optional_modality_inputs(
+    declared: Mapping[str, Any], values: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    all_dependencies = _collect_future_names(declared)
+    missing = all_dependencies - set(values)
+    if not missing:
+        return {
+            key: _resolve_value(value, values) for key, value in declared.items()
+        }
+    required_missing = _collect_future_names(declared, required_only=True) - set(values)
+    if required_missing:
+        raise KeyError(next(iter(sorted(required_missing))))
+    if missing != all_dependencies:
+        raise ValueError(
+            "Optional inputs for one fused modality must be present or absent "
+            f"together; missing {sorted(missing)}"
+        )
+    return None
 
 
 def _resolve_value(value: Any, values: Mapping[str, Any]) -> Any:

--- a/cornstarch/models/multimodal/modeling.py
+++ b/cornstarch/models/multimodal/modeling.py
@@ -116,8 +116,114 @@ class CornstarchModalityEncoder(nn.Module):
         merge code receives a standard ``BaseModelOutput`` from the projector.
         """
         encoder_outputs = self.encoder(**kwargs)
+        # The projector is the encoder tail. Intermediate PP stages hand their
+        # raw activation to the next stage and only the final stage projects.
+        pipeline_mesh = getattr(self, "_pipeline_mesh", None)
+        if pipeline_mesh is not None and not pipeline_mesh.is_last_stage():
+            return encoder_outputs
         hidden_states = _first_output_tensor(encoder_outputs)
         return self.projector(hidden_states)
+
+
+class CornstarchFusedModalityEncoder(nn.Module):
+    """Ordered group of modality encoders sharing one parallel configuration."""
+
+    def __init__(self, encoders: Mapping[str, CornstarchModalityEncoder]):
+        super().__init__()
+        if not encoders:
+            raise ValueError("A fused modality encoder requires at least one child.")
+        ordered: dict[str, CornstarchModalityEncoder] = {}
+        output_widths: set[int] = set()
+        for name, module in encoders.items():
+            if not name:
+                raise ValueError("Fused modality names must be nonempty.")
+            if not isinstance(module, CornstarchModalityEncoder):
+                raise TypeError(
+                    "Fused children must be CornstarchModalityEncoder instances; "
+                    f"got {type(module).__name__} for {name!r}."
+                )
+            if module.modality is not None and module.modality != name:
+                raise ValueError(
+                    f"Registry name {name!r} does not match child modality "
+                    f"{module.modality!r}."
+                )
+            module.modality = name
+            ordered[name] = module
+            output_widths.add(int(module.projector.config.out_features))
+        if len(output_widths) != 1:
+            raise ValueError(
+                "Every fused child projector must target the same language hidden size."
+            )
+        self.encoders = nn.ModuleDict(ordered)
+
+    @property
+    def modalities(self) -> tuple[str, ...]:
+        return tuple(self.encoders.keys())
+
+    @property
+    def config(
+        self,
+    ) -> Mapping[str, tuple[PretrainedConfig, CornstarchEncoderToLanguageProjectorConfig]]:
+        return {name: module.config for name, module in self.encoders.items()}
+
+    @property
+    def output_hidden_size(self) -> int:
+        first = next(iter(self.encoders.values()))
+        return int(first.projector.config.out_features)
+
+    def set_empty_init(self) -> None:
+        for module in self.encoders.values():
+            module.set_empty_init()
+
+    def set_random_init(self) -> None:
+        for module in self.encoders.values():
+            module.set_random_init()
+
+    def set_checkpoint_init(
+        self,
+        checkpoints: Mapping[str, Mapping[str, Any]],
+    ) -> None:
+        unknown = set(checkpoints) - set(self.encoders)
+        if unknown:
+            raise ValueError(f"Unknown fused checkpoint modalities: {sorted(unknown)}")
+        for name, module in self.encoders.items():
+            if name in checkpoints:
+                module.set_checkpoint_init(**dict(checkpoints[name]))
+
+    def materialize(
+        self,
+        device: str | torch.device = "cuda",
+        dtype: torch.dtype | None = None,
+    ) -> CornstarchFusedModalityEncoder:
+        for module in self.encoders.values():
+            module.materialize(device, dtype=dtype)
+        return self
+
+    def forward(
+        self,
+        inputs: Mapping[str, Mapping[str, Any]] | None = None,
+        **modality_inputs: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        provided = dict(inputs or {})
+        duplicates = set(provided) & set(modality_inputs)
+        if duplicates:
+            raise ValueError(f"Duplicate fused modality inputs: {sorted(duplicates)}")
+        provided.update(modality_inputs)
+        unknown = set(provided) - set(self.encoders)
+        if unknown:
+            raise ValueError(f"Unknown fused modalities: {sorted(unknown)}")
+        return {
+            name: module(**dict(provided[name]))
+            for name, module in self.encoders.items()
+            if name in provided
+        }
+
+
+def build_fused_modality_encoder(
+    encoders: Mapping[str, CornstarchModalityEncoder],
+) -> CornstarchFusedModalityEncoder:
+    """Build one ordered fused producer from already wrapped modality encoders."""
+    return CornstarchFusedModalityEncoder(encoders)
 
 
 def build_modality_encoder(
@@ -155,7 +261,11 @@ def _first_output_tensor(output: Any) -> torch.Tensor:
     if hasattr(output, "last_hidden_state"):
         return output.last_hidden_state
     if isinstance(output, Mapping):
-        return output["last_hidden_state"]
+        if "last_hidden_state" in output:
+            return output["last_hidden_state"]
+        if "hidden_states" in output:
+            return output["hidden_states"]
+        raise KeyError("Output mapping has neither last_hidden_state nor hidden_states.")
     if isinstance(output, tuple):
         return output[0]
     raise TypeError(f"Cannot extract hidden states from output of type {type(output).__name__}.")

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -22,7 +22,11 @@ import torch.nn.functional as F
 from tests.distributed.distributed_base import GlooDistributedTestBase
 from tests.model.model_configs import clip_vision_config, llama_config
 
-from cornstarch.distributed import ParallelConfig, ParallelizationPlan
+from cornstarch.distributed import (
+    ParallelConfig,
+    ParallelizationPlan,
+    PipelinePartitionSpec,
+)
 from cornstarch.distributed.context_parallel.splitters import (
     HeadTailContextParallelSplitter,
     UniformContextParallelSplitter,
@@ -37,6 +41,7 @@ from cornstarch.distributed.cross_mesh_routing import (
 from cornstarch.models import (
     CornstarchExecutionPlan,
     ExecutionFuture,
+    build_fused_modality_encoder,
     build_modality_encoder,
     from_hf_config,
 )
@@ -629,3 +634,112 @@ class TestCrossMeshCPCompiledSchedule(GlooDistributedTestBase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestFusedEncoderAndLanguagePipeline(GlooDistributedTestBase):
+    """Two fused encoders span PP=2 before an independently PP=2 LLM."""
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def test_fused_pp2_to_llm_pp2_forward_backward(self) -> None:
+        vision_config = _tiny_vision_config()
+        language_model = from_hf_config(
+            llama_config(), model_kind="language", attn_implementation="eager"
+        )
+        children = {}
+        for modality in ("vision", "aux"):
+            encoder = from_hf_config(
+                vision_config, model_kind="vision", attn_implementation="eager"
+            )
+            children[modality] = build_modality_encoder(
+                encoder, language_model, modality=modality
+            )
+        fused = build_fused_modality_encoder(children)
+        language_model.set_random_init()
+        fused.set_random_init()
+
+        parallel = ParallelizationPlan(global_ranks=list(range(self.world_size)))
+        encoder_partition = PipelinePartitionSpec((1, 2))
+        parallel.parallelize(
+            fused,
+            ParallelConfig(
+                tensor_parallel_size=1,
+                pipeline_parallel_size=2,
+                data_parallel_size=1,
+            ),
+            pipeline_partitions={
+                "vision": encoder_partition,
+                "aux": encoder_partition,
+            },
+        )
+        llm_layers = language_model.hf_config.num_hidden_layers
+        parallel.parallelize(
+            language_model,
+            ParallelConfig(
+                tensor_parallel_size=1,
+                pipeline_parallel_size=2,
+                data_parallel_size=1,
+            ),
+            pipeline_partitions=PipelinePartitionSpec((1, llm_layers)),
+        )
+        context = parallel.materialize("cpu", dtype=torch.float32)
+
+        tokens_per_encoder = _num_vision_tokens(vision_config)
+        seq_len = tokens_per_encoder * 2 + 3
+        generator = torch.Generator().manual_seed(7)
+        input_ids = torch.randint(
+            2,
+            language_model.hf_config.vocab_size,
+            (2, seq_len),
+            generator=generator,
+        )
+        input_ids[:, :tokens_per_encoder] = 0
+        input_ids[:, tokens_per_encoder : 2 * tokens_per_encoder] = 1
+        image_size = vision_config.image_size
+        batch = {
+            "input_ids": input_ids,
+            "labels": input_ids.clone(),
+            "vision_pixels": torch.randn(
+                2, 3, image_size, image_size, generator=generator
+            ),
+            "aux_pixels": torch.randn(
+                2, 3, image_size, image_size, generator=generator
+            ),
+        }
+        microbatches = [
+            {key: value.chunk(2, dim=0)[index] for key, value in batch.items()}
+            for index in range(2)
+        ]
+
+        execution = CornstarchExecutionPlan()
+        fused_outputs = execution.run_fused_modality_encoder(
+            fused,
+            inputs={
+                "vision": {"pixel_values": ExecutionFuture("vision_pixels")},
+                "aux": {"pixel_values": ExecutionFuture("aux_pixels")},
+            },
+        )
+        merged = execution.merge_modality_encoder_outputs(
+            language_model=language_model,
+            input_ids=ExecutionFuture("input_ids"),
+            labels=ExecutionFuture("labels"),
+            modality_token_ids={"vision": 0, "aux": 1},
+            encoder_outputs=fused_outputs,
+        )
+        output = execution.run_language_model(language_model, inputs=merged)
+        schedule = context.create_schedule(execution, output)
+        self.assertEqual(schedule.num_stages, 4)
+        result = schedule.step(microbatches, _criterion, return_loss=True)
+
+        rank = dist.get_rank()
+        if rank == 3:
+            self.assertIsNotNone(result["loss"])
+            self.assertTrue(result["loss"].isfinite().all())
+        else:
+            self.assertIsNone(result["loss"])
+        if rank in (0, 1):
+            self.assertTrue(_has_grad(fused), "fused encoder stage got no grad")
+        else:
+            self.assertTrue(_has_grad(language_model), "language stage got no grad")

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -692,7 +692,7 @@ class TestFusedEncoderAndLanguagePipeline(GlooDistributedTestBase):
         input_ids = torch.randint(
             2,
             language_model.hf_config.vocab_size,
-            (2, seq_len),
+            (4, seq_len),
             generator=generator,
         )
         input_ids[:, :tokens_per_encoder] = 0
@@ -702,23 +702,46 @@ class TestFusedEncoderAndLanguagePipeline(GlooDistributedTestBase):
             "input_ids": input_ids,
             "labels": input_ids.clone(),
             "vision_pixels": torch.randn(
-                2, 3, image_size, image_size, generator=generator
+                4, 3, image_size, image_size, generator=generator
             ),
             "aux_pixels": torch.randn(
-                2, 3, image_size, image_size, generator=generator
+                4, 3, image_size, image_size, generator=generator
             ),
         }
         microbatches = [
-            {key: value.chunk(2, dim=0)[index] for key, value in batch.items()}
-            for index in range(2)
+            {key: value.chunk(4, dim=0)[index] for key, value in batch.items()}
+            for index in range(4)
         ]
+        microbatches[1].pop("aux_pixels")
+        microbatches[1]["input_ids"].masked_fill_(
+            microbatches[1]["input_ids"] == 1, 2
+        )
+        microbatches[1]["labels"] = microbatches[1]["input_ids"].clone()
+        microbatches[2].pop("vision_pixels")
+        microbatches[2]["input_ids"].masked_fill_(
+            microbatches[2]["input_ids"] == 0, 2
+        )
+        microbatches[2]["labels"] = microbatches[2]["input_ids"].clone()
+        microbatches[3].pop("vision_pixels")
+        microbatches[3].pop("aux_pixels")
+        microbatches[3]["input_ids"].masked_fill_(
+            (microbatches[3]["input_ids"] == 0)
+            | (microbatches[3]["input_ids"] == 1),
+            2,
+        )
+        microbatches[3]["labels"] = microbatches[3]["input_ids"].clone()
+
 
         execution = CornstarchExecutionPlan()
         fused_outputs = execution.run_fused_modality_encoder(
             fused,
             inputs={
-                "vision": {"pixel_values": ExecutionFuture("vision_pixels")},
-                "aux": {"pixel_values": ExecutionFuture("aux_pixels")},
+                "vision": {
+                    "pixel_values": ExecutionFuture("vision_pixels", optional=True)
+                },
+                "aux": {
+                    "pixel_values": ExecutionFuture("aux_pixels", optional=True)
+                },
             },
         )
         merged = execution.merge_modality_encoder_outputs(

--- a/tests/distributed/test_parallelization_plan.py
+++ b/tests/distributed/test_parallelization_plan.py
@@ -141,3 +141,47 @@ def test_assign_ranks_rejects_unequal_colocated_ranks_per_replica() -> None:
     )  # rpr=2
     with pytest.raises(ValueError, match="equal\\s+ranks_per_replica"):
         plan._assign_ranks([0, 1], 2)
+
+
+def test_fused_module_is_counted_once_and_accepts_per_child_partitions() -> None:
+    from cornstarch.distributed import PipelinePartitionSpec
+    from cornstarch.models import build_fused_modality_encoder
+    from tests.model.model_configs import whisper_config
+
+    language_model = from_hf_config(llama_config(), model_kind="language")
+    vision = build_modality_encoder(
+        from_hf_config(clip_vision_config(), model_kind="vision"),
+        language_model,
+        modality="vision",
+    )
+    audio = build_modality_encoder(
+        from_hf_config(whisper_config(), model_kind="audio"),
+        language_model,
+        modality="audio",
+    )
+    fused = build_fused_modality_encoder({"vision": vision, "audio": audio})
+    vision_layers = len(vision.encoder.encoder_layers)
+    audio_layers = len(audio.encoder.encoder_layers)
+    llm_layers = len(language_model.decoder_layers)
+
+    plan = ParallelizationPlan(global_ranks=[0, 1, 2, 3])
+    plan.parallelize(
+        fused,
+        ParallelConfig(pipeline_parallel_size=2, data_parallel_size=1),
+        pipeline_partitions={
+            "vision": PipelinePartitionSpec((1, vision_layers)),
+            "audio": PipelinePartitionSpec((1, audio_layers)),
+        },
+    )
+    plan.parallelize(
+        language_model,
+        ParallelConfig(pipeline_parallel_size=2, data_parallel_size=1),
+        pipeline_partitions=PipelinePartitionSpec((1, llm_layers)),
+    )
+
+    pipelined, dp_size, module_ranks = plan._assign_ranks([0, 1, 2, 3], 4)
+    assert pipelined is True
+    assert dp_size == 1
+    assert module_ranks == [[0, 1], [2, 3]]
+    assert len(plan._modules) == 2
+    assert len(plan._pipeline_partitions) == 2

--- a/tests/distributed/test_plugin_hooks.py
+++ b/tests/distributed/test_plugin_hooks.py
@@ -1,0 +1,110 @@
+"""Public plugin hooks for schedules and caller-owned batch planning."""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+
+import pytest
+import torch
+from torch.utils.data import Dataset, SequentialSampler
+
+from cornstarch.distributed.parallelization import ParallelContext, ScheduleContext
+
+
+class _Dataset(Dataset):
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, index):
+        return {"value": torch.tensor(index)}
+
+
+def _context(*, uses_pipeline_parallel: bool = False) -> ParallelContext:
+    return ParallelContext(
+        modules=[],
+        configs=[],
+        meshes={},
+        layouts={},
+        dp_size=1,
+        dp_rank=0,
+        dp_group=None,
+        gradient_synchronizer=None,
+        uses_pipeline_parallel=uses_pipeline_parallel,
+    )
+
+
+def test_prepare_dataloader_accepts_caller_sampler_and_transform() -> None:
+    dataset = _Dataset()
+    loader = _context().prepare_dataloader(
+        dataset,
+        batch_size=2,
+        sampler=SequentialSampler(dataset),
+        collate_fn=lambda samples: {
+            "value": torch.stack([sample["value"] for sample in samples])
+        },
+        per_microbatch_transform=lambda batch: {
+            **batch,
+            "planned": torch.tensor(True),
+        },
+    )
+    batches = list(loader)
+    assert len(batches) == 2
+    assert batches[0][0]["value"].tolist() == [0, 1]
+    assert batches[0][0]["planned"].item() is True
+
+
+def test_prepare_dataloader_accepts_caller_batch_sampler() -> None:
+    dataset = _Dataset()
+    loader = _context().prepare_dataloader(
+        dataset,
+        batch_sampler=[[3, 1], [2, 0]],
+        collate_fn=lambda samples: {
+            "value": torch.stack([sample["value"] for sample in samples])
+        },
+    )
+    assert [batch[0]["value"].tolist() for batch in loader] == [[3, 1], [2, 0]]
+
+
+def test_schedule_factory_receives_immutable_public_context() -> None:
+    captured = {}
+
+    def factory(context: ScheduleContext):
+        captured["context"] = context
+        return "custom-schedule"
+
+    result = _context(uses_pipeline_parallel=True).create_schedule(
+        plan=object(),
+        output_future=object(),
+        schedule_factory=factory,
+    )
+    assert result == "custom-schedule"
+    schedule_context = captured["context"]
+    assert isinstance(schedule_context.layouts, MappingProxyType)
+    with pytest.raises(TypeError):
+        schedule_context.layouts[1] = object()
+
+
+def test_prepare_dataloader_transforms_structured_encoder_and_llm_views() -> None:
+    dataset = _Dataset()
+
+    def collate(samples):
+        values = torch.stack([sample["value"] for sample in samples]).unsqueeze(1)
+        return {
+            "encoder": {"input_ids": values.clone(), "labels": values.clone()},
+            "language": {"input_ids": values.clone(), "labels": values.clone()},
+            "plan_id": "iteration-0",
+        }
+
+    loader = _context().prepare_dataloader(
+        dataset,
+        batch_size=2,
+        collate_fn=collate,
+        microbatch_views=lambda planned: (
+            planned["encoder"],
+            planned["language"],
+        ),
+    )
+    planned = next(iter(loader))[0]
+    assert planned["plan_id"] == "iteration-0"
+    assert "cp_global_input_ids" in planned["encoder"]
+    assert "cp_global_input_ids" in planned["language"]

--- a/tests/distributed/test_tensor_parallel_unregistered.py
+++ b/tests/distributed/test_tensor_parallel_unregistered.py
@@ -6,9 +6,10 @@ lookup now happens before any mesh use, so this is a plain (non-distributed)
 unit test: building a model whose config class is not in the TP registry and
 calling ``apply_tensor_parallel`` must raise ``TensorParallelNotSupportedError``.
 """
+
 import unittest
 
-from tests.model.model_configs import clip_vision_config
+from tests.model.model_configs import nemotron_h_config
 
 from cornstarch.distributed.tensor_parallel import (
     TensorParallelNotSupportedError,
@@ -20,12 +21,12 @@ from cornstarch.models import from_hf_config
 
 class TestUnregisteredTensorParallel(unittest.TestCase):
     def test_unregistered_family_raises(self):
-        config = clip_vision_config()
+        config = nemotron_h_config()
         self.assertIsNone(
             get_tp_plan(type(config).__name__),
             "test requires an unregistered config family",
         )
-        model = from_hf_config(config, model_kind="vision")
+        model = from_hf_config(config, model_kind="language")
 
         # The plan lookup raises before the mesh is ever touched, so a real
         # process group / DeviceMesh is unnecessary here.
@@ -36,6 +37,31 @@ class TestUnregisteredTensorParallel(unittest.TestCase):
         from tests.model.model_configs import llama_config
 
         self.assertIsNotNone(get_tp_plan(type(llama_config()).__name__))
+
+    def test_requested_dense_tp_plans_resolve_every_path(self):
+        from tests.model.model_configs import (
+            clip_vision_config,
+            gemma4_vision_config,
+            llama4_config,
+            siglip2_vision_config,
+            whisper_config,
+        )
+
+        cases = (
+            (clip_vision_config(), "vision"),
+            (gemma4_vision_config(), "vision"),
+            (llama4_config(), "language"),
+            (siglip2_vision_config(), "vision"),
+            (whisper_config(), "audio"),
+        )
+        for config, model_kind in cases:
+            plan = get_tp_plan(type(config).__name__)
+            self.assertIsNotNone(plan)
+            model = from_hf_config(config, model_kind=model_kind)
+            repeated = getattr(model, model._section_names()[1])
+            for layer in repeated:
+                for path in plan:
+                    self.assertIsNotNone(layer.get_submodule(path))
 
 
 if __name__ == "__main__":

--- a/tests/model/test_cross_mesh_routing.py
+++ b/tests/model/test_cross_mesh_routing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+from unittest.mock import patch
 
 from cornstarch.distributed.context_parallel.splitters import (
     ContextParallelSplitter,
@@ -156,10 +157,24 @@ def test_incompatible_producer_hidden_shards_are_rejected() -> None:
     producer = MeshLayout((0, 1), 1, 1, 1, 2, 1)
     consumer = MeshLayout((2,), 1, 1, 1, 1, 1)
     try:
-        build_cross_mesh_groups(
-            producer_layout=producer, consumer_layout=consumer
-        )
+        build_cross_mesh_groups(producer_layout=producer, consumer_layout=consumer)
     except ValueError as error:
         assert "Incompatible TP layout" in str(error)
     else:
         raise AssertionError("expected incompatible TP seam validation failure")
+
+
+def test_divisible_producer_tp_fans_out_to_consumer_lanes() -> None:
+    producer = MeshLayout((0, 1), 1, 1, 1, 2, 1)
+    consumer = MeshLayout((2, 3, 4, 5), 1, 1, 1, 4, 1)
+    with patch("torch.distributed.new_group", side_effect=lambda ranks: tuple(ranks)):
+        groups = build_cross_mesh_groups(
+            producer_layout=producer, consumer_layout=consumer
+        )
+    assert [(group.producer_tp_rank, group.consumer_tp_rank) for group in groups] == [
+        (0, 0),
+        (1, 1),
+        (0, 2),
+        (1, 3),
+    ]
+    assert [group.producer_ranks for group in groups] == [(0,), (1,), (0,), (1,)]

--- a/tests/model/test_fused_modality_encoder.py
+++ b/tests/model/test_fused_modality_encoder.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import torch
+
+from cornstarch.models import (
+    CornstarchExecutionPlan,
+    build_fused_modality_encoder,
+    build_modality_encoder,
+    from_hf_config,
+)
+from tests.model.model_configs import clip_vision_config, llama_config, whisper_config
+
+
+def _modules():
+    language = from_hf_config(llama_config(), model_kind="language")
+    vision = build_modality_encoder(
+        from_hf_config(clip_vision_config(), model_kind="vision"),
+        language,
+        modality="vision",
+    )
+    audio = build_modality_encoder(
+        from_hf_config(whisper_config(), model_kind="audio"),
+        language,
+        modality="audio",
+    )
+    return language, vision, audio
+
+
+def test_fused_encoder_registry_and_lifecycle_are_ordered() -> None:
+    _, vision, audio = _modules()
+    fused = build_fused_modality_encoder({"vision": vision, "audio": audio})
+
+    assert fused.modalities == ("vision", "audio")
+    assert tuple(fused.config) == ("vision", "audio")
+    assert fused.output_hidden_size == vision.projector.config.out_features
+    fused.set_random_init()
+    assert vision.encoder._init_plan.mode == "random"
+    assert audio.encoder._init_plan.mode == "random"
+
+
+def test_fused_execution_node_runs_present_children_in_registry_order() -> None:
+    class Child(torch.nn.Module):
+        def __init__(self, modality: str):
+            super().__init__()
+            self.modality = modality
+            self.projector = type("Projector", (), {"config": type("C", (), {"out_features": 4})()})()
+            self.encoder = type("Encoder", (), {"config": type("C", (), {"hidden_size": 4})()})()
+            self.config = (self.encoder.config, self.projector.config)
+
+        def forward(self, value):
+            return value + 1
+
+        def set_empty_init(self): pass
+        def set_random_init(self): pass
+        def materialize(self, device="cpu", dtype=None): return self
+
+    # Use the real fused class but lightweight modality-module subclasses are
+    # deliberately rejected; this assertion protects the public type boundary.
+    _, vision, audio = _modules()
+    fused = build_fused_modality_encoder({"vision": vision, "audio": audio})
+    vision.forward = lambda **kwargs: kwargs["value"] + 1
+    audio.forward = lambda **kwargs: kwargs["value"] + 2
+
+    plan = CornstarchExecutionPlan()
+    future = plan.run_fused_modality_encoder(
+        fused,
+        inputs={"audio": {"value": torch.tensor(3)}},
+    )
+    result = future.execute()
+    assert tuple(result) == ("audio",)
+    assert torch.equal(result["audio"], torch.tensor(5))

--- a/tests/model/test_fused_modality_encoder.py
+++ b/tests/model/test_fused_modality_encoder.py
@@ -4,6 +4,7 @@ import torch
 
 from cornstarch.models import (
     CornstarchExecutionPlan,
+    ExecutionFuture,
     build_fused_modality_encoder,
     build_modality_encoder,
     from_hf_config,
@@ -67,5 +68,24 @@ def test_fused_execution_node_runs_present_children_in_registry_order() -> None:
         inputs={"audio": {"value": torch.tensor(3)}},
     )
     result = future.execute()
+    assert tuple(result) == ("audio",)
+    assert torch.equal(result["audio"], torch.tensor(5))
+
+
+def test_optional_fused_inputs_skip_absent_children_atomically() -> None:
+    _, vision, audio = _modules()
+    fused = build_fused_modality_encoder({"vision": vision, "audio": audio})
+    vision.forward = lambda **kwargs: kwargs["value"] + 1
+    audio.forward = lambda **kwargs: kwargs["value"] + 2
+
+    plan = CornstarchExecutionPlan()
+    future = plan.run_fused_modality_encoder(
+        fused,
+        inputs={
+            "vision": {"value": ExecutionFuture("vision_value", optional=True)},
+            "audio": {"value": ExecutionFuture("audio_value", optional=True)},
+        },
+    )
+    result = future.execute({"audio_value": torch.tensor(3)})
     assert tuple(result) == ("audio",)
     assert torch.equal(result["audio"], torch.tensor(5))

--- a/tests/model/test_pipeline_partition_spec.py
+++ b/tests/model/test_pipeline_partition_spec.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from cornstarch.distributed.pipeline_parallel import (
+    PipelinePartitionSpec,
+    apply_pipeline_parallel,
+)
+from cornstarch.models import from_hf_config
+from tests.model.model_configs import llama_config
+
+
+def test_partition_spec_validates_nonempty_contiguous_exhaustive_ranges() -> None:
+    spec = PipelinePartitionSpec((1, 3, 6))
+    assert spec.layer_range(total_layers=6, stage=0, num_stages=3) == (0, 1)
+    assert spec.layer_range(total_layers=6, stage=1, num_stages=3) == (1, 3)
+    assert spec.layer_range(total_layers=6, stage=2, num_stages=3) == (3, 6)
+
+    with pytest.raises(ValueError, match="exhaustive"):
+        spec.layer_range(total_layers=7, stage=0, num_stages=3)
+    with pytest.raises(ValueError, match="nonempty"):
+        PipelinePartitionSpec((1, 1, 3))
+
+
+def test_apply_pipeline_parallel_consumes_explicit_boundaries() -> None:
+    model = from_hf_config(llama_config(), model_kind="language")
+    total = len(model.decoder_layers)
+    assert total >= 2
+    spec = PipelinePartitionSpec((1, total))
+    mesh = SimpleNamespace(stage=0, num_stages=2, distribute_layers=lambda _: (0, total // 2))
+
+    apply_pipeline_parallel(model, mesh, partition=spec)
+
+    assert len(model.decoder_layers) == 1
+    assert model._pipeline_layer_offset == 0


### PR DESCRIPTION
## Summary

- add a public `CornstarchFusedModalityEncoder` and fused execution-DAG node whose output feeds the existing multimodal merge directly
- let one fused module registration share a mesh/config across every child while accepting explicit per-child pipeline partitions
- generalize the global schedule to fused encoder PP stages followed by LLM PP stages, including stable per-modality seam routing and inverse backward routing
- add public schedule-factory/context and eager-warmup hooks for plugins
- add caller-owned sampler, batch-sampler, per-microbatch transform, and structured microbatch-view hooks
- support optional fused-modality inputs per microbatch, including vision-only, audio-only, and fully text-only microbatches in one pipeline iteration
- preserve the active autocast dtype in encoder-to-LLM seam allocation so BF16 senders and receivers agree
- allow replicated producer TP lanes to fan out to a divisible consumer TP degree, such as fused TP=2 to LLM TP=4
- register declarative TP policies for converted CLIP, Gemma4 Vision, SigLIP2, Whisper, and Llama4 repeated layers

## Compatibility

Equal-layer pipeline slicing remains the default. Existing ordinary modality encoders and LLM-only schedules keep their current APIs. Explicit partitions, optional futures, fused modules, and structured views are opt-in. Producer TP collapse into a smaller consumer TP degree is still rejected because that requires a different replicated-gradient reduction contract.

## Validation

Passed:

- `python -m ruff check` on every changed source/test file
- 25 broader multimodal routing and tensor-parallel regressions
- four-rank fused encoder PP=2 to LLM PP=2 forward/backward with both modalities, either modality, and text-only microbatches under gloo
- Entrain integration: 7 CUDA/gloo tests, including FP32/BF16 forced multiple-deferral gradient parity, fused TP=1/PP=2 beside LLM TP=2/PP=2, and encoder TP=2/PP=2 checkpoint materialization
- full Cornstarch suite: 247 passed, 5 skipped

The full environment reports the same 12 failures recorded on the refactor baseline:

- 10 LoRA failures because installed PEFT rejects torchao 0.15 (requires above 0.16)
- existing Qwen3.5-MoE router/grouped-matmul parity failure
- existing DeepSeek V4 rotary-position tuple/dict mismatch

No files implementing those three baseline areas were changed by this PR.