### PR TITLE
Implement count-heuristic ZB-H2 pipeline schedule

### DIFF
--- a/cornstarch/distributed/__init__.py
+++ b/cornstarch/distributed/__init__.py
@@ -22,8 +22,8 @@ tests call these directly; everything else is built on them.
 - **Context parallelism** (``apply_context_parallel`` + ``splitters``):
   all-gather flash attention plus data-side sequence splitters.
 - **Pipeline parallelism** (``apply_pipeline_parallel`` + the
-  ``TrainingSchedule`` hierarchy + P2P): explicit Megatron/ColossalAI-style
-  1F1B scheduling, not DTensor-based. Multimodal encoder-to-LLM seams use a
+  ``TrainingSchedule`` hierarchy + P2P): explicit 1F1B and count-heuristic
+  ZB-H2 scheduling, not DTensor-based. Multimodal encoder-to-LLM seams use a
   differentiable variable-split all-to-all so each projected row moves directly
   between its source and destination CP owners.
 - **Expert parallelism** (``apply_expert_parallel``): shards a MoE layer's
@@ -60,8 +60,13 @@ from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
 from cornstarch.distributed.pipeline_parallel.schedule import (
     BasePipelineSchedule,
     MeshLayout,
-    OneForwardOneBackwardSchedule,
     TrainingSchedule,
+)
+from cornstarch.distributed.pipeline_parallel.schedule_1f1b import (
+    OneForwardOneBackwardSchedule,
+)
+from cornstarch.distributed.pipeline_parallel.schedule_zbpp import (
+    ZeroBubblePipelineSchedule,
 )
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.distributed.tensor_parallel import (
@@ -87,6 +92,7 @@ __all__ = [
     "TrainingSchedule",
     "BasePipelineSchedule",
     "OneForwardOneBackwardSchedule",
+    "ZeroBubblePipelineSchedule",
     "MeshLayout",
     # expert parallel
     "apply_expert_parallel",

--- a/cornstarch/distributed/expert_parallel/__init__.py
+++ b/cornstarch/distributed/expert_parallel/__init__.py
@@ -39,6 +39,9 @@ from cornstarch.distributed.expert_parallel.routing import (
     ExpertParallelDispatcher,
     ExpertRouter,
 )
+from cornstarch.distributed.pipeline_parallel.deferred_weight_grad import (
+    deferred_expert_linear,
+)
 from cornstarch.models.model_base import CornstarchModelBase
 
 
@@ -79,8 +82,12 @@ class _BatchedExperts(nn.Module):
             expert_idx = expert_idx[0]
             top_k_pos, token_idx = torch.where(expert_mask[expert_idx])
             current = hidden_states[token_idx]
-            gate, up = F.linear(current, self.gate_up_proj[expert_idx]).chunk(2, dim=-1)
-            current = F.linear(self.act_fn(gate) * up, self.down_proj[expert_idx])
+            gate, up = deferred_expert_linear(
+                current, self.gate_up_proj, expert_idx
+            ).chunk(2, dim=-1)
+            current = deferred_expert_linear(
+                self.act_fn(gate) * up, self.down_proj, expert_idx
+            )
             current = current * top_k_weights[token_idx, top_k_pos, None]
             final = final.index_add(0, token_idx, current.to(final.dtype))
         return final

--- a/cornstarch/distributed/parallel_config.py
+++ b/cornstarch/distributed/parallel_config.py
@@ -30,6 +30,9 @@ class ParallelConfig:
       (all ``None`` ⇒ no pipeline parallelism; all positive ⇒ pipeline
       parallelism); a mix is rejected by ``materialize()``. Cornstarch never
       infers a stage count — the user states it.
+    - ``pipeline_schedule``: ``"1f1b"`` (default) or count-heuristic ZB-H2
+      (``"zbpp"``). Every pipelined module in one plan must select the same
+      schedule.
     - ``context_parallel_size`` (``cp``): sequence is split across these ranks
       (data-side); requires a ``context_parallel_splitter``.
     - ``data_parallel_size`` (``dp``): replicas trained on different data shards.

--- a/cornstarch/distributed/parallel_config.py
+++ b/cornstarch/distributed/parallel_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from cornstarch.distributed.context_parallel.splitters import ContextParallelSplitter
@@ -43,6 +43,7 @@ class ParallelConfig:
 
     tensor_parallel_size: int = 1
     pipeline_parallel_size: int | None = None
+    pipeline_schedule: Literal["1f1b", "zbpp"] = "1f1b"
     context_parallel_size: int = 1
     data_parallel_size: int = 1
     expert_parallel_size: int = 1
@@ -61,6 +62,10 @@ class ParallelConfig:
         # stage count (disaggregate); it is never < 1.
         if self.pipeline_parallel_size is not None and self.pipeline_parallel_size < 1:
             raise ValueError("pipeline_parallel_size must be None or >= 1.")
+        if self.pipeline_schedule not in ("1f1b", "zbpp"):
+            raise ValueError(
+                "pipeline_schedule must be either '1f1b' or 'zbpp'."
+            )
         if self.context_parallel_size > 1 and self.context_parallel_splitter is None:
             raise ValueError(
                 "context_parallel_splitter must be provided when "

--- a/cornstarch/distributed/parallelization.py
+++ b/cornstarch/distributed/parallelization.py
@@ -40,10 +40,12 @@ from cornstarch.distributed.data_parallel import GradientSynchronizer
 from cornstarch.distributed.expert_parallel import apply_expert_parallel
 from cornstarch.distributed.parallel_config import ParallelConfig
 from cornstarch.distributed.pipeline_parallel import apply_pipeline_parallel
-from cornstarch.distributed.pipeline_parallel.schedule import (
-    MeshLayout,
+from cornstarch.distributed.pipeline_parallel.deferred_weight_grad import (
+    apply_deferred_weight_gradients,
+)
+from cornstarch.distributed.pipeline_parallel.schedule import MeshLayout, TrainingSchedule
+from cornstarch.distributed.pipeline_parallel.schedule_1f1b import (
     OneForwardOneBackwardSchedule,
-    TrainingSchedule,
 )
 from cornstarch.distributed.process_group_mesh import ModalProcessGroupMesh
 from cornstarch.distributed.tensor_parallel import apply_tensor_parallel
@@ -407,9 +409,10 @@ class ParallelContext:
         Only call this when pipeline parallelism is used (``uses_pipeline_parallel``);
         without it there are no stages and the training loop runs the plan directly
         (``output_future.execute()`` + ``backward()`` per microbatch). The returned
-        :class:`OneForwardOneBackwardSchedule` drives the global pipeline — the
-        modality encoder(s) as leading stage(s) feeding the language-model stages,
-        with the encoder→language-model boundary crossed by the cross-mesh seam.
+        The schedule selected by ``ParallelConfig.pipeline_schedule`` drives the
+        global pipeline — modality encoder(s) as leading stage(s) feeding the
+        language-model stages, with the encoder→language-model boundary crossed
+        by the cross-mesh seam.
 
         Construction is cheap (DAG/stage analysis + a rank-local program, no
         collectives), so the caller may rebuild it per step. The number of
@@ -421,7 +424,27 @@ class ParallelContext:
                 "parallelism the modules are co-located; run the plan directly "
                 "(output_future.execute() + backward()) per microbatch instead."
             )
-        return OneForwardOneBackwardSchedule(
+        schedules = {
+            config.pipeline_schedule
+            for config in self._configs
+            if config.uses_pipeline_parallel
+        }
+        if len(schedules) != 1:
+            raise ValueError(
+                "All pipelined modules in one plan must select the same "
+                "pipeline_schedule."
+            )
+        schedule_name = schedules.pop()
+        if schedule_name == "1f1b":
+            schedule_cls = OneForwardOneBackwardSchedule
+        else:
+            from cornstarch.distributed.pipeline_parallel.schedule_zbpp import (
+                ZeroBubblePipelineSchedule,
+            )
+
+            schedule_cls = ZeroBubblePipelineSchedule
+
+        return schedule_cls(
             plan,
             output_future,
             {id(module): self._layouts[id(module)] for module in self._modules},
@@ -678,6 +701,8 @@ class ParallelizationPlan:
         module.materialize(device, dtype=dtype)
         if config.expert_parallel_size > 1:
             apply_expert_parallel(target, mesh.ep_group)
+        if config.uses_pipeline_parallel and config.pipeline_schedule == "zbpp":
+            apply_deferred_weight_gradients(target)
 
     def _build_cross_mesh_groups(
         self, layouts: dict[int, MeshLayout]
@@ -723,6 +748,17 @@ class ParallelizationPlan:
         pp_flags = [cfg.uses_pipeline_parallel for cfg in self._configs]
         if all(pp_flags):
             pipelined = True
+            schedules = {cfg.pipeline_schedule for cfg in self._configs}
+            if len(schedules) != 1:
+                named = ", ".join(
+                    f"{type(module).__name__}(pipeline_schedule="
+                    f"{config.pipeline_schedule!r})"
+                    for module, config in zip(self._modules, self._configs)
+                )
+                raise ValueError(
+                    "All pipelined modules in one plan must select the same "
+                    f"pipeline_schedule; got {named}."
+                )
         elif not any(pp_flags):
             pipelined = False
         else:

--- a/cornstarch/distributed/pipeline_parallel/__init__.py
+++ b/cornstarch/distributed/pipeline_parallel/__init__.py
@@ -1,4 +1,4 @@
-"""Pipeline parallelism: P2P communication, forward spec wrapper, and 1F1B schedule."""
+"""Pipeline parallelism: stage partitioning, P2P, and training schedules."""
 from __future__ import annotations
 
 import torch.nn as nn

--- a/cornstarch/distributed/pipeline_parallel/deferred_weight_grad.py
+++ b/cornstarch/distributed/pipeline_parallel/deferred_weight_grad.py
@@ -1,0 +1,251 @@
+"""Deferred linear weight-gradient computation for zero-bubble schedules.
+
+The custom autograd functions compute activation gradients during ``B`` and
+record just enough state for a later ``W`` operation. Outside an active capture
+they behave like ordinary linear autograd, which keeps instrumented modules safe
+for diagnostics and non-scheduled backward calls.
+"""
+from __future__ import annotations
+
+from collections import deque
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from types import MethodType
+from typing import Callable, Iterator
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+@dataclass
+class _Capture:
+    store: "DeferredWeightGradStore"
+    microbatch: int
+
+
+_ACTIVE_CAPTURE: ContextVar[_Capture | None] = ContextVar(
+    "cornstarch_deferred_weight_grad_capture", default=None
+)
+
+
+def _linear_weight_grad(
+    input: torch.Tensor, grad_output: torch.Tensor
+) -> torch.Tensor:
+    input_2d = input.reshape(-1, input.shape[-1])
+    grad_output_2d = grad_output.reshape(-1, grad_output.shape[-1])
+    return grad_output_2d.transpose(0, 1).matmul(input_2d)
+
+
+def _linear_bias_grad(grad_output: torch.Tensor) -> torch.Tensor:
+    return grad_output.reshape(-1, grad_output.shape[-1]).sum(dim=0)
+
+
+def _accumulate_grad(parameter: torch.Tensor, grad: torch.Tensor) -> None:
+    grad = grad.detach()
+    if parameter.grad is None:
+        parameter.grad = grad
+    else:
+        parameter.grad.add_(grad)
+
+
+class DeferredWeightGradStore:
+    """FIFO of per-microbatch linear weight-gradient work."""
+
+    def __init__(self) -> None:
+        self._microbatch_work: dict[int, list[Callable[[], None]]] = {}
+        self._pending: deque[tuple[int, list[Callable[[], None]]]] = deque()
+
+    @contextmanager
+    def forward(self, microbatch: int) -> Iterator[None]:
+        """Associate linear autograd nodes created by F with a microbatch."""
+        if microbatch in self._microbatch_work:
+            raise RuntimeError(f"Microbatch {microbatch} is already being captured.")
+        self._microbatch_work[microbatch] = []
+        token = _ACTIVE_CAPTURE.set(_Capture(self, microbatch))
+        try:
+            yield
+        finally:
+            _ACTIVE_CAPTURE.reset(token)
+
+    @contextmanager
+    def backward(self, microbatch: int) -> Iterator[None]:
+        """Run B, then expose its collected weight work to the W FIFO."""
+        if microbatch not in self._microbatch_work:
+            raise RuntimeError(
+                f"Microbatch {microbatch} has no matching deferred forward capture."
+            )
+        try:
+            yield
+        finally:
+            work = self._microbatch_work.pop(microbatch)
+            self._pending.append((microbatch, work))
+
+    @contextmanager
+    def capture(self, microbatch: int) -> Iterator[None]:
+        """Convenience context for tests that execute F and B together."""
+        with self.forward(microbatch):
+            yield
+        work = self._microbatch_work.pop(microbatch)
+        self._pending.append((microbatch, work))
+
+    def defer(self, microbatch: int, work: Callable[[], None]) -> None:
+        try:
+            self._microbatch_work[microbatch].append(work)
+        except KeyError as error:
+            raise RuntimeError(
+                f"No active deferred-weight capture for microbatch {microbatch}."
+            ) from error
+
+    def execute(self, microbatch: int) -> None:
+        if not self._pending:
+            raise RuntimeError("Deferred W queue is empty.")
+        pending_microbatch, work = self._pending.popleft()
+        if pending_microbatch != microbatch:
+            raise RuntimeError(
+                "Deferred W FIFO mismatch: expected microbatch "
+                f"{microbatch}, found {pending_microbatch}."
+            )
+        with torch.no_grad():
+            for item in work:
+                item()
+        work.clear()
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    def assert_empty(self) -> None:
+        if self._microbatch_work or self._pending:
+            raise RuntimeError("Deferred weight-gradient state leaked across steps.")
+
+
+class _DeferredLinear(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        weight: torch.Tensor,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(input, weight)
+        ctx.weight_target = weight
+        ctx.has_bias = bias is not None
+        ctx.capture = _ACTIVE_CAPTURE.get()
+        return F.linear(input, weight, bias)
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        input, weight = ctx.saved_tensors
+        grad_input = (
+            grad_output.matmul(weight)
+            if ctx.needs_input_grad[0]
+            else None
+        )
+        grad_bias = (
+            _linear_bias_grad(grad_output)
+            if ctx.has_bias and ctx.needs_input_grad[2]
+            else None
+        )
+        grad_weight = None
+        if ctx.needs_input_grad[1]:
+            capture = ctx.capture
+            if capture is None:
+                grad_weight = _linear_weight_grad(input, grad_output)
+            else:
+                weight_target = ctx.weight_target
+                capture.store.defer(
+                    capture.microbatch,
+                    lambda input=input, grad_output=grad_output, weight=weight_target: (
+                        _accumulate_grad(
+                            weight, _linear_weight_grad(input, grad_output)
+                        )
+                    ),
+                )
+        return grad_input, grad_weight, grad_bias
+
+
+class _DeferredExpertLinear(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        input: torch.Tensor,
+        weights: torch.Tensor,
+        expert_index: int,
+    ) -> torch.Tensor:
+        ctx.save_for_backward(input, weights)
+        ctx.weights_target = weights
+        ctx.expert_index = expert_index
+        ctx.capture = _ACTIVE_CAPTURE.get()
+        return F.linear(input, weights[expert_index])
+
+    @staticmethod
+    def backward(ctx, grad_output: torch.Tensor):
+        input, weights = ctx.saved_tensors
+        expert_index = ctx.expert_index
+        weight = weights[expert_index]
+        grad_input = (
+            grad_output.matmul(weight)
+            if ctx.needs_input_grad[0]
+            else None
+        )
+        grad_weights = None
+        if ctx.needs_input_grad[1]:
+            capture = ctx.capture
+            if capture is None:
+                grad_weights = torch.zeros_like(weights)
+                grad_weights[expert_index].copy_(
+                    _linear_weight_grad(input, grad_output)
+                )
+            else:
+                weights_target = ctx.weights_target
+
+                def accumulate() -> None:
+                    grad = torch.zeros_like(weights_target)
+                    grad[expert_index].copy_(
+                        _linear_weight_grad(input, grad_output)
+                    )
+                    _accumulate_grad(weights_target, grad)
+
+                capture.store.defer(capture.microbatch, accumulate)
+        return grad_input, grad_weights, None
+
+
+def deferred_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Linear whose weight gradient can be split from activation backward."""
+    return _DeferredLinear.apply(input, weight, bias)
+
+
+def deferred_expert_linear(
+    input: torch.Tensor,
+    weights: torch.Tensor,
+    expert_index: int | torch.Tensor,
+) -> torch.Tensor:
+    """Deferred linear over one slice of a stacked expert parameter."""
+    if isinstance(expert_index, torch.Tensor):
+        expert_index = int(expert_index.item())
+    return _DeferredExpertLinear.apply(input, weights, expert_index)
+
+
+def _deferred_linear_forward(module: nn.Linear, input: torch.Tensor) -> torch.Tensor:
+    return deferred_linear(input, module.weight, module.bias)
+
+
+def apply_deferred_weight_gradients(module: nn.Module) -> None:
+    """Instrument every ordinary linear module for split B/W execution.
+
+    Instance-level forward replacement preserves module identity, parameters,
+    state-dict names, hooks installed by DTensor TP, and tied parameter objects.
+    """
+    for child in module.modules():
+        if not isinstance(child, nn.Linear):
+            continue
+        if getattr(child, "_cornstarch_deferred_weight_grad", False):
+            continue
+        child.forward = MethodType(_deferred_linear_forward, child)
+        child._cornstarch_deferred_weight_grad = True

--- a/cornstarch/distributed/pipeline_parallel/p2p.py
+++ b/cornstarch/distributed/pipeline_parallel/p2p.py
@@ -161,19 +161,24 @@ class PipelineP2PCommunication:
     def send_forward_recv_backward(
         self, output: Any, send_first: bool = True
     ) -> Any | None:
-        """Simultaneously send forward activations and receive backward gradients."""
-        next_ranks = self._mesh.get_next_ranks()
-        if not next_ranks:
-            return None
-        received = self._exchange(output, next_ranks, next_ranks, send_first)
-        return received[0] if len(received) == 1 else received
+        """Send forward activations, then receive backward gradients.
+
+        The object protocol has separate size and payload phases. Completing the
+        forward object before starting the backward object prevents those phases
+        from crossing when an H2 neighbor is still in its deeper warmup.
+        """
+        self.send_forward(output)
+        return self.recv_backward()
 
     def send_backward_recv_forward(
-        self, grad: Any, send_first: bool = True
+        self, grad: Any, send_first: bool = False
     ) -> Any | None:
-        """Simultaneously send backward gradients and receive forward activations."""
-        prev_ranks = self._mesh.get_prev_ranks()
-        if not prev_ranks:
-            return None
-        received = self._exchange(grad, prev_ranks, prev_ranks, send_first)
-        return received[0] if len(received) == 1 else received
+        """Receive forward activations while sending backward gradients.
+
+        Receive-first ordering is required by the deeper H2 warmup: the previous
+        stage may still be in a forward-only warmup send and cannot receive this
+        gradient until that activation transfer completes.
+        """
+        forward = self.recv_forward()
+        self.send_backward(grad)
+        return forward

--- a/cornstarch/distributed/pipeline_parallel/schedule.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule.py
@@ -28,8 +28,8 @@ ordinary point-to-point transport remains in use for intra-model PP hops.
     how it forwards, and how it communicates with its neighbors), and the shared
     forward/backward microbatch machinery. Subclasses implement the ordering.
 
-``OneForwardOneBackwardSchedule``
-    The 1F1B ordering (warmup / steady / cooldown).
+Concrete orderings live in ``schedule_1f1b`` and ``schedule_zbpp``. They are
+also lazily re-exported from this module for import compatibility.
 """
 from __future__ import annotations
 
@@ -637,96 +637,18 @@ class BasePipelineSchedule(TrainingSchedule):
         return self._lm_comm.send_backward_recv_forward(grad)
 
 
-# ---------------------------------------------------------------------------
-# 1F1B schedule
-# ---------------------------------------------------------------------------
-
-class OneForwardOneBackwardSchedule(BasePipelineSchedule):
-    """One-forward-one-backward pipeline schedule over the global pipeline."""
-
-    def step(
-        self,
-        microbatches: list[dict[str, torch.Tensor]],
-        criterion: Callable[..., Any],
-        optimizer: Optimizer | None = None,
-        return_loss: bool = True,
-        return_outputs: bool = False,
-    ) -> dict:
-        if self._idle:
-            # No stage in this batch's plan (e.g. encoder ranks on a text-only
-            # step): nothing to run, no transfers to anyone.
-            return {"loss": None, "outputs": None}
-
-        if not isinstance(microbatches, list):
-            microbatches = [microbatches]
-        num_microbatches = len(microbatches)
-        self._device = _first_tensor_device(microbatches) or _default_device()
-
-        num_warmup = min(self._num_stages - self._stage - 1, num_microbatches)
-        num_steady = num_microbatches - num_warmup
-
-        accum_loss: torch.Tensor | None = None
-        if return_loss and self.is_last_stage():
-            accum_loss = torch.zeros(1, device=self._device)
-        outputs: list[Any] | None = (
-            [] if return_outputs and self.is_last_stage() else None
+def __getattr__(name: str) -> Any:
+    """Lazily preserve concrete-schedule imports from this legacy module."""
+    if name == "OneForwardOneBackwardSchedule":
+        from cornstarch.distributed.pipeline_parallel.schedule_1f1b import (
+            OneForwardOneBackwardSchedule,
         )
 
-        input_objs: list[Any] = []
-        output_objs: list[Any] = []
-        mb_index = 0
+        return OneForwardOneBackwardSchedule
+    if name == "ZeroBubblePipelineSchedule":
+        from cornstarch.distributed.pipeline_parallel.schedule_zbpp import (
+            ZeroBubblePipelineSchedule,
+        )
 
-        # Warmup.
-        for _ in range(num_warmup):
-            active_microbatch = microbatches[mb_index]
-            input_obj = self._recv_forward(active_microbatch)
-            output_obj = self._forward_step(
-                active_microbatch, input_obj, criterion,
-                num_microbatches, accum_loss, outputs,
-            )
-            mb_index += 1
-            self._send_forward(output_obj, active_microbatch)
-            input_objs.append(input_obj)
-            output_objs.append(output_obj)
-
-        if num_steady > 0:
-            input_obj = self._recv_forward(microbatches[mb_index])
-
-        # Steady state.
-        for i in range(num_steady):
-            last = i == num_steady - 1
-            active_microbatch = microbatches[mb_index]
-            output_obj = self._forward_step(
-                active_microbatch, input_obj, criterion,
-                num_microbatches, accum_loss, outputs,
-            )
-            mb_index += 1
-            output_obj_grad = self._send_forward_recv_backward(
-                output_obj, active_microbatch
-            )
-            input_objs.append(input_obj)
-            output_objs.append(output_obj)
-
-            input_obj = input_objs.pop(0)
-            output_obj = output_objs.pop(0)
-            input_obj_grad = self._backward_step(input_obj, output_obj, output_obj_grad)
-
-            if last:
-                self._send_backward(input_obj_grad)
-            else:
-                input_obj = self._send_backward_recv_forward(
-                    input_obj_grad, microbatches[mb_index]
-                )
-
-        # Cooldown.
-        for _ in range(num_warmup):
-            input_obj = input_objs.pop(0)
-            output_obj = output_objs.pop(0)
-            output_obj_grad = self._recv_backward()
-            input_obj_grad = self._backward_step(input_obj, output_obj, output_obj_grad)
-            self._send_backward(input_obj_grad)
-
-        return {
-            "loss": accum_loss if return_loss else None,
-            "outputs": _merge_batch(outputs) if outputs is not None else None,
-        }
+        return ZeroBubblePipelineSchedule
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/cornstarch/distributed/pipeline_parallel/schedule_1f1b.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule_1f1b.py
@@ -1,0 +1,105 @@
+"""One-forward-one-backward pipeline-parallel training schedule."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import torch
+from torch.optim import Optimizer
+
+from cornstarch.distributed.pipeline_parallel.schedule import (
+    BasePipelineSchedule,
+    _default_device,
+    _first_tensor_device,
+    _merge_batch,
+)
+
+
+class OneForwardOneBackwardSchedule(BasePipelineSchedule):
+    """One-forward-one-backward pipeline schedule over the global pipeline."""
+
+    def step(
+        self,
+        microbatches: list[dict[str, torch.Tensor]],
+        criterion: Callable[..., Any],
+        optimizer: Optimizer | None = None,
+        return_loss: bool = True,
+        return_outputs: bool = False,
+    ) -> dict:
+        if self._idle:
+            # No stage in this batch's plan (e.g. encoder ranks on a text-only
+            # step): nothing to run, no transfers to anyone.
+            return {"loss": None, "outputs": None}
+
+        if not isinstance(microbatches, list):
+            microbatches = [microbatches]
+        num_microbatches = len(microbatches)
+        self._device = _first_tensor_device(microbatches) or _default_device()
+
+        num_warmup = min(self._num_stages - self._stage - 1, num_microbatches)
+        num_steady = num_microbatches - num_warmup
+
+        accum_loss: torch.Tensor | None = None
+        if return_loss and self.is_last_stage():
+            accum_loss = torch.zeros(1, device=self._device)
+        outputs: list[Any] | None = (
+            [] if return_outputs and self.is_last_stage() else None
+        )
+
+        input_objs: list[Any] = []
+        output_objs: list[Any] = []
+        mb_index = 0
+
+        # Warmup.
+        for _ in range(num_warmup):
+            active_microbatch = microbatches[mb_index]
+            input_obj = self._recv_forward(active_microbatch)
+            output_obj = self._forward_step(
+                active_microbatch, input_obj, criterion,
+                num_microbatches, accum_loss, outputs,
+            )
+            mb_index += 1
+            self._send_forward(output_obj, active_microbatch)
+            input_objs.append(input_obj)
+            output_objs.append(output_obj)
+
+        if num_steady > 0:
+            input_obj = self._recv_forward(microbatches[mb_index])
+
+        # Steady state.
+        for i in range(num_steady):
+            last = i == num_steady - 1
+            active_microbatch = microbatches[mb_index]
+            output_obj = self._forward_step(
+                active_microbatch, input_obj, criterion,
+                num_microbatches, accum_loss, outputs,
+            )
+            mb_index += 1
+            output_obj_grad = self._send_forward_recv_backward(
+                output_obj, active_microbatch
+            )
+            input_objs.append(input_obj)
+            output_objs.append(output_obj)
+
+            input_obj = input_objs.pop(0)
+            output_obj = output_objs.pop(0)
+            input_obj_grad = self._backward_step(input_obj, output_obj, output_obj_grad)
+
+            if last:
+                self._send_backward(input_obj_grad)
+            else:
+                input_obj = self._send_backward_recv_forward(
+                    input_obj_grad, microbatches[mb_index]
+                )
+
+        # Cooldown.
+        for _ in range(num_warmup):
+            input_obj = input_objs.pop(0)
+            output_obj = output_objs.pop(0)
+            output_obj_grad = self._recv_backward()
+            input_obj_grad = self._backward_step(input_obj, output_obj, output_obj_grad)
+            self._send_backward(input_obj_grad)
+
+        return {
+            "loss": accum_loss if return_loss else None,
+            "outputs": _merge_batch(outputs) if outputs is not None else None,
+        }

--- a/cornstarch/distributed/pipeline_parallel/schedule_zbpp.py
+++ b/cornstarch/distributed/pipeline_parallel/schedule_zbpp.py
@@ -1,0 +1,255 @@
+"""Count-heuristic ZB-H2 pipeline-parallel training schedule."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable
+
+import torch
+from torch.optim import Optimizer
+
+from cornstarch.distributed.pipeline_parallel.deferred_weight_grad import (
+    DeferredWeightGradStore,
+)
+from cornstarch.distributed.pipeline_parallel.schedule import (
+    BasePipelineSchedule,
+    _default_device,
+    _first_tensor_device,
+    _merge_batch,
+)
+
+
+class OperationType(str, Enum):
+    FORWARD = "F"
+    BACKWARD = "B"
+    WEIGHT = "W"
+
+
+@dataclass(frozen=True)
+class PipelineOperation:
+    """One count-selected ZB-H2 operation and its microbatch index."""
+
+    type: OperationType
+    microbatch: int
+
+
+def h2_warmup_for_stage(num_stages: int, stage: int) -> int:
+    """Return ``u_s = 2(p-s)-1`` for a valid zero-based stage."""
+    if num_stages < 1:
+        raise ValueError("num_stages must be >= 1.")
+    if not 0 <= stage < num_stages:
+        raise ValueError(
+            f"stage must be in [0, {num_stages}), got {stage}."
+        )
+    return 2 * (num_stages - stage) - 1
+
+
+def select_main_operations(
+    forward_count: int,
+    backward_count: int,
+    weight_count: int,
+    num_microbatches: int,
+) -> tuple[PipelineOperation, ...]:
+    """Select one H2 main-loop iteration purely from unconsumed counts.
+
+    Forward and backward checks are deliberately independent. The W check sees
+    the B selected in this iteration, yielding F/B/W, then B/W, then W if a
+    caller supplies a state with only deferred weight work remaining.
+    """
+    if not 0 <= weight_count <= backward_count <= forward_count <= num_microbatches:
+        raise ValueError(
+            "ZB-H2 counters must satisfy 0 <= w <= b <= f <= m."
+        )
+
+    operations: list[PipelineOperation] = []
+    next_backward_count = backward_count
+    if forward_count < num_microbatches:
+        operations.append(PipelineOperation(OperationType.FORWARD, forward_count))
+    if backward_count < num_microbatches:
+        operations.append(PipelineOperation(OperationType.BACKWARD, backward_count))
+        next_backward_count += 1
+    if weight_count < next_backward_count:
+        operations.append(PipelineOperation(OperationType.WEIGHT, weight_count))
+    return tuple(operations)
+
+
+class ZeroBubblePipelineSchedule(BasePipelineSchedule):
+    """ZB-H2 with an H2 warmup and a count-only F/B/W main program."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._weight_grad_store = DeferredWeightGradStore()
+
+    def _assert_iteration_state(
+        self,
+        forward_count: int,
+        backward_count: int,
+        weight_count: int,
+        num_microbatches: int,
+        input_objs: list[Any],
+        output_objs: list[Any],
+    ) -> None:
+        assert 0 <= weight_count <= backward_count <= forward_count <= num_microbatches
+        expected_activations = forward_count - backward_count
+        assert len(input_objs) == expected_activations
+        assert len(output_objs) == expected_activations
+        assert self._weight_grad_store.pending_count == backward_count - weight_count
+
+    def step(
+        self,
+        microbatches: list[dict[str, torch.Tensor]],
+        criterion: Callable[..., Any],
+        optimizer: Optimizer | None = None,
+        return_loss: bool = True,
+        return_outputs: bool = False,
+    ) -> dict:
+        if self._idle:
+            return {"loss": None, "outputs": None}
+
+        if not isinstance(microbatches, list):
+            microbatches = [microbatches]
+        num_microbatches = len(microbatches)
+        minimum_microbatches = 2 * self._num_stages - 1
+        if num_microbatches < minimum_microbatches:
+            raise ValueError(
+                "ZB-H2 requires at least 2p-1 microbatches: "
+                f"got m={num_microbatches}, p={self._num_stages}, "
+                f"minimum={minimum_microbatches}."
+            )
+        self._weight_grad_store.assert_empty()
+        if self._seam_states:
+            raise RuntimeError("Cross-mesh seam state leaked into a ZB-H2 step.")
+
+        self._device = _first_tensor_device(microbatches) or _default_device()
+        num_warmup = h2_warmup_for_stage(self._num_stages, self._stage)
+
+        accum_loss: torch.Tensor | None = None
+        if return_loss and self.is_last_stage():
+            accum_loss = torch.zeros(1, device=self._device)
+        outputs: list[Any] | None = (
+            [] if return_outputs and self.is_last_stage() else None
+        )
+
+        input_objs: list[Any] = []
+        output_objs: list[Any] = []
+
+        # H2 warmup: u_s forwards, with adjacent stages offset by two.
+        for forward_count in range(num_warmup):
+            active_microbatch = microbatches[forward_count]
+            input_obj = self._recv_forward(active_microbatch)
+            with self._weight_grad_store.forward(forward_count):
+                output_obj = self._forward_step(
+                    active_microbatch,
+                    input_obj,
+                    criterion,
+                    num_microbatches,
+                    accum_loss,
+                    outputs,
+                )
+            self._send_forward(output_obj, active_microbatch)
+            input_objs.append(input_obj)
+            output_objs.append(output_obj)
+            self._assert_iteration_state(
+                forward_count + 1,
+                0,
+                0,
+                num_microbatches,
+                input_objs,
+                output_objs,
+            )
+
+        forward_count = num_warmup
+        backward_count = 0
+        weight_count = 0
+        self._assert_iteration_state(
+            forward_count,
+            backward_count,
+            weight_count,
+            num_microbatches,
+            input_objs,
+            output_objs,
+        )
+
+        next_input_obj: Any | None = None
+        if forward_count < num_microbatches:
+            next_input_obj = self._recv_forward(microbatches[forward_count])
+
+        while (
+            forward_count < num_microbatches
+            or backward_count < num_microbatches
+            or weight_count < num_microbatches
+        ):
+            operations = select_main_operations(
+                forward_count,
+                backward_count,
+                weight_count,
+                num_microbatches,
+            )
+            operation_types = {operation.type for operation in operations}
+            output_obj_grad: Any | None = None
+
+            # Operations are always executed in the selected F, B, W order.
+            for operation in operations:
+                if operation.type is OperationType.FORWARD:
+                    active_microbatch = microbatches[operation.microbatch]
+                    with self._weight_grad_store.forward(operation.microbatch):
+                        output_obj = self._forward_step(
+                            active_microbatch,
+                            next_input_obj,
+                            criterion,
+                            num_microbatches,
+                            accum_loss,
+                            outputs,
+                        )
+                    if OperationType.BACKWARD in operation_types:
+                        output_obj_grad = self._send_forward_recv_backward(
+                            output_obj, active_microbatch
+                        )
+                    else:
+                        self._send_forward(output_obj, active_microbatch)
+                    input_objs.append(next_input_obj)
+                    output_objs.append(output_obj)
+                    forward_count += 1
+
+                elif operation.type is OperationType.BACKWARD:
+                    if OperationType.FORWARD not in operation_types:
+                        output_obj_grad = self._recv_backward()
+                    input_obj = input_objs.pop(0)
+                    output_obj = output_objs.pop(0)
+                    with self._weight_grad_store.backward(operation.microbatch):
+                        input_obj_grad = self._backward_step(
+                            input_obj, output_obj, output_obj_grad
+                        )
+                    backward_count += 1
+
+                    if forward_count < num_microbatches:
+                        next_input_obj = self._send_backward_recv_forward(
+                            input_obj_grad, microbatches[forward_count]
+                        )
+                    else:
+                        self._send_backward(input_obj_grad)
+                        next_input_obj = None
+
+                else:
+                    self._weight_grad_store.execute(operation.microbatch)
+                    weight_count += 1
+
+            self._assert_iteration_state(
+                forward_count,
+                backward_count,
+                weight_count,
+                num_microbatches,
+                input_objs,
+                output_objs,
+            )
+
+        assert not input_objs
+        assert not output_objs
+        self._weight_grad_store.assert_empty()
+        if self._seam_states:
+            raise RuntimeError("Cross-mesh seam state leaked out of a ZB-H2 step.")
+
+        return {
+            "loss": accum_loss if return_loss else None,
+            "outputs": _merge_batch(outputs) if outputs is not None else None,
+        }

--- a/tests/distributed/test_multimodal_distributed.py
+++ b/tests/distributed/test_multimodal_distributed.py
@@ -434,8 +434,8 @@ class TestCrossMeshCPRouting(GlooDistributedTestBase):
                 torch.testing.assert_close(features.grad, expected_grad)
 
 
-class TestCrossMeshCPCompiledSchedule(GlooDistributedTestBase):
-    """An actual ParallelContext routes CP2 projected rows into an LLM CP4."""
+class TestCrossMeshCPZeroBubbleSchedule(GlooDistributedTestBase):
+    """ZB-H2 routes CP2 projected rows into an LLM CP4 without stale seam state."""
 
     @property
     def world_size(self) -> int:
@@ -450,6 +450,7 @@ class TestCrossMeshCPCompiledSchedule(GlooDistributedTestBase):
             modality_encoder,
             ParallelConfig(
                 pipeline_parallel_size=1,
+                pipeline_schedule="zbpp",
                 context_parallel_size=2,
                 context_parallel_splitter=source_splitter,
             ),
@@ -458,6 +459,7 @@ class TestCrossMeshCPCompiledSchedule(GlooDistributedTestBase):
             language_model,
             ParallelConfig(
                 pipeline_parallel_size=1,
+                pipeline_schedule="zbpp",
                 context_parallel_size=4,
                 context_parallel_splitter=destination_splitter,
             ),
@@ -596,7 +598,7 @@ class TestCrossMeshCPCompiledSchedule(GlooDistributedTestBase):
             patch.object(dist, "broadcast", side_effect=AssertionError("broadcast")),
         ):
             result = ctx.create_schedule(exec_plan, output).step(
-                [microbatch], _criterion, return_loss=True
+                [microbatch, microbatch, microbatch], _criterion, return_loss=True
             )
             ctx.sync_gradients()
 

--- a/tests/distributed/test_parallelism_integration.py
+++ b/tests/distributed/test_parallelism_integration.py
@@ -122,6 +122,7 @@ def _run_combo(
     moe: bool,
     *,
     config: object | None = None,
+    pipeline_schedule: str = "1f1b",
 ) -> None:
     dp, pp, cp, tp, ep = combo
     world_size = dp * pp * cp * tp * ep
@@ -136,6 +137,7 @@ def _run_combo(
             context_parallel_size=cp,
             data_parallel_size=dp,
             expert_parallel_size=ep,
+            pipeline_schedule=pipeline_schedule,
         ),
     )
     ctx = plan.materialize("cpu", dtype=torch.float32)
@@ -161,9 +163,13 @@ def _run_combo(
 
     # The microbatch list is the user's responsibility (collate_fn); here split
     # the batch into 2 microbatches under PP, otherwise a single microbatch.
-    num_microbatches = 2 if pp > 1 else 1
+    num_microbatches = (
+        2 * pp - 1
+        if pp > 1 and pipeline_schedule == "zbpp"
+        else 2 if pp > 1 else 1
+    )
     microbatches = [
-        {k: v.chunk(num_microbatches, dim=0)[i] for k, v in batch.items()}
+        {k: v.tensor_split(num_microbatches, dim=0)[i] for k, v in batch.items()}
         for i in range(num_microbatches)
     ]
 
@@ -239,6 +245,39 @@ class TestDenseQwenTensorPipelineComposition(GlooDistributedTestBase):
             (1, 2, 1, 2, 1),
             moe=False,
             config=_dense_qwen_config(),
+        )
+
+
+@instantiate_parametrized_tests
+class TestZeroBubbleDenseComposition(GlooDistributedTestBase):
+    """ZB-H2 through the declarative PP and PP+TP materialization paths."""
+
+    @property
+    def world_size(self) -> int:
+        return _world_size_from_name(self._testMethodName)
+
+    @parametrize(
+        "combo",
+        [(1, 2, 1, 1, 1), (1, 2, 1, 2, 1)],
+        name_fn=_name,
+    )
+    def test(self, combo):
+        _run_combo(self, combo, moe=False, pipeline_schedule="zbpp")
+
+
+class TestZeroBubbleExpertComposition(GlooDistributedTestBase):
+    """ZB-H2 split expert gradients compose with PP and EP routing."""
+
+    @property
+    def world_size(self) -> int:
+        return 4
+
+    def test_dp1_pp2_cp1_tp1_ep2(self) -> None:
+        _run_combo(
+            self,
+            (1, 2, 1, 1, 2),
+            moe=True,
+            pipeline_schedule="zbpp",
         )
 
 

--- a/tests/distributed/test_pipeline_parallel.py
+++ b/tests/distributed/test_pipeline_parallel.py
@@ -166,6 +166,137 @@ class TestPipelineP2P(GlooDistributedTestBase):
         grads = [p.grad for p in model.parameters() if p.grad is not None]
         self.assertGreater(len(grads), 0)
 
+    def test_zb_h2_matches_1f1b_loss_and_gradients(self):
+        """ZB-H2 matches 1F1B over the same three microbatches on two ranks."""
+        from cornstarch.distributed.pipeline_parallel.deferred_weight_grad import (
+            apply_deferred_weight_gradients,
+        )
+        from cornstarch.distributed.pipeline_parallel.forward_spec_wrapper import (
+            PipelineParallelForwardSpec,
+        )
+        from cornstarch.distributed.pipeline_parallel.schedule import MeshLayout
+        from cornstarch.distributed.pipeline_parallel.schedule_1f1b import (
+            OneForwardOneBackwardSchedule,
+        )
+        from cornstarch.distributed.pipeline_parallel.schedule_zbpp import (
+            ZeroBubblePipelineSchedule,
+        )
+        from cornstarch.models import CornstarchExecutionPlan, ExecutionFuture, from_hf_config
+        from tests.model.model_configs import llama_config
+
+        mesh = self._make_mesh()
+
+        def make_schedule(schedule_type, *, deferred=False):
+            torch.manual_seed(123)
+            config = llama_config()
+            config.vocab_size = 128
+            config.tie_word_embeddings = False
+            model = from_hf_config(
+                config, model_kind="language", attn_implementation="eager"
+            )
+            start, end = mesh.distribute_layers(len(model.decoder_layers))
+            model.decoder_layers = nn.ModuleList(list(model.decoder_layers)[start:end])
+            model.forward_spec = PipelineParallelForwardSpec(model.forward_spec, mesh)
+            model.set_random_init()
+            model.materialize("cpu")
+            with torch.no_grad():
+                for parameter in model.parameters():
+                    parameter.mul_(0.01)
+            if deferred:
+                apply_deferred_weight_gradients(model)
+            model.train()
+
+            plan = CornstarchExecutionPlan()
+            merged = plan.merge_modality_encoder_outputs(
+                language_model=model,
+                input_ids=ExecutionFuture("input_ids"),
+                labels=ExecutionFuture("labels"),
+                modality_token_ids={},
+                encoder_outputs={},
+            )
+            output_future = plan.run_language_model(module=model, inputs=merged)
+            layout = MeshLayout(
+                global_ranks=tuple(mesh._global_ranks),
+                dp_size=mesh.dp_size,
+                num_pp_stages=mesh.num_stages,
+                cp_size=mesh.cp_size,
+                tp_size=mesh.tp_size,
+                ep_size=mesh.ep_size,
+            )
+            schedule = schedule_type(
+                plan,
+                output_future,
+                {id(model): layout},
+                {id(model): mesh},
+                mesh.dp_size,
+            )
+            return model, schedule
+
+        torch.manual_seed(321)
+        batch = {
+            "input_ids": torch.randint(0, 128, (3, 8)),
+            "labels": torch.randint(0, 128, (3, 8)),
+        }
+        microbatches = [
+            {key: value[index : index + 1] for key, value in batch.items()}
+            for index in range(3)
+        ]
+
+        def criterion(output, _batch):
+            if isinstance(output, torch.Tensor):
+                return output
+            return output.loss if hasattr(output, "loss") else output["loss"]
+
+        baseline_model, baseline_schedule = make_schedule(
+            OneForwardOneBackwardSchedule
+        )
+        baseline_result = baseline_schedule.step(microbatches, criterion)
+        baseline_grads = {
+            name: parameter.grad.detach().clone()
+            for name, parameter in baseline_model.named_parameters()
+            if parameter.grad is not None
+        }
+
+        # The model compiles stage graphs lazily. Clear the graph cache so the
+        # second instance is traced with its deferred-linear forwards rather
+        # than reusing the ordinary-linear graph from the baseline instance.
+        torch._dynamo.reset()
+
+        zb_model, zb_schedule = make_schedule(
+            ZeroBubblePipelineSchedule, deferred=True
+        )
+        zb_result = zb_schedule.step(microbatches, criterion)
+        zb_grads = {
+            name: parameter.grad.detach().clone()
+            for name, parameter in zb_model.named_parameters()
+            if parameter.grad is not None
+        }
+
+        self.assertEqual(baseline_grads.keys(), zb_grads.keys())
+        for name in baseline_grads:
+            self.assertTrue(
+                torch.allclose(baseline_grads[name], zb_grads[name], atol=1e-5),
+                name,
+            )
+        if mesh.is_last_stage():
+            self.assertTrue(
+                torch.allclose(
+                    baseline_result["loss"], zb_result["loss"], atol=1e-6
+                )
+            )
+
+        # Reuse the schedule after clearing caller-owned gradients. Any stale
+        # activation, P2P, seam, or deferred-W state makes this second step fail.
+        zb_model.zero_grad(set_to_none=True)
+        second_result = zb_schedule.step(microbatches, criterion)
+        self.assertTrue(any(p.grad is not None for p in zb_model.parameters()))
+        if mesh.is_last_stage():
+            self.assertTrue(
+                torch.allclose(
+                    zb_result["loss"], second_result["loss"], atol=1e-6
+                )
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/distributed/test_zero_bubble_pipeline.py
+++ b/tests/distributed/test_zero_bubble_pipeline.py
@@ -1,0 +1,200 @@
+"""Unit tests for the count-heuristic ZB-H2 program and split B/W."""
+from __future__ import annotations
+
+import copy
+import inspect
+import unittest
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from cornstarch.distributed.parallel_config import ParallelConfig
+from cornstarch.distributed.parallelization import ParallelizationPlan
+from cornstarch.distributed.pipeline_parallel.deferred_weight_grad import (
+    DeferredWeightGradStore,
+    apply_deferred_weight_gradients,
+    deferred_expert_linear,
+)
+from cornstarch.distributed.pipeline_parallel.schedule_zbpp import (
+    OperationType,
+    ZeroBubblePipelineSchedule,
+    h2_warmup_for_stage,
+    select_main_operations,
+)
+
+
+class TestZBH2Program(unittest.TestCase):
+    def test_h2_counts_for_two_three_and_four_stages(self):
+        for num_stages in (2, 3, 4):
+            num_microbatches = 2 * num_stages
+            warmups = [
+                h2_warmup_for_stage(num_stages, stage)
+                for stage in range(num_stages)
+            ]
+            self.assertTrue(
+                all(left - right == 2 for left, right in zip(warmups, warmups[1:]))
+            )
+
+            for num_warmup in warmups:
+                f, b, w = num_warmup, 0, 0
+                programs = []
+                counts = {
+                    OperationType.FORWARD: num_warmup,
+                    OperationType.BACKWARD: 0,
+                    OperationType.WEIGHT: 0,
+                }
+                while f < num_microbatches or b < num_microbatches or w < num_microbatches:
+                    operations = select_main_operations(f, b, w, num_microbatches)
+                    programs.append("".join(operation.type.value for operation in operations))
+                    for operation in operations:
+                        counts[operation.type] += 1
+                        if operation.type is OperationType.FORWARD:
+                            f += 1
+                        elif operation.type is OperationType.BACKWARD:
+                            b += 1
+                        else:
+                            w += 1
+                    self.assertLessEqual(w, b)
+                    self.assertLessEqual(b, f)
+                    self.assertLessEqual(f, num_microbatches)
+
+                self.assertEqual(programs.count("FBW"), num_microbatches - num_warmup)
+                self.assertEqual(programs.count("BW"), num_warmup)
+                self.assertNotIn("W", programs)
+                self.assertEqual(set(counts.values()), {num_microbatches})
+
+    def test_operation_checks_are_independent_and_count_only(self):
+        signature = inspect.signature(select_main_operations)
+        self.assertEqual(
+            list(signature.parameters),
+            ["forward_count", "backward_count", "weight_count", "num_microbatches"],
+        )
+        self.assertEqual(
+            [op.type.value for op in select_main_operations(3, 1, 1, 4)],
+            ["F", "B", "W"],
+        )
+        self.assertEqual(
+            [op.type.value for op in select_main_operations(4, 2, 2, 4)],
+            ["B", "W"],
+        )
+        self.assertEqual(
+            [op.type.value for op in select_main_operations(4, 4, 3, 4)],
+            ["W"],
+        )
+
+    def test_rejects_too_few_microbatches(self):
+        schedule = ZeroBubblePipelineSchedule.__new__(ZeroBubblePipelineSchedule)
+        schedule._idle = False
+        schedule._num_stages = 2
+        with self.assertRaisesRegex(ValueError, "at least 2p-1"):
+            schedule.step([{}, {}], lambda *_: None)
+
+
+class TestDeferredWeightGradient(unittest.TestCase):
+    def test_dense_bias_and_microbatch_accumulation_match_backward(self):
+        torch.manual_seed(7)
+        baseline = nn.Sequential(
+            nn.Linear(4, 8), nn.GELU(), nn.Linear(8, 3, bias=True)
+        )
+        split = copy.deepcopy(baseline)
+        apply_deferred_weight_gradients(split)
+        store = DeferredWeightGradStore()
+
+        baseline_inputs = [torch.randn(3, 4, requires_grad=True) for _ in range(3)]
+        split_inputs = [value.detach().clone().requires_grad_(True) for value in baseline_inputs]
+        for value in baseline_inputs:
+            baseline(value).square().mean().backward()
+
+        for microbatch, value in enumerate(split_inputs):
+            with store.capture(microbatch):
+                split(value).square().mean().backward()
+            if microbatch == 0:
+                weight_grads = [
+                    parameter.grad
+                    for name, parameter in split.named_parameters()
+                    if name.endswith("weight")
+                ]
+                self.assertTrue(all(grad is None for grad in weight_grads))
+            store.execute(microbatch)
+
+        for baseline_parameter, split_parameter in zip(
+            baseline.parameters(), split.parameters()
+        ):
+            self.assertTrue(
+                torch.allclose(
+                    baseline_parameter.grad, split_parameter.grad, atol=1e-6
+                )
+            )
+        for baseline_input, split_input in zip(baseline_inputs, split_inputs):
+            self.assertTrue(torch.allclose(baseline_input.grad, split_input.grad, atol=1e-6))
+        store.assert_empty()
+
+    def test_tied_weight_accumulates_embedding_b_and_linear_w(self):
+        class TiedModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.embedding = nn.Embedding(11, 5)
+                self.output = nn.Linear(5, 11, bias=False)
+                self.output.weight = self.embedding.weight
+
+            def forward(self, tokens):
+                hidden = self.embedding(tokens).mean(dim=1)
+                return self.output(hidden)
+
+        torch.manual_seed(11)
+        baseline = TiedModel()
+        split = copy.deepcopy(baseline)
+        apply_deferred_weight_gradients(split)
+        tokens = torch.randint(0, 11, (4, 3))
+        baseline(tokens).square().sum().backward()
+
+        store = DeferredWeightGradStore()
+        with store.capture(0):
+            split(tokens).square().sum().backward()
+        # The tied embedding contribution is intentionally produced during B.
+        self.assertIsNotNone(split.embedding.weight.grad)
+        store.execute(0)
+        self.assertTrue(
+            torch.allclose(
+                baseline.embedding.weight.grad,
+                split.embedding.weight.grad,
+                atol=1e-6,
+            )
+        )
+
+    def test_stacked_expert_weight_gradient_matches_linear(self):
+        torch.manual_seed(19)
+        inputs = torch.randn(5, 4, requires_grad=True)
+        split_inputs = inputs.detach().clone().requires_grad_(True)
+        weights = nn.Parameter(torch.randn(3, 6, 4))
+        split_weights = nn.Parameter(weights.detach().clone())
+        F.linear(inputs, weights[1]).square().sum().backward()
+
+        store = DeferredWeightGradStore()
+        with store.capture(0):
+            deferred_expert_linear(split_inputs, split_weights, 1).square().sum().backward()
+        self.assertIsNone(split_weights.grad)
+        store.execute(0)
+        self.assertTrue(torch.allclose(weights.grad, split_weights.grad, atol=1e-6))
+        self.assertTrue(torch.allclose(inputs.grad, split_inputs.grad, atol=1e-6))
+
+
+class TestZBPPConfiguration(unittest.TestCase):
+    def test_invalid_schedule_name_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "pipeline_schedule"):
+            ParallelConfig(pipeline_schedule="vpp")
+
+    def test_pipelined_modules_must_select_one_schedule(self):
+        plan = ParallelizationPlan()
+        plan._modules = [object(), object()]
+        plan._configs = [
+            ParallelConfig(pipeline_parallel_size=1, pipeline_schedule="1f1b"),
+            ParallelConfig(pipeline_parallel_size=1, pipeline_schedule="zbpp"),
+        ]
+        with self.assertRaisesRegex(ValueError, "same pipeline_schedule"):
+            plan._assign_ranks([0, 1], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- split OneForwardOneBackwardSchedule into schedule_1f1b.py while preserving compatibility re-exports
- add count-heuristic ZB-H2 with the u_s = 2(p-s)-1 warmup and independent count-selected F/B/W operations
- add genuine deferred linear weight-gradient computation for tied weights, DTensor TP paths, and stacked expert weights
- add ParallelConfig.pipeline_schedule dispatch and reject inconsistent per-module selections
- preserve the multimodal encoder-to-LM seam and intentionally omit ZBV/VPP

## Validation

- Ruff checks passed
- 22 focused schedule, configuration, and pipeline tests passed
- full distributed parallelism integration matrix: 16 passed
- existing 1F1B multimodal seam tests plus six-rank ZB-H2 CP seam parity: 3 passed
- strict two-rank 1F1B versus ZB-H2 loss and local-gradient parity, including consecutive-step cleanup
- PP+TP and PP+EP Gloo coverage