### PR TITLE
Require Transformers 5 or newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 dependencies = [
     "torch>=2.6.0",
     "triton",
-    "transformers>=4.50.0",
+    "transformers>=5.0.0",
     "loguru",
     "simple_parsing",
     "datasets",


### PR DESCRIPTION
## Summary

- raise the minimum supported Transformers version from 4.50.0 to 5.0.0

## Why

The `refactor` branch uses Transformers 5-era APIs and model integrations, while the package metadata still advertises compatibility with Transformers 4.50. Updating the dependency floor prevents unsupported 4.x environments from being resolved.

## Impact

Installations now resolve Transformers 5.0.0 or newer, matching the refactored implementation's compatibility baseline.

## Validation

- parsed `pyproject.toml` with Python's `tomllib`
- parsed and asserted the dependency specifier with `packaging.requirements.Requirement`
- ran `git diff --check`
